### PR TITLE
Fix: Release Workflow Syntax Error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,12 +34,17 @@ jobs:
           echo "TAG=v$VERSION" >> $GITHUB_OUTPUT
           echo "NPM_VERSION=$NPM_VERSION" >> $GITHUB_OUTPUT
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: client/package-lock.json
+
       - name: Sync package.json version
         working-directory: ./client
         run: |
           npm version ${{ steps.nbgv.outputs.NPM_VERSION }} --no-git-tag-version
-
-      - name: Setup Node.js
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
This PR fixes a syntax error in the release workflow where the Node.js setup step was missing its configuration and incorrectly ordered.