### PR TITLE
fix: Prevent premature recording stop on long transmissions

### DIFF
--- a/server-net/OpenScanner.Server/Services/RtlDevice.cs
+++ b/server-net/OpenScanner.Server/Services/RtlDevice.cs
@@ -629,7 +629,7 @@ public class RtlDevice : BackgroundService
         // Valid Frame detected
         if (_state.Status != "RECEIVING" || (src.HasValue && _state.SourceID != src))
         {
-            UpdateState(_state with { Status = "RECEIVING", SourceID = src, TargetID = tgt });
+            UpdateState(_state with { Status = "RECEIVING", SourceID = src, TargetID = tgt, LastTranscription = null });
         }
         
         // Start recording if not already started


### PR DESCRIPTION
Fixes #14. 

This PR ensures that incoming audio data resets the recording inactivity timer. Previously, only metadata frames from the decoder would reset the timer, causing recordings to stop after 2 seconds if the decoder went silent on stderr (even if audio was still flowing on stdout).