### PR TITLE
Fix audio catch-up when returning to backgrounded tab (#93)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -96,6 +96,7 @@ function App() {
   const wakeLock = useRef<WakeLockSentinel | null>(null);
   const activeSource = useRef<AudioBufferSourceNode | null>(null);
   const isParallelRef = useRef(false);
+  const isPageHiddenRef = useRef(false);
   const volumeRef = useRef(volume);
 
   const manualHold = scannerState.manualHoldFrequency;
@@ -231,6 +232,18 @@ function App() {
       }
     };
   }, [scannerState.status]);
+
+  // Track page visibility to handle background tab audio issues
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      isPageHiddenRef.current = document.visibilityState === 'hidden';
+      if (document.visibilityState === 'visible' && nextStartTime.current > 0) {
+        nextStartTime.current = 0;
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibilityChange);
+    return () => document.removeEventListener('visibilitychange', onVisibilityChange);
+  }, []);
 
   // Clock Effect
   useEffect(() => {
@@ -539,6 +552,9 @@ function App() {
           // console.log("[Audio DEBUG] Message received:", event.data);
 
           if (event.data instanceof Blob) {
+            // Skip audio processing when tab is hidden to prevent scheduler catch-up bursts
+            if (isPageHiddenRef.current) return;
+
             try {
                 // Log incoming data size
                 // console.log(`[Audio] Received Blob size: ${event.data.size}`);
@@ -569,6 +585,11 @@ function App() {
                 if (ctx && ctx.state === 'suspended') {
                     console.log("[Audio] Resuming suspended context...");
                     await ctx.resume();
+                }
+
+                // Reset scheduler after context resume to prevent catch-up burst
+                if (ctx && nextStartTime.current > ctx.currentTime) {
+                    nextStartTime.current = 0;
                 }
 
                 if (!ctx) {

--- a/client/src/components/RfSpectrum.tsx
+++ b/client/src/components/RfSpectrum.tsx
@@ -14,62 +14,64 @@ interface Props {
 const RfSpectrum: React.FC<Props> = ({ data, height = 150 }) => {
     const canvasRef = useRef<HTMLCanvasElement>(null);
     const historyRef = useRef<HTMLCanvasElement | null>(null);
+    const queueRef = useRef<DataPoint[][]>([]);
+    const animationRef = useRef<number>(0);
     const lastDataRef = useRef<string>('');
 
+    // Push new data to queue
     useEffect(() => {
-        if (!canvasRef.current || !data || data.length === 0) return;
-
+        if (!data || data.length === 0) return;
+        
+        // Basic stability check
         const dataStr = JSON.stringify(data.slice(0, 5)); 
         if (dataStr === lastDataRef.current) return;
         lastDataRef.current = dataStr;
 
+        queueRef.current.push(data);
+        
+        // Cap the queue to prevent memory issues if hidden for a long time
+        if (queueRef.current.length > 500) {
+            queueRef.current.shift();
+        }
+    }, [data]);
+
+    useEffect(() => {
         const width = 800; // Fixed internal width
         const canHeight = height;
 
-        // Initialize history canvas if needed
-        if (!historyRef.current) {
-            historyRef.current = document.createElement('canvas');
-            historyRef.current.width = width;
-            historyRef.current.height = canHeight;
-            const hCtx = historyRef.current.getContext('2d');
-            if (hCtx) {
-                hCtx.fillStyle = '#000';
-                hCtx.fillRect(0, 0, width, canHeight);
+        const drawRowToHistory = (rowData: DataPoint[]) => {
+            if (!historyRef.current) {
+                historyRef.current = document.createElement('canvas');
+                historyRef.current.width = width;
+                historyRef.current.height = canHeight;
+                const hCtx = historyRef.current.getContext('2d');
+                if (hCtx) {
+                    hCtx.fillStyle = '#000';
+                    hCtx.fillRect(0, 0, width, canHeight);
+                }
             }
-        }
 
-        const hCanvas = historyRef.current;
-        const hCtx = hCanvas.getContext('2d', { willReadFrequently: true });
-        if (!hCtx) return;
+            const hCanvas = historyRef.current;
+            const hCtx = hCanvas.getContext('2d', { willReadFrequently: true });
+            if (!hCtx) return;
 
-        // 1. Shift history down
-        const tempCanvas = document.createElement('canvas');
-        tempCanvas.width = width;
-        tempCanvas.height = canHeight;
-        const tempCtx = tempCanvas.getContext('2d');
-        if (tempCtx) {
-            tempCtx.drawImage(hCanvas, 0, 0);
+            // 1. Shift history down
+            hCtx.drawImage(hCanvas, 0, 0, width, canHeight, 0, 1, width, canHeight);
+            
+            // 2. Clear the top row
             hCtx.fillStyle = '#000';
-            hCtx.fillRect(0, 0, width, canHeight);
-            hCtx.drawImage(tempCanvas, 0, 1);
-        }
+            hCtx.fillRect(0, 0, width, 1);
 
-        // 2. Draw new row to history
-        const rowCanvas = document.createElement('canvas');
-        rowCanvas.width = data.length;
-        rowCanvas.height = 1;
-        const rowCtx = rowCanvas.getContext('2d');
-        if (rowCtx) {
-            const imageData = rowCtx.createImageData(data.length, 1);
-            const minDb = -100; // Lowered floor
-            const maxDb = -20;  // Adjusted ceiling
+            // 3. Draw new row
+            const imageData = hCtx.createImageData(rowData.length, 1);
+            const minDb = -100;
+            const maxDb = -20;
 
-            for (let x = 0; x < data.length; x++) {
-                const db = data[x].db;
+            for (let x = 0; x < rowData.length; x++) {
+                const db = rowData[x].db;
                 const val = Math.max(0, Math.min(255, ((db - minDb) / (maxDb - minDb)) * 255));
 
                 let r = 0, g = 0, b = 0;
-                // Improved Heatmap: DarkBlue -> Cyan -> Green -> Yellow -> Red
                 if (val < 50) {
                     b = val * 5;
                 } else if (val < 100) {
@@ -92,17 +94,45 @@ const RfSpectrum: React.FC<Props> = ({ data, height = 150 }) => {
                 imageData.data[i + 2] = b;
                 imageData.data[i + 3] = 255;
             }
-            rowCtx.putImageData(imageData, 0, 0);
-            hCtx.drawImage(rowCanvas, 0, 0, data.length, 1, 0, 0, width, 1);
-        }
+            
+            // Draw the computed row to a temp canvas to stretch it if necessary
+            const rowCanvas = document.createElement('canvas');
+            rowCanvas.width = rowData.length;
+            rowCanvas.height = 1;
+            const rowCtx = rowCanvas.getContext('2d');
+            if (rowCtx) {
+                rowCtx.putImageData(imageData, 0, 0);
+                hCtx.drawImage(rowCanvas, 0, 0, rowData.length, 1, 0, 0, width, 1);
+            }
+        };
 
-        // 3. Copy history to visible canvas
-        const ctx = canvasRef.current.getContext('2d');
-        if (ctx) {
-            ctx.drawImage(hCanvas, 0, 0);
-        }
+        const render = () => {
+            if (queueRef.current.length > 0) {
+                // If we have a massive backlog, process up to 10 rows per frame
+                // to "catch up" quickly but not all at once.
+                const rowsToProcess = Math.min(queueRef.current.length, 10);
+                for (let i = 0; i < rowsToProcess; i++) {
+                    const nextRow = queueRef.current.shift();
+                    if (nextRow) drawRowToHistory(nextRow);
+                }
 
-    }, [data, height]);
+                // Update visible canvas
+                if (canvasRef.current && historyRef.current) {
+                    const ctx = canvasRef.current.getContext('2d');
+                    if (ctx) {
+                        ctx.drawImage(historyRef.current, 0, 0);
+                    }
+                }
+            }
+            animationRef.current = requestAnimationFrame(render);
+        };
+
+        animationRef.current = requestAnimationFrame(render);
+        
+        return () => {
+            if (animationRef.current) cancelAnimationFrame(animationRef.current);
+        };
+    }, [height]);
 
     const minFreq = data && data.length > 0 ? data[0].frequency.toFixed(2) : '---';
     const maxFreq = data && data.length > 0 ? data[data.length - 1].frequency.toFixed(2) : '---';


### PR DESCRIPTION
Closes #93

When the browser tab is hidden, the AudioContext suspends and `ctx.currentTime` freezes, but `nextStartTime` kept accumulating for every buffered WebSocket message. On return, the scheduler went into a catch-up burst, playing audio rapidly.

**Changes:**
- Skip audio processing entirely while page is hidden (`isPageHiddenRef`)
- Reset `nextStartTime` to 0 on visibility change to visible, so the next packet schedules fresh
- Reset scheduler after AudioContext resume if `nextStartTime` drifted ahead
- Refactored RfSpectrum waterfall to use queue + requestAnimationFrame for graceful backlog handling