### PR TITLE
feat: add DMR decoder support with P25 metadata, emergency flag, and speaker chain

### DIFF
--- a/client/src/components/ChannelManager.tsx
+++ b/client/src/components/ChannelManager.tsx
@@ -37,7 +37,10 @@ const ChannelManager: React.FC<Props> = ({ open, onClose, channels, onSave, onDe
             tone: '',
             mode: 'P25',
             tag: '',
-            avoid: false
+            avoid: false,
+            dmrSlot: undefined,
+            dmrColorCode: undefined,
+            dmrTalkgroup: undefined
         } as Channel);
         setIsFormOpen(true);
     };
@@ -57,7 +60,8 @@ const ChannelManager: React.FC<Props> = ({ open, onClose, channels, onSave, onDe
 
     const handleChange = (field: keyof Channel, value: string | number | boolean) => {
         if (!editing) return;
-        setEditing({ ...editing, [field]: value });
+        const coerced = value === '' ? undefined : value;
+        setEditing({ ...editing, [field]: coerced });
     };
 
     if (isFormOpen && editing) {
@@ -110,6 +114,40 @@ const ChannelManager: React.FC<Props> = ({ open, onClose, channels, onSave, onDe
                                     placeholder="e.g. 100.0"
                                 />
                             </Box>
+                            {editing.mode === 'DMR' && (
+                                <Box display="flex" gap={2}>
+                                    <FormControl sx={{ flex: 1 }}>
+                                        <InputLabel>Slot</InputLabel>
+                                        <Select
+                                            value={editing.dmrSlot?.toString() ?? ''}
+                                            label="Slot"
+                                            onChange={e => handleChange('dmrSlot', e.target.value === '' ? '' : Number(e.target.value))}
+                                        >
+                                            <MenuItem value="">Any</MenuItem>
+                                            <MenuItem value="1">Slot 1</MenuItem>
+                                            <MenuItem value="2">Slot 2</MenuItem>
+                                        </Select>
+                                    </FormControl>
+                                    <TextField
+                                        label="Color Code (0–15)"
+                                        type="number"
+                                        inputProps={{ min: 0, max: 15 }}
+                                        value={editing.dmrColorCode ?? ''}
+                                        onChange={e => handleChange('dmrColorCode', e.target.value === '' ? '' : Number(e.target.value))}
+                                        sx={{ flex: 1 }}
+                                        placeholder="0–15"
+                                    />
+                                    <TextField
+                                        label="Talkgroup ID"
+                                        type="number"
+                                        inputProps={{ min: 0 }}
+                                        value={editing.dmrTalkgroup ?? ''}
+                                        onChange={e => handleChange('dmrTalkgroup', e.target.value === '' ? '' : Number(e.target.value))}
+                                        sx={{ flex: 1 }}
+                                        placeholder="e.g. 1234"
+                                    />
+                                </Box>
+                            )}
                             <Box display="flex" gap={2}>
                                 <TextField 
                                     label="License" 

--- a/client/src/components/ChannelManager.tsx
+++ b/client/src/components/ChannelManager.tsx
@@ -100,10 +100,7 @@ const ChannelManager: React.FC<Props> = ({ open, onClose, channels, onSave, onDe
                                     >
                                         <MenuItem value="P25">P25 (Digital)</MenuItem>
                                         <MenuItem value="DMR">DMR (Digital)</MenuItem>
-                                        <MenuItem value="FM">FM (EXPERIMENTAL)</MenuItem>
                                         <MenuItem value="NFM">NFM (Analog)</MenuItem>
-                                        <MenuItem value="WFM">WFM (EXPERIMENTAL)</MenuItem>
-                                        <MenuItem value="AM">AM (EXPERIMENTAL)</MenuItem>
                                     </Select>
                                 </FormControl>
                                 <TextField 

--- a/client/src/components/ChannelManager.tsx
+++ b/client/src/components/ChannelManager.tsx
@@ -95,6 +95,7 @@ const ChannelManager: React.FC<Props> = ({ open, onClose, channels, onSave, onDe
                                         onChange={e => handleChange('mode', e.target.value)}
                                     >
                                         <MenuItem value="P25">P25 (Digital)</MenuItem>
+                                        <MenuItem value="DMR">DMR (Digital)</MenuItem>
                                         <MenuItem value="FM">FM (EXPERIMENTAL)</MenuItem>
                                         <MenuItem value="NFM">NFM (EXPERIMENTAL)</MenuItem>
                                         <MenuItem value="WFM">WFM (EXPERIMENTAL)</MenuItem>

--- a/client/src/components/ScannerDisplay.tsx
+++ b/client/src/components/ScannerDisplay.tsx
@@ -179,7 +179,7 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                     }}
                                 />
                             )}
-                            {state.currentTone && state.currentTone !== 'ANALOG' && (
+                            {state.currentTone && state.currentTone !== 'ANALOG' && state.currentTone !== 'EMRG' && (
                                 <Chip 
                                     label={state.currentTone} 
                                     size="small" 
@@ -190,6 +190,23 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                         color: '#00ffff', 
                                         fontFamily: 'monospace' 
                                     }} 
+                                />
+                            )}
+                            {state.currentTone === 'EMRG' && (
+                                <Chip
+                                    label="! EMERGENCY"
+                                    size="small"
+                                    sx={{
+                                        height: 22,
+                                        fontSize: '0.75rem',
+                                        fontWeight: 'bold',
+                                        fontFamily: 'monospace',
+                                        letterSpacing: 1,
+                                        bgcolor: '#ff0000',
+                                        color: '#ffffff',
+                                        animation: 'pulse 0.6s infinite alternate',
+                                        border: '1px solid #ff6666',
+                                    }}
                                 />
                             )}
                             {state.lastDetectedTone && (

--- a/client/src/components/ScannerDisplay.tsx
+++ b/client/src/components/ScannerDisplay.tsx
@@ -208,16 +208,29 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                 />
                             )}
                         </Box>
-                        {isReceiving && state.sourceID && (
-                            <Typography variant="caption" sx={{ 
-                                color: state.sourceID < 100 ? '#00ffff' : '#ffaa00', 
-                                fontWeight: 'bold',
-                                mt: 0.5,
-                                display: 'block',
-                                letterSpacing: 1
-                            }}>
-                                {state.sourceID < 100 ? `[BASE]` : `[UNIT ${state.sourceID}]`}
-                            </Typography>
+                        {isReceiving && (state.sourceID || state.targetID) && (
+                            <Box sx={{ mt: 0.5, display: 'flex', gap: 1.5 }}>
+                                {state.sourceID && (
+                                    <Typography variant="caption" sx={{ 
+                                        color: '#ffaa00', 
+                                        fontWeight: 'bold',
+                                        fontFamily: 'monospace',
+                                        letterSpacing: 1
+                                    }}>
+                                        From: {state.sourceID}
+                                    </Typography>
+                                )}
+                                {state.targetID && (
+                                    <Typography variant="caption" sx={{ 
+                                        color: '#00bfff', 
+                                        fontWeight: 'bold',
+                                        fontFamily: 'monospace',
+                                        letterSpacing: 1
+                                    }}>
+                                        To: {state.targetID}
+                                    </Typography>
+                                )}
+                            </Box>
                         )}
                             </>
                         )}

--- a/client/src/components/ScannerDisplay.tsx
+++ b/client/src/components/ScannerDisplay.tsx
@@ -209,28 +209,16 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                             )}
                         </Box>
                         {isReceiving && (state.sourceID || state.targetID) && (
-                            <Box sx={{ mt: 0.5, display: 'flex', gap: 1.5 }}>
-                                {state.sourceID && (
-                                    <Typography variant="caption" sx={{ 
-                                        color: '#ffaa00', 
-                                        fontWeight: 'bold',
-                                        fontFamily: 'monospace',
-                                        letterSpacing: 1
-                                    }}>
-                                        From: {state.sourceID}
-                                    </Typography>
-                                )}
-                                {state.targetID && (
-                                    <Typography variant="caption" sx={{ 
-                                        color: '#00bfff', 
-                                        fontWeight: 'bold',
-                                        fontFamily: 'monospace',
-                                        letterSpacing: 1
-                                    }}>
-                                        To: {state.targetID}
-                                    </Typography>
-                                )}
-                            </Box>
+                            <Typography variant="caption" sx={{ 
+                                color: '#ffaa00', 
+                                fontWeight: 'bold',
+                                mt: 0.5,
+                                display: 'block',
+                                fontFamily: 'monospace',
+                                letterSpacing: 1
+                            }}>
+                                {state.sourceID ?? '?'} → {state.targetID ?? '?'}
+                            </Typography>
                         )}
                             </>
                         )}

--- a/client/src/components/ScannerDisplay.tsx
+++ b/client/src/components/ScannerDisplay.tsx
@@ -234,7 +234,9 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                 fontFamily: 'monospace',
                                 letterSpacing: 1
                             }}>
-                                {state.sourceID ?? '?'} → {state.targetID ?? '?'}
+                                {state.speakerChain
+                                    ? `${state.speakerChain} → TG ${state.targetID ?? '?'}`
+                                    : `${state.sourceID ?? '?'} → TG ${state.targetID ?? '?'}`}
                             </Typography>
                         )}
                             </>

--- a/client/src/components/ScannerDisplay.tsx
+++ b/client/src/components/ScannerDisplay.tsx
@@ -225,7 +225,7 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                 />
                             )}
                         </Box>
-                        {isReceiving && (state.sourceID || state.targetID) && (
+                        {isReceiving && (state.speakerChain || state.sourceID || state.targetID) && (
                             <Typography variant="caption" sx={{ 
                                 color: '#ffaa00', 
                                 fontWeight: 'bold',

--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -515,14 +515,9 @@ const LogItem = ({ log, playingId, onPlay, onDelete, onFavoriteToggle }: { log: 
                                 </Typography>
                             )}
                             <Box display="flex" gap={1} mt={0.5} flexWrap="wrap">
-                                {log.sourceID && (
+                                {(log.sourceID || log.targetID) && (
                                     <Typography variant="caption" sx={{ color: '#ffaa00', fontSize: '10px', fontFamily: 'monospace' }}>
-                                        From: {log.sourceID}
-                                    </Typography>
-                                )}
-                                {log.targetID && (
-                                    <Typography variant="caption" sx={{ color: '#00bfff', fontSize: '10px', fontFamily: 'monospace' }}>
-                                        To: {log.targetID}
+                                        {log.sourceID ?? '?'} → {log.targetID ?? '?'}
                                     </Typography>
                                 )}
                                 {log.lat && log.lat !== 0 && (

--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -487,9 +487,25 @@ const LogItem = ({ log, playingId, onPlay, onDelete, onFavoriteToggle }: { log: 
                             </Typography>
                             <Box display="flex" alignItems="center" gap={0.75} flexShrink={0}>
                                 {log.detectedTone && (
-                                    <Typography variant="caption" sx={{ color: '#ff0000', fontWeight: 'bold', fontSize: '9px', border: '1px solid #ff0000', px: 0.5, borderRadius: 0.5 }}>
-                                        {log.detectedTone}
-                                    </Typography>
+                                    log.detectedTone === 'EMRG' ? (
+                                        <Typography variant="caption" sx={{
+                                            color: '#ffffff',
+                                            fontWeight: 'bold',
+                                            fontSize: '9px',
+                                            bgcolor: '#cc0000',
+                                            border: '1px solid #ff4444',
+                                            px: 0.6,
+                                            py: 0.1,
+                                            borderRadius: 0.5,
+                                            letterSpacing: 0.5,
+                                        }}>
+                                            ! EMRG
+                                        </Typography>
+                                    ) : (
+                                        <Typography variant="caption" sx={{ color: '#ff0000', fontWeight: 'bold', fontSize: '9px', border: '1px solid #ff0000', px: 0.5, borderRadius: 0.5 }}>
+                                            {log.detectedTone}
+                                        </Typography>
+                                    )
                                 )}
                                 {log.duration && (
                                     <Typography variant="caption" sx={{ color: '#555', fontSize: '0.7rem', fontFamily: 'monospace' }}>

--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -532,19 +532,40 @@ const LogItem = ({ log, playingId, onPlay, onDelete, onFavoriteToggle }: { log: 
                                 <Typography variant="caption" sx={{ fontFamily: 'monospace', color: '#444', fontSize: '0.68rem' }}>
                                     {log.frequency.toFixed(3)} MHz
                                 </Typography>
-                                {(log.sourceID || log.targetID) && (
+                                {(log.speakerChain || log.sourceID || log.targetID) && (
                                     <>
                                         <Typography variant="caption" sx={{ color: '#333', fontSize: '0.65rem' }}>·</Typography>
                                         <Box display="flex" alignItems="center" gap={0.4}>
-                                            <Typography variant="caption" sx={{ color: '#555', fontSize: '0.65rem', fontFamily: 'monospace' }}>SRC</Typography>
-                                            <Typography variant="caption" sx={{ color: '#ffaa00', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
-                                                {log.sourceID ?? '?'}
-                                            </Typography>
-                                            <Typography variant="caption" sx={{ color: '#444', fontSize: '0.65rem' }}>→</Typography>
-                                            <Typography variant="caption" sx={{ color: '#555', fontSize: '0.65rem', fontFamily: 'monospace' }}>TG</Typography>
-                                            <Typography variant="caption" sx={{ color: '#00bfff', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
-                                                {log.targetID ?? '?'}
-                                            </Typography>
+                                            {log.speakerChain ? (
+                                                // Multi-speaker chain: "12345 → 67890 → 12345 → TG 763901"
+                                                <>
+                                                    <Typography variant="caption" sx={{ color: '#ffaa00', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
+                                                        {log.speakerChain}
+                                                    </Typography>
+                                                    {log.targetID && (
+                                                        <>
+                                                            <Typography variant="caption" sx={{ color: '#444', fontSize: '0.65rem' }}>→</Typography>
+                                                            <Typography variant="caption" sx={{ color: '#555', fontSize: '0.65rem', fontFamily: 'monospace' }}>TG</Typography>
+                                                            <Typography variant="caption" sx={{ color: '#00bfff', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
+                                                                {log.targetID}
+                                                            </Typography>
+                                                        </>
+                                                    )}
+                                                </>
+                                            ) : (
+                                                // Single speaker: "SRC 12345 → TG 763901"
+                                                <>
+                                                    <Typography variant="caption" sx={{ color: '#555', fontSize: '0.65rem', fontFamily: 'monospace' }}>SRC</Typography>
+                                                    <Typography variant="caption" sx={{ color: '#ffaa00', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
+                                                        {log.sourceID ?? '?'}
+                                                    </Typography>
+                                                    <Typography variant="caption" sx={{ color: '#444', fontSize: '0.65rem' }}>→</Typography>
+                                                    <Typography variant="caption" sx={{ color: '#555', fontSize: '0.65rem', fontFamily: 'monospace' }}>TG</Typography>
+                                                    <Typography variant="caption" sx={{ color: '#00bfff', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
+                                                        {log.targetID ?? '?'}
+                                                    </Typography>
+                                                </>
+                                            )}
                                         </Box>
                                     </>
                                 )}

--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -514,10 +514,15 @@ const LogItem = ({ log, playingId, onPlay, onDelete, onFavoriteToggle }: { log: 
                                     "{log.transcription}"
                                 </Typography>
                             )}
-                            <Box display="flex" gap={1} mt={0.5}>
+                            <Box display="flex" gap={1} mt={0.5} flexWrap="wrap">
                                 {log.sourceID && (
-                                    <Typography variant="caption" sx={{ color: log.sourceID < 100 ? '#00ffff' : '#ffaa00', fontSize: '10px' }}>
-                                        {log.sourceID < 100 ? `BASE` : `UNIT ${log.sourceID}`}
+                                    <Typography variant="caption" sx={{ color: '#ffaa00', fontSize: '10px', fontFamily: 'monospace' }}>
+                                        From: {log.sourceID}
+                                    </Typography>
+                                )}
+                                {log.targetID && (
+                                    <Typography variant="caption" sx={{ color: '#00bfff', fontSize: '10px', fontFamily: 'monospace' }}>
+                                        To: {log.targetID}
                                     </Typography>
                                 )}
                                 {log.lat && log.lat !== 0 && (

--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -481,51 +481,71 @@ const LogItem = ({ log, playingId, onPlay, onDelete, onFavoriteToggle }: { log: 
                 <ListItemText 
                     sx={{ pr: 20 }}
                     primary={
-                        <Box display="flex" alignItems="center" gap={0.75} flexWrap="wrap">
-                            <Typography variant="caption" sx={{ fontFamily: 'monospace', color: '#666', fontSize: '0.72rem' }}>
-                                {(() => {
-                                    const d = new Date(log.timestamp.endsWith('Z') ? log.timestamp : log.timestamp + 'Z');
-                                    return `${d.toLocaleDateString([], { year: 'numeric', month: '2-digit', day: '2-digit' })} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}`;
-                                })()}
-                            </Typography>
-                            <Typography variant="caption" sx={{ color: '#444', fontSize: '0.65rem' }}>|</Typography>
-                            <Typography variant="caption" sx={{ color: '#fff', fontWeight: 'bold', fontSize: '0.8rem' }}>
+                        <Box display="flex" alignItems="center" justifyContent="space-between" gap={1}>
+                            <Typography sx={{ color: '#eee', fontWeight: 'bold', fontSize: '0.85rem', lineHeight: 1.2 }}>
                                 {log.alphaTag}
                             </Typography>
-                            {log.detectedTone && (
-                                <Typography variant="caption" sx={{ color: '#ff0000', fontWeight: 'bold', fontSize: '9px', border: '1px solid #ff0000', px: 0.5, borderRadius: 0.5 }}>
-                                    {log.detectedTone}
-                                </Typography>
-                            )}
-                            {log.duration && (
-                                <>
-                                    <Typography variant="caption" sx={{ color: '#444', fontSize: '0.65rem' }}>|</Typography>
-                                    <Typography variant="caption" sx={{ color: '#555', fontSize: '0.72rem', fontFamily: 'monospace' }}>
+                            <Box display="flex" alignItems="center" gap={0.75} flexShrink={0}>
+                                {log.detectedTone && (
+                                    <Typography variant="caption" sx={{ color: '#ff0000', fontWeight: 'bold', fontSize: '9px', border: '1px solid #ff0000', px: 0.5, borderRadius: 0.5 }}>
+                                        {log.detectedTone}
+                                    </Typography>
+                                )}
+                                {log.duration && (
+                                    <Typography variant="caption" sx={{ color: '#555', fontSize: '0.7rem', fontFamily: 'monospace' }}>
                                         {log.duration.toFixed(1)}s
                                     </Typography>
-                                </>
-                            )}
+                                )}
+                            </Box>
                         </Box>
                     }
                     secondary={
                         <Box component="span" display="block">
+                            <Box display="flex" alignItems="center" gap={0.75} mt={0.3} flexWrap="wrap">
+                                <Typography variant="caption" sx={{ fontFamily: 'monospace', color: '#555', fontSize: '0.68rem' }}>
+                                    {(() => {
+                                        const d = new Date(log.timestamp.endsWith('Z') ? log.timestamp : log.timestamp + 'Z');
+                                        const now = new Date();
+                                        const isToday = d.toDateString() === now.toDateString();
+                                        return isToday
+                                            ? d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+                                            : `${d.toLocaleDateString([], { month: '2-digit', day: '2-digit' })} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+                                    })()}
+                                </Typography>
+                                <Typography variant="caption" sx={{ color: '#333', fontSize: '0.65rem' }}>·</Typography>
+                                <Typography variant="caption" sx={{ fontFamily: 'monospace', color: '#444', fontSize: '0.68rem' }}>
+                                    {log.frequency.toFixed(3)} MHz
+                                </Typography>
+                                {(log.sourceID || log.targetID) && (
+                                    <>
+                                        <Typography variant="caption" sx={{ color: '#333', fontSize: '0.65rem' }}>·</Typography>
+                                        <Box display="flex" alignItems="center" gap={0.4}>
+                                            <Typography variant="caption" sx={{ color: '#555', fontSize: '0.65rem', fontFamily: 'monospace' }}>SRC</Typography>
+                                            <Typography variant="caption" sx={{ color: '#ffaa00', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
+                                                {log.sourceID ?? '?'}
+                                            </Typography>
+                                            <Typography variant="caption" sx={{ color: '#444', fontSize: '0.65rem' }}>→</Typography>
+                                            <Typography variant="caption" sx={{ color: '#555', fontSize: '0.65rem', fontFamily: 'monospace' }}>TG</Typography>
+                                            <Typography variant="caption" sx={{ color: '#00bfff', fontSize: '0.7rem', fontFamily: 'monospace', fontWeight: 'bold' }}>
+                                                {log.targetID ?? '?'}
+                                            </Typography>
+                                        </Box>
+                                    </>
+                                )}
+                                {log.lat && log.lat !== 0 && (
+                                    <>
+                                        <Typography variant="caption" sx={{ color: '#333', fontSize: '0.65rem' }}>·</Typography>
+                                        <Typography variant="caption" sx={{ color: '#444', fontSize: '0.68rem', fontFamily: 'monospace' }}>
+                                            {log.lat.toFixed(3)}, {log.lon?.toFixed(3)}
+                                        </Typography>
+                                    </>
+                                )}
+                            </Box>
                             {log.transcription && (
-                                <Typography variant="body2" sx={{ color: '#ccc', fontStyle: 'italic', fontSize: '11px', mt: 0.5 }}>
+                                <Typography variant="body2" sx={{ color: '#999', fontStyle: 'italic', fontSize: '0.72rem', mt: 0.4, lineHeight: 1.3 }}>
                                     "{log.transcription}"
                                 </Typography>
                             )}
-                            <Box display="flex" gap={1} mt={0.5} flexWrap="wrap">
-                                {(log.sourceID || log.targetID) && (
-                                    <Typography variant="caption" sx={{ color: '#ffaa00', fontSize: '10px', fontFamily: 'monospace' }}>
-                                        {log.sourceID ?? '?'} → {log.targetID ?? '?'}
-                                    </Typography>
-                                )}
-                                {log.lat && log.lat !== 0 && (
-                                    <Typography variant="caption" sx={{ color: '#444', fontSize: '10px' }}>
-                                        {log.lat.toFixed(3)}, {log.lon?.toFixed(3)}
-                                    </Typography>
-                                )}
-                            </Box>
                         </Box>
                     }
                     secondaryTypographyProps={{ component: 'div' }}

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -40,6 +40,7 @@ export interface ScannerState {
     lastTranscription?: string;
     sourceID?: number;
     targetID?: number;
+    speakerChain?: string;
     currentTone?: string;
     lastDetectedTone?: string;
 }
@@ -57,6 +58,7 @@ export interface CallLog {
     transcription?: string;
     sourceID?: number;
     targetID?: number;
+    speakerChain?: string;
     detectedTone?: string;
     isFavorite?: boolean;
 }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -9,6 +9,9 @@ export interface Channel {
     mode: string;
     tag: string;
     avoid: boolean;
+    dmrSlot?: number;
+    dmrColorCode?: number;
+    dmrTalkgroup?: number;
 }
 
 export interface ScannerState {

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -68,6 +68,18 @@ fi
 # ----------------------------------------------------------------
 log_step "Updating Repository..."
 if git remote get-url origin &> /dev/null; then
+    # The installer modifies client/package.json (via `npm version`).
+    # If the only locally modified files are package.json / package-lock.json,
+    # restore them so git pull can apply upstream changes cleanly.
+    CHANGED_FILES=$(git diff --name-only 2>/dev/null)
+    if [ -n "$CHANGED_FILES" ]; then
+        NON_PKG=$(echo "$CHANGED_FILES" | grep -v "^client/package\.json$" | grep -v "^client/package-lock\.json$")
+        if [ -z "$NON_PKG" ]; then
+            log_info "Resetting auto-modified package files before update..."
+            git checkout -- client/package.json client/package-lock.json 2>/dev/null || true
+        fi
+    fi
+
     if git pull origin main; then
         log_success "Code pulled successfully."
     else

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -68,7 +68,7 @@ fi
 # ----------------------------------------------------------------
 log_step "Updating Repository..."
 if git remote get-url origin &> /dev/null; then
-    # The installer modifies client/package.json (via `npm version`).
+    # npm install (run by the .NET build) may modify package-lock.json.
     # If the only locally modified files are package.json / package-lock.json,
     # restore them so git pull can apply upstream changes cleanly.
     CHANGED_FILES=$(git diff --name-only 2>/dev/null)
@@ -90,7 +90,7 @@ else
 fi
 
 # ----------------------------------------------------------------
-# 3. Dependency Checks (Node.js for Client, .NET for Server)
+# 3. Dependency Checks (Node.js for .NET build, .NET SDK)
 # ----------------------------------------------------------------
 log_step "Checking Environment..."
 
@@ -138,7 +138,7 @@ if ! command -v nbgv &> /dev/null; then
     dotnet tool install -g nbgv
 fi
 
-# --- Check Node.js (For Client Build) ---
+# --- Check Node.js (Required for .NET client build step) ---
 NODE_PATH=$(which node || true)
 
 if [ -z "$NODE_PATH" ]; then
@@ -293,38 +293,7 @@ fi
 # ----------------------------------------------------------------
 log_step "Building Application..."
 
-# Build Client
-log_info "Building Client..."
-cd "$PROJECT_ROOT/client"
-if [ -f "package-lock.json" ] && [ -n "$NODE_PATH" ]; then
-    # Sync version if nbgv is available
-    if command -v nbgv &> /dev/null; then
-        if NPM_VER=$(nbgv get-version -v NpmPackageVersion 2>/dev/null); then
-            npm version "$NPM_VER" --no-git-tag-version --silent || true
-            log_info "Synced package.json to version $NPM_VER"
-        fi
-    fi
-
-    # Try npm ci, fallback to npm install if it fails
-    if ! npm ci --silent; then
-        log_warn "npm ci failed, falling back to npm install..."
-        npm install --silent
-    fi
-    
-    # Fix permissions for binaries
-    chmod +x node_modules/.bin/* || true
-
-    if npm run build; then
-        log_success "Client built."
-    else
-        log_error "Client build failed."
-        exit 1
-    fi
-else
-    log_warn "Skipping Client build (Node missing or no package.json)"
-fi
-
-# Build Server (.NET)
+# Build Server (.NET) — the .NET build also compiles the React client
 log_info "Building Server (.NET)..."
 cd "$PROJECT_ROOT/server/OpenScanner.Server"
 if dotnet build -c Release -o bin/Release/net10.0/publish; then

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -79,6 +79,7 @@ public class Database : IDatabase
         try { conn.Execute("ALTER TABLE channels ADD COLUMN dmrColorCode INTEGER;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: dmrColorCode column already exists or failed"); }
         try { conn.Execute("ALTER TABLE channels ADD COLUMN dmrTalkgroup INTEGER;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: dmrTalkgroup column already exists or failed"); }
         try { conn.Execute("ALTER TABLE transmissions ADD COLUMN isFavorite INTEGER DEFAULT 0;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: isFavorite column already exists or failed"); }
+        try { conn.Execute("ALTER TABLE transmissions ADD COLUMN speakerChain TEXT;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: speakerChain column already exists or failed"); }
 
         conn.Execute(@"
             CREATE TABLE IF NOT EXISTS fire_tones (

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -75,6 +75,9 @@ public class Database : IDatabase
         try { conn.Execute("ALTER TABLE channels ADD COLUMN lon REAL;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: lon column already exists or failed"); }
         try { conn.Execute("ALTER TABLE channels ADD COLUMN range REAL;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: range column already exists or failed"); }
         try { conn.Execute("ALTER TABLE channels ADD COLUMN avoid INTEGER DEFAULT 0;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: avoid column already exists or failed"); }
+        try { conn.Execute("ALTER TABLE channels ADD COLUMN dmrSlot INTEGER;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: dmrSlot column already exists or failed"); }
+        try { conn.Execute("ALTER TABLE channels ADD COLUMN dmrColorCode INTEGER;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: dmrColorCode column already exists or failed"); }
+        try { conn.Execute("ALTER TABLE channels ADD COLUMN dmrTalkgroup INTEGER;"); } catch (Exception ex) { _logger.LogDebug(ex, "Migration skip: dmrTalkgroup column already exists or failed"); }
 
         conn.Execute(@"
             CREATE TABLE IF NOT EXISTS fire_tones (

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -15,14 +15,15 @@ public class DMR : DSDBase
     {
         _channel = channel;
 
-        // 24000 Hz: better-tested rate for DMR via dsd-fme stdin pipe from rtl_fm.
-        // -fd: generic DMR decode — more stable than -fs for piped stdout output.
+        // 48000 Hz: required — dsd-fme -s only accepts 48000 or 96000; 24000 causes SIGFPE.
+        // -fs: DMR TDMA BS and MS Simplex — correct flag for direct DMR channels.
+        //      (-fd is D-STAR, not DMR!)
         // -V 3: explicit TDMA voice synthesis on both slots (default, but be explicit).
-        int captureRate = 24000;
-        int outputRate = 24000;
+        int captureRate = 48000;
+        int outputRate = 48000;
         int dsdOutputRate = 8000;
         string rtlMode = "fm";
-        string dsdArgs = "-fd -V 3"; // DMR decode, both TDMA slots
+        string dsdArgs = "-fs -V 3"; // DMR TDMA Simplex, both slots
 
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -15,14 +15,14 @@ public class DMR : DSDBase
     {
         _channel = channel;
 
-        // 24000 Hz: well-tested rate for DMR via dsd-fme stdin pipe from rtl_fm.
-        // -fs: DMR TDMA BS and MS Simplex — correct flag for direct DMR channels.
+        // 24000 Hz: better-tested rate for DMR via dsd-fme stdin pipe from rtl_fm.
+        // -fd: generic DMR decode — more stable than -fs for piped stdout output.
         // -V 3: explicit TDMA voice synthesis on both slots (default, but be explicit).
         int captureRate = 24000;
         int outputRate = 24000;
         int dsdOutputRate = 8000;
         string rtlMode = "fm";
-        string dsdArgs = "-fs -V 3"; // DMR TDMA Simplex, both slots
+        string dsdArgs = "-fd -V 3"; // DMR decode, both TDMA slots
 
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -34,10 +34,11 @@ public class DMR : DSDBase
 
     protected override void ParseMetadata(string line)
     {
-        // Detect which DMR slot this line belongs to
+        // Detect which DMR slot this line belongs to.
+        // dsd-fme emits "SLOT 1" / "SLOT 2" (all caps).
         int? lineSlot = null;
-        if (line.Contains("Slot 1")) lineSlot = 1;
-        else if (line.Contains("Slot 2")) lineSlot = 2;
+        if (line.Contains("SLOT 1")) lineSlot = 1;
+        else if (line.Contains("SLOT 2")) lineSlot = 2;
 
         // Filter by configured slot — skip lines from the wrong slot
         if (_channel?.DmrSlot.HasValue == true && lineSlot.HasValue && lineSlot != _channel.DmrSlot)
@@ -47,20 +48,27 @@ public class DMR : DSDBase
         // early and the session timeout gets reset while dsd-fme is still syncing.
         bool isActivity =
             line.Contains("Voice") ||
-            line.Contains("Slot 1") || line.Contains("Slot 2") ||
+            line.Contains("SLOT 1") || line.Contains("SLOT 2") ||
             line.Contains("CACH") ||
-            line.Contains("LC:") ||       // Link Control — present during sync lock
-            line.Contains("MFID:") ||     // Manufacturer ID — present in voice header
-            line.Contains("Sync:") ||     // dsd-fme sync lock line
-            line.Contains("SYNC") ||      // alternate sync format
-            (line.Contains("DMR") && !line.Contains("dsd-fme")); // avoid matching our own log lines
+            line.Contains("LC:") ||
+            line.Contains("MFID:") ||
+            line.Contains("Sync:") ||
+            line.Contains("Group Call") ||
+            line.Contains("Private Call") ||
+            (line.Contains("DMR") && !line.Contains("dsd-fme"));
 
         if (!isActivity) return;
 
         int? src = null;
         int? tgt = null;
 
-        if (line.Contains("Src:"))
+        // dsd-fme DMR output: "SLOT 1 TGT=763901 SRC=12345678 Group Call"
+        if (line.Contains("SRC="))
+        {
+            var parts = line.Split("SRC=");
+            if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var s)) src = s;
+        }
+        else if (line.Contains("Src:"))
         {
             var parts = line.Split("Src:");
             if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var s)) src = s;
@@ -71,7 +79,12 @@ public class DMR : DSDBase
             if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var s)) src = s;
         }
 
-        if (line.Contains("Dst:"))
+        if (line.Contains("TGT="))
+        {
+            var parts = line.Split("TGT=");
+            if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var t)) tgt = t;
+        }
+        else if (line.Contains("Dst:"))
         {
             var parts = line.Split("Dst:");
             if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var t)) tgt = t;

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -15,15 +15,18 @@ public class DMR : DSDBase
     {
         _channel = channel;
 
-        int captureRate = 48000;
-        int outputRate = 48000;
+        // 24000 Hz: well-tested rate for DMR via dsd-fme stdin pipe from rtl_fm.
+        // -fs: DMR TDMA BS and MS Simplex — correct flag for direct DMR channels.
+        // -V 3: explicit TDMA voice synthesis on both slots (default, but be explicit).
+        int captureRate = 24000;
+        int outputRate = 24000;
         int dsdOutputRate = 8000;
         string rtlMode = "fm";
-        string dsdArgs = "-fd"; // DMR
+        string dsdArgs = "-fs -V 3"; // DMR TDMA Simplex, both slots
 
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 
-        return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+        return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar 48000 -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }
 
     protected override void ParseMetadata(string line)
@@ -37,11 +40,17 @@ public class DMR : DSDBase
         if (_channel?.DmrSlot.HasValue == true && lineSlot.HasValue && lineSlot != _channel.DmrSlot)
             return;
 
+        // Broad activity detection: includes lock/sync lines so HandleActivity fires
+        // early and the session timeout gets reset while dsd-fme is still syncing.
         bool isActivity =
             line.Contains("Voice") ||
             line.Contains("Slot 1") || line.Contains("Slot 2") ||
             line.Contains("CACH") ||
-            (line.Contains("DMR") && !line.Contains("SYNC"));
+            line.Contains("LC:") ||       // Link Control — present during sync lock
+            line.Contains("MFID:") ||     // Manufacturer ID — present in voice header
+            line.Contains("Sync:") ||     // dsd-fme sync lock line
+            line.Contains("SYNC") ||      // alternate sync format
+            (line.Contains("DMR") && !line.Contains("dsd-fme")); // avoid matching our own log lines
 
         if (!isActivity) return;
 

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -18,12 +18,14 @@ public class DMR : DSDBase
         // 48000 Hz: required — dsd-fme -s only accepts 48000 or 96000; 24000 causes SIGFPE.
         // -fs: DMR TDMA BS and MS Simplex — correct flag for direct DMR channels.
         //      (-fd is D-STAR, not DMR!)
+        // -mg: GFSK modulation optimization — DMR uses GFSK, not C4FM (dsd-fme default -mc).
+        //      Without this, every AMBE frame gets FEC errors → robot/garbled audio.
         // -V 3: explicit TDMA voice synthesis on both slots (default, but be explicit).
         int captureRate = 48000;
         int outputRate = 48000;
         int dsdOutputRate = 8000;
         string rtlMode = "fm";
-        string dsdArgs = "-fs -V 3"; // DMR TDMA Simplex, both slots
+        string dsdArgs = "-fs -mg -V 3"; // DMR TDMA Simplex, GFSK modulation, both slots
 
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -5,12 +5,16 @@ namespace OpenScanner.Server.Decoders;
 
 public class DMR : DSDBase
 {
+    private Channel? _channel;
+
     public DMR(ILogger<DMR> logger) : base(logger)
     {
     }
 
     public override string GetCommandLine(Channel channel)
     {
+        _channel = channel;
+
         int captureRate = 48000;
         int outputRate = 48000;
         int dsdOutputRate = 8000;
@@ -20,5 +24,61 @@ public class DMR : DSDBase
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 
         return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+    }
+
+    protected override void ParseMetadata(string line)
+    {
+        // Detect which DMR slot this line belongs to
+        int? lineSlot = null;
+        if (line.Contains("Slot 1")) lineSlot = 1;
+        else if (line.Contains("Slot 2")) lineSlot = 2;
+
+        // Filter by configured slot — skip lines from the wrong slot
+        if (_channel?.DmrSlot.HasValue == true && lineSlot.HasValue && lineSlot != _channel.DmrSlot)
+            return;
+
+        bool isActivity =
+            line.Contains("Voice") ||
+            line.Contains("Slot 1") || line.Contains("Slot 2") ||
+            line.Contains("CACH") ||
+            (line.Contains("DMR") && !line.Contains("SYNC"));
+
+        if (!isActivity) return;
+
+        int? src = null;
+        int? tgt = null;
+
+        if (line.Contains("Src:"))
+        {
+            var parts = line.Split("Src:");
+            if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var s)) src = s;
+        }
+        else if (line.Contains("Source:"))
+        {
+            var parts = line.Split("Source:");
+            if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var s)) src = s;
+        }
+
+        if (line.Contains("Dst:"))
+        {
+            var parts = line.Split("Dst:");
+            if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var t)) tgt = t;
+        }
+        else if (line.Contains("Tgt:"))
+        {
+            var parts = line.Split("Tgt:");
+            if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var t)) tgt = t;
+        }
+        else if (line.Contains("Target:"))
+        {
+            var parts = line.Split("Target:");
+            if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var t)) tgt = t;
+        }
+
+        // Filter by configured talkgroup — skip if talkgroup doesn't match
+        if (_channel?.DmrTalkgroup.HasValue == true && tgt.HasValue && tgt != _channel.DmrTalkgroup)
+            return;
+
+        RaiseActivity(src, tgt, null);
     }
 }

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -1,0 +1,24 @@
+using Microsoft.Extensions.Logging;
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Decoders;
+
+public class DMR : DSDBase
+{
+    public DMR(ILogger<DMR> logger) : base(logger)
+    {
+    }
+
+    public override string GetCommandLine(Channel channel)
+    {
+        int captureRate = 48000;
+        int outputRate = 48000;
+        int dsdOutputRate = 8000;
+        string rtlMode = "fm";
+        string dsdArgs = "-fd"; // DMR
+
+        string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
+
+        return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+    }
+}

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -15,17 +15,16 @@ public class DMR : DSDBase
     {
         _channel = channel;
 
-        // 48000 Hz: required — dsd-fme -s only accepts 48000 or 96000; 24000 causes SIGFPE.
-        // -fs: DMR TDMA BS and MS Simplex — correct flag for direct DMR channels.
-        //      (-fd is D-STAR, not DMR!)
-        // -mg: GFSK modulation optimization — DMR uses GFSK, not C4FM (dsd-fme default -mc).
-        //      Without this, every AMBE frame gets FEC errors → robot/garbled audio.
-        // -V 3: explicit TDMA voice synthesis on both slots (default, but be explicit).
+        // 48000 Hz: required — dsd-fme -s only accepts 48000 or 96000.
+        // -fs: DMR TDMA BS and MS Simplex.
+        // -ma: auto-select modulation optimizer — more robust than forcing -mg (GFSK).
+        // -V 1: synthesize voice for slot 1 only. -V 3 (both slots) doubles the PCM
+        //       output data on a single-slot call, making audio play at half speed.
         int captureRate = 48000;
         int outputRate = 48000;
         int dsdOutputRate = 8000;
         string rtlMode = "fm";
-        string dsdArgs = "-fs -mg -V 3"; // DMR TDMA Simplex, GFSK modulation, both slots
+        string dsdArgs = "-fs -ma -V 1"; // DMR TDMA Simplex, auto modulation, slot 1
 
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -20,6 +20,12 @@ public class DMR : DSDBase
         // -ma: auto-select modulation optimizer — more robust than forcing -mg (GFSK).
         // -V 1: synthesize voice for slot 1 only. -V 3 (both slots) doubles the PCM
         //       output data on a single-slot call, making audio play at half speed.
+        //
+        // IMPORTANT: -fs hardcodes pulse_digi_out_channels=2 in dsd-fme source (dmr_bs.c).
+        // dsd-fme always writes STEREO (interleaved L=slot1, R=slot2) to stdout when
+        // using any DMR simplex mode, regardless of -V. With -V 1, R channel is silence.
+        // ffmpeg must read with -ac 2; volume=2.0 compensates for the L+R downmix
+        // halving the volume (out = (L+0)/2 = L/2 without compensation).
         int captureRate = 48000;
         int outputRate = 48000;
         int dsdOutputRate = 8000;
@@ -28,7 +34,7 @@ public class DMR : DSDBase
 
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 
-        return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar 48000 -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+        return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 2 -probesize 32 -analyzeduration 0 -i - -af volume=2.0 -f s16le -ar 48000 -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }
 
     protected override void ParseMetadata(string line)

--- a/server/OpenScanner.Server/Decoders/DSDBase.cs
+++ b/server/OpenScanner.Server/Decoders/DSDBase.cs
@@ -148,7 +148,10 @@ public abstract class DSDBase : IDecoder
             line.Contains("HDU") || // P25 Header Data Unit
             line.Contains("TDU") || // P25 Terminator
             (line.Contains("P25") && !line.Contains("TSBK")) || 
-            line.Contains("CTCSS") || line.Contains("DCS") || line.Contains("ANALOG");
+            line.Contains("CTCSS") || line.Contains("DCS") || line.Contains("ANALOG") ||
+            line.Contains("Slot 1") || line.Contains("Slot 2") || // DMR time slots
+            line.Contains("CACH") || // DMR Common Announcement Channel Header
+            (line.Contains("DMR") && !line.Contains("SYNC")); // DMR voice/data frames
 
         if (isActivity)
         {
@@ -175,6 +178,11 @@ public abstract class DSDBase : IDecoder
             else if (line.Contains("Tgt:"))
             {
                 var parts = line.Split("Tgt:");
+                if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var t)) tgt = t;
+            }
+            else if (line.Contains("Dst:")) // DMR destination talkgroup
+            {
+                var parts = line.Split("Dst:");
                 if (parts.Length > 1 && int.TryParse(parts[1].Trim().Split(' ')[0], out var t)) tgt = t;
             }
 

--- a/server/OpenScanner.Server/Decoders/DecoderFactory.cs
+++ b/server/OpenScanner.Server/Decoders/DecoderFactory.cs
@@ -16,6 +16,7 @@ public class DecoderFactory : IDecoderFactory
         return (mode?.ToUpper()) switch
         {
             "P25" => _serviceProvider.GetRequiredService<P25>(),
+            "DMR" => _serviceProvider.GetRequiredService<DMR>(),
             "NFM" => _serviceProvider.GetRequiredService<NFM>(),
             "FM" => _serviceProvider.GetRequiredService<NFM>(),
             "AM" => _serviceProvider.GetRequiredService<AM>(),

--- a/server/OpenScanner.Server/Decoders/P25.cs
+++ b/server/OpenScanner.Server/Decoders/P25.cs
@@ -81,6 +81,7 @@ public class P25 : DSDBase
             }
         }
 
-        RaiseActivity(src, tgt, null);
+        string? tone = line.Contains("Emergency") ? "EMRG" : null;
+        RaiseActivity(src, tgt, tone);
     }
 }

--- a/server/OpenScanner.Server/Decoders/P25.cs
+++ b/server/OpenScanner.Server/Decoders/P25.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using OpenScanner.Server.Models;
 
@@ -5,6 +6,18 @@ namespace OpenScanner.Server.Decoders;
 
 public class P25 : DSDBase
 {
+    // Matches: "Group Voice Channel User - Group 12345 Source 67890"
+    private static readonly Regex GroupCallRegex =
+        new(@"Group\s+(\d+)\s+Source\s+(\d+)", RegexOptions.Compiled);
+
+    // Matches: "Unit to Unit Voice Channel User - Target 12345 Source 67890"
+    private static readonly Regex UnitCallRegex =
+        new(@"Target\s+(\d+)\s+Source\s+(\d+)", RegexOptions.Compiled);
+
+    // Matches: "TGT: 12345; SRC: 67890;" (extended unit-to-unit)
+    private static readonly Regex ExtendedCallRegex =
+        new(@"TGT:\s*(\d+).*?SRC:\s*(\d+)", RegexOptions.Compiled);
+
     public P25(ILogger<P25> logger) : base(logger)
     {
     }
@@ -20,5 +33,54 @@ public class P25 : DSDBase
         string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -M {rtlMode} -";
 
         return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+    }
+
+    protected override void ParseMetadata(string line)
+    {
+        // P25 activity detection — avoid TSBK (control channel data bursts)
+        bool isActivity =
+            line.Contains("LDU") ||          // P25 Voice Frame (LDU1/LDU2)
+            line.Contains("HDU") ||          // Header Data Unit — start of call
+            line.Contains("TDU") ||          // Terminator — end of call
+            line.Contains("Voice") ||
+            line.Contains("Group Voice") ||
+            line.Contains("Unit to Unit") ||
+            line.Contains("TGT:") ||         // Extended unit-to-unit LCW
+            (line.Contains("P25") && !line.Contains("TSBK"));
+
+        if (!isActivity) return;
+
+        int? src = null;
+        int? tgt = null;
+
+        // "Group Voice Channel User - Group 12345 Source 67890"
+        var m = GroupCallRegex.Match(line);
+        if (m.Success)
+        {
+            if (int.TryParse(m.Groups[1].Value, out var g)) tgt = g;
+            if (int.TryParse(m.Groups[2].Value, out var s)) src = s;
+        }
+        else
+        {
+            // "Unit to Unit Voice Channel User - Target 12345 Source 67890"
+            m = UnitCallRegex.Match(line);
+            if (m.Success)
+            {
+                if (int.TryParse(m.Groups[1].Value, out var t)) tgt = t;
+                if (int.TryParse(m.Groups[2].Value, out var s)) src = s;
+            }
+            else
+            {
+                // "TGT: 12345; SRC: 67890;"
+                m = ExtendedCallRegex.Match(line);
+                if (m.Success)
+                {
+                    if (int.TryParse(m.Groups[1].Value, out var t)) tgt = t;
+                    if (int.TryParse(m.Groups[2].Value, out var s)) src = s;
+                }
+            }
+        }
+
+        RaiseActivity(src, tgt, null);
     }
 }

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -922,6 +922,12 @@ public class RtlDevice : BackgroundService, IRadioSource
                 _preRollBuffer.Clear();
             }
         }
+        else if (src.HasValue || tgt.HasValue)
+        {
+            // Update IDs mid-recording — the first activity event (sync line) often
+            // fires before dsd-fme emits the TGT/SRC line, so the IDs arrive late.
+            _recordingService.UpdateSourceTarget(src, tgt);
+        }
 
         ResetActivityTimeout();
     }

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -897,6 +897,10 @@ public class RtlDevice : BackgroundService, IRadioSource
         // STRICT ATTRIBUTION: Ignore activity if we have moved to a different channel
         if (_state.CurrentChannel == null || Math.Abs(_state.CurrentChannel.Frequency - originChannel.Frequency) > 0.001) return;
 
+        // Capture IDs BEFORE UpdateState overwrites them — needed for split detection below.
+        var prevSourceID = _state.SourceID;
+        var prevTargetID = _state.TargetID;
+
         // Valid Activity detected
         if (_state.Status != "RECEIVING" || 
             (src.HasValue && _state.SourceID != src) || 
@@ -927,19 +931,20 @@ public class RtlDevice : BackgroundService, IRadioSource
                 _preRollBuffer.Clear();
             }
         }
-        else if (src.HasValue && tgt.HasValue && _state.SourceID.HasValue && _state.TargetID.HasValue
-                 && (src != _state.SourceID || tgt != _state.TargetID))
+        else if (src.HasValue && tgt.HasValue && prevSourceID.HasValue && prevTargetID.HasValue
+                 && (src != prevSourceID || tgt != prevTargetID))
         {
             // SRC/TG changed while recording — a new talker or talkgroup is active.
             // Close the current transmission and open a fresh one so each gets its own log entry.
+            // Use prevSourceID/prevTargetID for the comparison: _state was already updated above.
             _recordingService.StopRecording(originChannel, _lastDetectedTone);
             _lastDetectedTone = null;
             _recordingService.StartRecording(originChannel, src, tgt, new LinkedList<byte[]>());
         }
-        else if (src.HasValue || tgt.HasValue)
+        else if ((src.HasValue || tgt.HasValue) && !prevSourceID.HasValue)
         {
-            // Update IDs mid-recording — the first activity event (sync line) often
-            // fires before dsd-fme emits the TGT/SRC line, so the IDs arrive late.
+            // Late-arriving IDs — the first activity event (sync line) fired before dsd-fme
+            // emitted the TGT/SRC line. Only update when the recording has no confirmed IDs yet.
             _recordingService.UpdateSourceTarget(src, tgt);
         }
 

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -910,6 +910,11 @@ public class RtlDevice : BackgroundService, IRadioSource
                 LastTranscription = null 
             });
         }
+
+        // Emergency calls route the tone to _lastDetectedTone so it is persisted
+        // to the DB (normally only fire tones flow through that path).
+        if (tone == "EMRG")
+            _lastDetectedTone = "EMRG";
         
         // Start recording if not already started
         if (!_recordingService.IsRecording)

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -805,6 +805,9 @@ public class RtlDevice : BackgroundService, IRadioSource
     private void StartDecoding(Channel channel)
     {
         StopDecoding();
+
+        // Reset per-call state for the new channel.
+        UpdateState(_state with { SourceID = null, TargetID = null, SpeakerChain = null });
         
         _decodeCts = new CancellationTokenSource();
         var token = _decodeCts.Token;
@@ -897,9 +900,17 @@ public class RtlDevice : BackgroundService, IRadioSource
         // STRICT ATTRIBUTION: Ignore activity if we have moved to a different channel
         if (_state.CurrentChannel == null || Math.Abs(_state.CurrentChannel.Frequency - originChannel.Frequency) > 0.001) return;
 
-        // Capture IDs BEFORE UpdateState overwrites them — needed for split detection below.
+        // Capture the previous source ID before UpdateState overwrites it.
         var prevSourceID = _state.SourceID;
-        var prevTargetID = _state.TargetID;
+
+        // Build the live speaker chain for the UI: append when the talker changes.
+        string? updatedChain = _state.SpeakerChain;
+        if (src.HasValue && src != prevSourceID)
+        {
+            updatedChain = updatedChain == null
+                ? src.Value.ToString()
+                : $"{updatedChain} → {src.Value}";
+        }
 
         // Valid Activity detected
         if (_state.Status != "RECEIVING" || 
@@ -909,7 +920,8 @@ public class RtlDevice : BackgroundService, IRadioSource
             UpdateState(_state with { 
                 Status = "RECEIVING", 
                 SourceID = src ?? _state.SourceID, 
-                TargetID = tgt ?? _state.TargetID, 
+                TargetID = tgt ?? _state.TargetID,
+                SpeakerChain = updatedChain,
                 CurrentTone = tone ?? _state.CurrentTone,
                 LastTranscription = null 
             });
@@ -931,21 +943,22 @@ public class RtlDevice : BackgroundService, IRadioSource
                 _preRollBuffer.Clear();
             }
         }
-        else if (src.HasValue && tgt.HasValue && prevSourceID.HasValue && prevTargetID.HasValue
-                 && (src != prevSourceID || tgt != prevTargetID))
+        else if (src.HasValue)
         {
-            // SRC/TG changed while recording — a new talker or talkgroup is active.
-            // Close the current transmission and open a fresh one so each gets its own log entry.
-            // Use prevSourceID/prevTargetID for the comparison: _state was already updated above.
-            _recordingService.StopRecording(originChannel, _lastDetectedTone);
-            _lastDetectedTone = null;
-            _recordingService.StartRecording(originChannel, src, tgt, new LinkedList<byte[]>());
+            if (!prevSourceID.HasValue)
+            {
+                // Late-arriving IDs — first activity event fired before dsd-fme emitted TGT/SRC.
+                _recordingService.UpdateSourceTarget(src, tgt);
+            }
+            else if (src != prevSourceID)
+            {
+                // Talker changed — append to the speaker chain within the same recording.
+                _recordingService.AppendSpeaker(src.Value);
+            }
         }
-        else if ((src.HasValue || tgt.HasValue) && !prevSourceID.HasValue)
+        else if (tgt.HasValue && !prevSourceID.HasValue)
         {
-            // Late-arriving IDs — the first activity event (sync line) fired before dsd-fme
-            // emitted the TGT/SRC line. Only update when the recording has no confirmed IDs yet.
-            _recordingService.UpdateSourceTarget(src, tgt);
+            _recordingService.UpdateSourceTarget(null, tgt);
         }
 
         ResetActivityTimeout();

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -751,10 +751,11 @@ public class RtlDevice : BackgroundService, IRadioSource
             StartDecoding(channel);
         });
 
-        // Safety timeout
+        // Safety timeout — DMR needs more time to sync (TDMA framing + AMBE vocoder)
         if (!_manualOverride)
         {
-            RestartSessionTimeout(10000); // 10s to hear something (sync up)
+            int initialTimeout = channel.Mode == "DMR" ? 20000 : 10000;
+            RestartSessionTimeout(initialTimeout);
         }
     }
 
@@ -840,7 +841,7 @@ public class RtlDevice : BackgroundService, IRadioSource
             };
 
             _currentDecoder.OnActivity += (src, tgt, tone) => HandleActivity(channel, src, tgt, tone);
-            _currentDecoder.OnMetadata += (line) => _logger.LogDebug($"Decoder: {line}");
+            _currentDecoder.OnMetadata += (line) => _logger.LogInformation($"Decoder: {line}");
 
             // Start safely
             Task.Run(async () => 

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -927,6 +927,15 @@ public class RtlDevice : BackgroundService, IRadioSource
                 _preRollBuffer.Clear();
             }
         }
+        else if (src.HasValue && tgt.HasValue && _state.SourceID.HasValue && _state.TargetID.HasValue
+                 && (src != _state.SourceID || tgt != _state.TargetID))
+        {
+            // SRC/TG changed while recording — a new talker or talkgroup is active.
+            // Close the current transmission and open a fresh one so each gets its own log entry.
+            _recordingService.StopRecording(originChannel, _lastDetectedTone);
+            _lastDetectedTone = null;
+            _recordingService.StartRecording(originChannel, src, tgt, new LinkedList<byte[]>());
+        }
         else if (src.HasValue || tgt.HasValue)
         {
             // Update IDs mid-recording — the first activity event (sync line) often

--- a/server/OpenScanner.Server/Interfaces/IRecordingService.cs
+++ b/server/OpenScanner.Server/Interfaces/IRecordingService.cs
@@ -8,6 +8,7 @@ public interface IRecordingService
     bool IsRecording { get; }
     void StartRecording(Channel channel, int? src, int? tgt, LinkedList<byte[]> preRollBuffer);
     void UpdateSourceTarget(int? src, int? tgt);
+    void AppendSpeaker(int src);
     void StopRecording(Channel channel, string? lastDetectedTone);
     void ProcessAudio(byte[] audio);
 }

--- a/server/OpenScanner.Server/Interfaces/IRecordingService.cs
+++ b/server/OpenScanner.Server/Interfaces/IRecordingService.cs
@@ -7,6 +7,7 @@ public interface IRecordingService
     event Action<CallLog>? OnNewLog;
     bool IsRecording { get; }
     void StartRecording(Channel channel, int? src, int? tgt, LinkedList<byte[]> preRollBuffer);
+    void UpdateSourceTarget(int? src, int? tgt);
     void StopRecording(Channel channel, string? lastDetectedTone);
     void ProcessAudio(byte[] audio);
 }

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -160,6 +160,11 @@ public class CallLog
     /// P25 Talkgroup ID.
     /// </summary>
     public int? TargetID { get; set; }
+
+    /// <summary>
+    /// Ordered chain of speaker IDs for the call, e.g. "12345 → 67890 → 12345".
+    /// </summary>
+    public string? SpeakerChain { get; set; }
     
     /// <summary>
     /// Filename of the audio recording (relative to /audio).
@@ -189,7 +194,7 @@ public class CallLog
 
     public CallLog() { }
 
-    public CallLog(string id, string timestamp, double frequency, string alphaTag, string description, double? lat, double? lon, string? audioPath, double? duration, string? transcription = null, int? sourceID = null, int? targetID = null, string? detectedTone = null)
+    public CallLog(string id, string timestamp, double frequency, string alphaTag, string description, double? lat, double? lon, string? audioPath, double? duration, string? transcription = null, int? sourceID = null, int? targetID = null, string? detectedTone = null, string? speakerChain = null)
     {
         Id = id;
         Timestamp = timestamp;
@@ -204,6 +209,7 @@ public class CallLog
         SourceID = sourceID;
         TargetID = targetID;
         DetectedTone = detectedTone;
+        SpeakerChain = speakerChain;
     }
 }
 
@@ -327,6 +333,7 @@ public record ScannerState(
     string? LastTranscription = null,
     int? SourceID = null,
     int? TargetID = null,
+    string? SpeakerChain = null,
     string? CurrentTone = null,
     string? LastDetectedTone = null
 );

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -72,9 +72,24 @@ public class Channel
     /// </summary>
     public bool Avoid { get; set; }
 
+    /// <summary>
+    /// DMR time slot (1 or 2). Only applicable when Mode is "DMR".
+    /// </summary>
+    public int? DmrSlot { get; set; }
+
+    /// <summary>
+    /// DMR color code (0–15). Only applicable when Mode is "DMR".
+    /// </summary>
+    public int? DmrColorCode { get; set; }
+
+    /// <summary>
+    /// DMR talkgroup ID to monitor. Only applicable when Mode is "DMR".
+    /// </summary>
+    public int? DmrTalkgroup { get; set; }
+
     public Channel() { }
 
-    public Channel(double frequency, string alphaTag, string description, string mode = "P25", string type = "RM", string tone = "", string tag = "", string license = "", bool avoid = false)
+    public Channel(double frequency, string alphaTag, string description, string mode = "P25", string type = "RM", string tone = "", string tag = "", string license = "", bool avoid = false, int? dmrSlot = null, int? dmrColorCode = null, int? dmrTalkgroup = null)
     {
         Frequency = frequency;
         AlphaTag = alphaTag;
@@ -85,6 +100,9 @@ public class Channel
         Tag = tag;
         License = license;
         Avoid = avoid;
+        DmrSlot = dmrSlot;
+        DmrColorCode = dmrColorCode;
+        DmrTalkgroup = dmrTalkgroup;
     }
 }
 

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddHostedService(sp => sp.GetRequiredService<GpsService>());
 builder.Services.AddSingleton<ToneDetector>();
 
 builder.Services.AddTransient<OpenScanner.Server.Decoders.P25>();
+builder.Services.AddTransient<OpenScanner.Server.Decoders.DMR>();
 builder.Services.AddTransient<OpenScanner.Server.Decoders.NFM>();
 builder.Services.AddTransient<OpenScanner.Server.Decoders.AM>();
 builder.Services.AddTransient<OpenScanner.Server.Decoders.WFM>();

--- a/server/OpenScanner.Server/Services/RecordingService.cs
+++ b/server/OpenScanner.Server/Services/RecordingService.cs
@@ -40,9 +40,16 @@ public class RecordingService : IRecordingService
         _gpsService = gpsService;
     }
 
+    public void UpdateSourceTarget(int? src, int? tgt)
+    {
+        if (src.HasValue) _currentSourceID = src;
+        if (tgt.HasValue) _currentTargetID = tgt;
+    }
+
     public void StartRecording(Channel channel, int? src, int? tgt, LinkedList<byte[]> preRollBuffer)
     {
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+
         var filename = $"rec_{now}_{channel.Frequency}.raw";
         
         // Ensure data dir exists
@@ -59,6 +66,7 @@ public class RecordingService : IRecordingService
             _recordingStartTime = now;
             _currentSourceID = src;
             _currentTargetID = tgt;
+
 
             try 
             {

--- a/server/OpenScanner.Server/Services/RecordingService.cs
+++ b/server/OpenScanner.Server/Services/RecordingService.cs
@@ -201,8 +201,8 @@ public class RecordingService : IRecordingService
                  var lon = gps?.Lon ?? 0;
 
                  var log = new CallLog(
-                      $"log_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}",
-                      DateTime.UtcNow.ToString("o"),
+                      $"log_{startTime}",
+                      DateTimeOffset.FromUnixTimeMilliseconds(startTime).UtcDateTime.ToString("o"),
                       channel.Frequency,
                       channel.AlphaTag,
                       channel.Description,

--- a/server/OpenScanner.Server/Services/RecordingService.cs
+++ b/server/OpenScanner.Server/Services/RecordingService.cs
@@ -17,6 +17,7 @@ public class RecordingService : IRecordingService
     private long _recordingStartTime;
     private int? _currentSourceID;
     private int? _currentTargetID;
+    private readonly List<int> _speakerList = new();
 
     public event Action<CallLog>? OnNewLog;
 
@@ -46,6 +47,12 @@ public class RecordingService : IRecordingService
         if (tgt.HasValue) _currentTargetID = tgt;
     }
 
+    public void AppendSpeaker(int src)
+    {
+        if (_speakerList.Count == 0 || _speakerList[^1] != src)
+            _speakerList.Add(src);
+    }
+
     public void StartRecording(Channel channel, int? src, int? tgt, LinkedList<byte[]> preRollBuffer)
     {
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
@@ -66,7 +73,8 @@ public class RecordingService : IRecordingService
             _recordingStartTime = now;
             _currentSourceID = src;
             _currentTargetID = tgt;
-
+            _speakerList.Clear();
+            if (src.HasValue) _speakerList.Add(src.Value);
 
             try 
             {
@@ -114,6 +122,7 @@ public class RecordingService : IRecordingService
     {
         string? recordingPath;
         long startTime;
+        string? speakerChain;
         
         lock (_audioLock)
         {
@@ -122,6 +131,9 @@ public class RecordingService : IRecordingService
             _recordingStream = null;
             recordingPath = _currentRecordingPath;
             startTime = _recordingStartTime;
+            speakerChain = _speakerList.Count > 1
+                ? string.Join(" → ", _speakerList)
+                : null;
         }
 
         var duration = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTime) / 1000.0;
@@ -213,7 +225,8 @@ public class RecordingService : IRecordingService
                       transcription,
                       _currentSourceID,
                       _currentTargetID,
-                      lastDetectedTone
+                      lastDetectedTone,
+                      speakerChain
                   );
                  
                   

--- a/server/OpenScanner.Server/Sql/Channels/GetAll.sql
+++ b/server/OpenScanner.Server/Sql/Channels/GetAll.sql
@@ -1,1 +1,1 @@
-SELECT id, frequency, license, type, tone, alphaTag, description, mode, tag, lat, lon, range, avoid FROM channels ORDER BY frequency ASC
+SELECT id, frequency, license, type, tone, alphaTag, description, mode, tag, lat, lon, range, avoid, dmrSlot, dmrColorCode, dmrTalkgroup FROM channels ORDER BY frequency ASC

--- a/server/OpenScanner.Server/Sql/Channels/GetWithGps.sql
+++ b/server/OpenScanner.Server/Sql/Channels/GetWithGps.sql
@@ -1,1 +1,1 @@
-SELECT id, frequency, license, type, tone, alphaTag, description, mode, tag, lat, lon, range, avoid FROM channels WHERE lat IS NOT NULL AND lon IS NOT NULL
+SELECT id, frequency, license, type, tone, alphaTag, description, mode, tag, lat, lon, range, avoid, dmrSlot, dmrColorCode, dmrTalkgroup FROM channels WHERE lat IS NOT NULL AND lon IS NOT NULL

--- a/server/OpenScanner.Server/Sql/Channels/Insert.sql
+++ b/server/OpenScanner.Server/Sql/Channels/Insert.sql
@@ -1,3 +1,3 @@
-INSERT INTO channels (frequency, license, type, tone, alphaTag, description, mode, tag, lat, lon, range, avoid)
-VALUES (@Frequency, @License, @Type, @Tone, @AlphaTag, @Description, @Mode, @Tag, @Lat, @Lon, @Range, @Avoid)
+INSERT INTO channels (frequency, license, type, tone, alphaTag, description, mode, tag, lat, lon, range, avoid, dmrSlot, dmrColorCode, dmrTalkgroup)
+VALUES (@Frequency, @License, @Type, @Tone, @AlphaTag, @Description, @Mode, @Tag, @Lat, @Lon, @Range, @Avoid, @DmrSlot, @DmrColorCode, @DmrTalkgroup)
 RETURNING id

--- a/server/OpenScanner.Server/Sql/Channels/Update.sql
+++ b/server/OpenScanner.Server/Sql/Channels/Update.sql
@@ -1,5 +1,6 @@
 UPDATE channels 
 SET frequency=@Frequency, license=@License, type=@Type, tone=@Tone, 
     alphaTag=@AlphaTag, description=@Description, mode=@Mode, tag=@Tag,
-    lat=@Lat, lon=@Lon, range=@Range, avoid=@Avoid
+    lat=@Lat, lon=@Lon, range=@Range, avoid=@Avoid,
+    dmrSlot=@DmrSlot, dmrColorCode=@DmrColorCode, dmrTalkgroup=@DmrTalkgroup
 WHERE id=@Id

--- a/server/OpenScanner.Server/Sql/Initialize.sql
+++ b/server/OpenScanner.Server/Sql/Initialize.sql
@@ -36,5 +36,8 @@ CREATE TABLE IF NOT EXISTS channels (
     lat REAL,
     lon REAL,
     range REAL,
-    avoid INTEGER DEFAULT 0
+    avoid INTEGER DEFAULT 0,
+    dmrSlot INTEGER,
+    dmrColorCode INTEGER,
+    dmrTalkgroup INTEGER
 );

--- a/server/OpenScanner.Server/Sql/Transmissions/GetFavorites.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetFavorites.sql
@@ -1,4 +1,4 @@
-SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, isFavorite
+SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, detectedTone, speakerChain, isFavorite
 FROM transmissions
 WHERE isFavorite = 1
 ORDER BY timestamp DESC

--- a/server/OpenScanner.Server/Sql/Transmissions/GetFiltered.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetFiltered.sql
@@ -1,4 +1,4 @@
-SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, isFavorite 
+SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, detectedTone, speakerChain, isFavorite 
 FROM transmissions 
 WHERE strftime('%Y', timestamp, 'localtime') = @Year 
   AND strftime('%m', timestamp, 'localtime') = @Month 

--- a/server/OpenScanner.Server/Sql/Transmissions/GetHistory.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetHistory.sql
@@ -1,1 +1,1 @@
-SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, isFavorite FROM transmissions ORDER BY timestamp DESC LIMIT @Limit
+SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, detectedTone, speakerChain, isFavorite FROM transmissions ORDER BY timestamp DESC LIMIT @Limit

--- a/server/OpenScanner.Server/Sql/Transmissions/Insert.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/Insert.sql
@@ -1,2 +1,2 @@
-INSERT INTO transmissions (id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path, duration, transcription, detectedTone, sourceID, targetID)
-VALUES (@Id, @Timestamp, @Frequency, @AlphaTag, @Description, @Lat, @Lon, 0, @AudioPath, @Duration, @Transcription, @DetectedTone, @SourceID, @TargetID)
+INSERT INTO transmissions (id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path, duration, transcription, detectedTone, sourceID, targetID, speakerChain)
+VALUES (@Id, @Timestamp, @Frequency, @AlphaTag, @Description, @Lat, @Lon, 0, @AudioPath, @Duration, @Transcription, @DetectedTone, @SourceID, @TargetID, @SpeakerChain)

--- a/server/OpenScanner.Server/Sql/Transmissions/Search.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/Search.sql
@@ -1,4 +1,4 @@
-SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, isFavorite 
+SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, detectedTone, speakerChain, isFavorite 
 FROM transmissions 
 WHERE transcription LIKE @Query 
    OR description LIKE @Query 


### PR DESCRIPTION
## Summary

This PR adds DMR digital radio decoding alongside existing P25 support, plus several improvements to metadata display, audio quality, and the transmission history UI.

## Changes

### DMR Decoder
- Add DMR decoder using dsd-fme with correct flags (-ma auto modulation, stereo output)
- Fix dsd-fme DMR audio pipeline for correct speed and quality (stereo read via ffmpeg -ac 2)
- Parse DMR slot, color code, and talkgroup from dsd-fme output

### P25 Metadata
- Parse Source ID and Talkgroup ID from dsd-fme P25 output
- Persist late-arriving Source/Target IDs when dsd-fme emits them after the Sync line
- Show From/To IDs in live scanner display and transmission history

### Emergency Flag
- Detect P25 emergency flag in dsd-fme output
- Show flashing red EMERGENCY chip in live scanner display
- Show filled red EMRG badge in transmission history

### Speaker Chain
- Track back-and-forth radio conversations within a single recording
- Display live speaker chain in scanner display (e.g. 12345 -> 67890 -> TG 763901)
- Store speaker chain in DB and show in history for multi-speaker calls
- Single-speaker calls fall back to SRC X -> TG Y display

### Timestamp Fix
- Use recording start time for log timestamp and ID instead of save time (which included recording + transcription duration)

### UI Improvements
- Redesign transmission history log item layout with cleaner metadata display

### Installer
- Remove redundant frontend build step (the .NET csproj already runs npm install + npm run build via MSBuild target)
- Reset auto-modified package files before git pull to prevent dirty-state false positives

### Bug Fixes
- Fix SQL SELECT queries that were missing detectedTone and speakerChain columns (history badges and chain never rendered)
- Fix read-before-write bug where UpdateState overwrote SourceID before split/chain comparison