### PR TITLE
Fix Date Time Problem in History Tree

### DIFF
--- a/server/OpenScanner.Server/Sql/Transmissions/GetChannels.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetChannels.sql
@@ -1,1 +1,1 @@
-SELECT DISTINCT alphaTag, frequency FROM transmissions WHERE strftime('%Y', timestamp) = @Year AND strftime('%m', timestamp) = @Month AND strftime('%d', timestamp) = @Day ORDER BY alphaTag, frequency
+SELECT DISTINCT alphaTag, frequency FROM transmissions WHERE strftime('%Y', timestamp, 'localtime') = @Year AND strftime('%m', timestamp, 'localtime') = @Month AND strftime('%d', timestamp, 'localtime') = @Day ORDER BY alphaTag, frequency

--- a/server/OpenScanner.Server/Sql/Transmissions/GetDays.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetDays.sql
@@ -1,1 +1,1 @@
-SELECT DISTINCT strftime('%d', timestamp) FROM transmissions WHERE strftime('%Y', timestamp) = @Year AND strftime('%m', timestamp) = @Month ORDER BY 1 DESC
+SELECT DISTINCT strftime('%d', timestamp, 'localtime') FROM transmissions WHERE strftime('%Y', timestamp, 'localtime') = @Year AND strftime('%m', timestamp, 'localtime') = @Month ORDER BY 1 DESC

--- a/server/OpenScanner.Server/Sql/Transmissions/GetFiltered.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetFiltered.sql
@@ -1,8 +1,8 @@
 SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID 
 FROM transmissions 
-WHERE strftime('%Y', timestamp) = @Year 
-  AND strftime('%m', timestamp) = @Month 
-  AND strftime('%d', timestamp) = @Day
+WHERE strftime('%Y', timestamp, 'localtime') = @Year 
+  AND strftime('%m', timestamp, 'localtime') = @Month 
+  AND strftime('%d', timestamp, 'localtime') = @Day
   AND alphaTag = @AlphaTag
   AND frequency = @Frequency
 ORDER BY timestamp DESC

--- a/server/OpenScanner.Server/Sql/Transmissions/GetMonths.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetMonths.sql
@@ -1,1 +1,1 @@
-SELECT DISTINCT strftime('%m', timestamp) FROM transmissions WHERE strftime('%Y', timestamp) = @Year ORDER BY 1 DESC
+SELECT DISTINCT strftime('%m', timestamp, 'localtime') FROM transmissions WHERE strftime('%Y', timestamp, 'localtime') = @Year ORDER BY 1 DESC

--- a/server/OpenScanner.Server/Sql/Transmissions/GetYears.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetYears.sql
@@ -1,1 +1,1 @@
-SELECT DISTINCT strftime('%Y', timestamp) FROM transmissions ORDER BY 1 DESC
+SELECT DISTINCT strftime('%Y', timestamp, 'localtime') FROM transmissions ORDER BY 1 DESC


### PR DESCRIPTION
This PR fixes issue #71 where historical logs were grouped under the wrong date due to UTC conversion.

Changes:
- Updated all history-related SQL queries to use SQLite's `localtime` modifier.
- This ensures that Year/Month/Day grouping aligns with the user's local timezone.
- Verified that individual log timestamps continue to display correctly in the frontend.