### PR TITLE
MDC1200 decoding, fire tone-out event log, and single-tone paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,41 @@ For API documentation, visit:
 - **Full Install**: `./scripts/install_service.sh` (Builds everything and installs the systemd service).
 - **Dependencies Only**: `./scripts/install_service.sh --deps-only` (Installs all required system libraries, radio drivers, and Whisper models, then exits without building the app or installing the service).
 
+## Running on macOS
+
+OpenScanner also runs on macOS (Apple Silicon and Intel) for development and desktop use. The macOS setup script uses **Homebrew** to install dependencies, builds whisper.cpp and DSD-FME from source, builds the app, and prints how to run it. macOS has no systemd, so it does **not** install a background service.
+
+```bash
+git clone https://github.com/briannippert/OpenScanner.git
+cd OpenScanner
+chmod +x scripts/*.sh
+
+# Installs deps (Homebrew + .NET 10 + whisper.cpp + dsd-fme) and builds the app
+./scripts/install_mac.sh
+
+# Dependencies only:
+./scripts/install_mac.sh --deps-only
+```
+
+Then run the app and open `http://localhost:8080` (Swagger at `/swagger`):
+
+```bash
+cd server/OpenScanner.Server
+dotnet run -c Release --urls "http://0.0.0.0:8080"
+```
+
+**Requirements:** [Homebrew](https://brew.sh) and macOS 13+. The script installs the rest (`rtl-sdr`, `ffmpeg`, `coreutils`, the .NET 10 SDK, etc.).
+
+**No SDR hardware?** OpenScanner ships with a mock radio source so you can run the full UI without a dongle. Set the provider to `Mock` in `server/OpenScanner.Server/appsettings.Development.json`:
+
+```json
+"Radio": { "Provider": "Mock" }
+```
+
+**GPS (optional):** OpenScanner connects to `gpsd` on `localhost:2947`; install and start it via `brew install gpsd` if you want live location.
+
+> **Note on external tools:** OpenScanner resolves `rtl_sdr`, `rtl_fm`, `ffmpeg`, and `dsd-fme` from your `PATH` and common install locations (Homebrew's `/opt/homebrew/bin` and `/usr/local/bin`, plus the standard Linux paths), so the same code runs on both the Raspberry Pi and macOS.
+
 ## Updating
 
 To update OpenScanner to the latest version, simply navigate to the project directory and re-run the installation script. This will pull the latest changes, rebuild components, and restart the service:

--- a/client/e2e/flows/scanner.spec.ts
+++ b/client/e2e/flows/scanner.spec.ts
@@ -7,9 +7,9 @@ test.describe('Scanner Control', () => {
 
   test('clicking channel card triggers hold', async ({ page }) => {
     let holdRequestSent = false;
-    await page.route(/\/api\/control/, async route => {
+    await page.route(/\/api\/scanner\/hold/, async route => {
         const data = route.request().postDataJSON();
-        if (data.action === 'hold' && data.frequency === 155.000) {
+        if (route.request().method() === 'PUT' && data.frequency === 155.000) {
             holdRequestSent = true;
         }
         await route.fulfill({ status: 200 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -251,22 +251,30 @@ function App() {
     return () => clearInterval(timer);
   }, []);
 
-  // Helper to send commands
-  const sendCommand = (action: string, frequency?: number, value?: number) => {
-    fetch('/api/control', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action, frequency, value })
+  // Low-level REST helper for scanner control endpoints
+  const scannerApi = (path: string, method: string, body?: object) =>
+    fetch(`/api/scanner/${path}`, {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
     }).catch(err => console.error("Command failed:", err));
+
+  // Helper to send commands, mapping legacy action names onto REST endpoints
+  const sendCommand = (action: string, frequency?: number, value?: number) => {
+    switch (action) {
+        case 'scan': return scannerApi('hold', 'DELETE');
+        case 'hold': return scannerApi('hold', 'PUT', { frequency });
+        case 'start': return scannerApi('power', 'PUT', { enabled: true });
+        case 'stop': return scannerApi('power', 'PUT', { enabled: false });
+        case 'set_squelch': return scannerApi('squelch', 'PUT', { value });
+        case 'debug_spectrum': return scannerApi('debug-spectrum', 'POST', { frequency, gain: value });
+        default: console.error("Unknown command:", action);
+    }
   };
 
   const handleSkip = (freq?: number) => {
     if (freq) {
-        fetch('/api/control', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ action: 'avoid', frequency: freq, duration: 10 })
-        }).catch(err => console.error("Skip command failed:", err));
+        scannerApi('avoids', 'POST', { frequency: freq, duration: 10 });
     } else {
         sendCommand('scan');
     }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,7 +23,8 @@ import SupportAgentIcon from '@mui/icons-material/SupportAgent';
 import SettingsIcon from '@mui/icons-material/Settings';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import MonitorIcon from '@mui/icons-material/Monitor';
-import type { ScannerState, Channel, CallLog, FireToneSet } from './types';
+import type { ScannerState, Channel, CallLog, FireToneSet, RadioEvent } from './types';
+import EventLog from './components/EventLog';
 
 const darkTheme = createTheme({
   palette: {
@@ -73,6 +74,7 @@ function App() {
   const [channels, setChannels] = useState<Channel[]>([]);
   const [fireTones, setFireTones] = useState<FireToneSet[]>([]);
   const [callLog, setCallLog] = useState<CallLog[]>([]);
+  const [radioEvents, setRadioEvents] = useState<RadioEvent[]>([]);
   const [audioAnalyser, setAudioAnalyser] = useState<AnalyserNode | undefined>(undefined);
   const [isManagerOpen, setIsManagerOpen] = useState(false);
   const [isToneManagerOpen, setIsToneManagerOpen] = useState(false);
@@ -424,6 +426,15 @@ function App() {
       .catch(err => console.error("Failed to fetch fire tones:", err));
   };
 
+  const clearEvents = async () => {
+    try {
+      await fetch(`/api/events`, { method: 'DELETE' });
+      setRadioEvents([]);
+    } catch (err) {
+      console.error("Failed to clear events:", err);
+    }
+  };
+
   const handleSaveChannel = async (channel: Channel) => {
     const baseUrl = `/api/channels`;
 
@@ -502,6 +513,11 @@ function App() {
       .then(data => setCallLog(data))
       .catch(err => console.error("Failed to fetch history:", err));
 
+    fetch(`/api/events`)
+      .then(res => res.json())
+      .then(data => setRadioEvents(data))
+      .catch(err => console.error("Failed to fetch events:", err));
+
     const connectControlWs = () => {
         wsControl.current = new WebSocket(wsControlUrl);
         
@@ -533,6 +549,12 @@ function App() {
                     } else {
                       return [newEntry, ...log].slice(0, 100);
                     }
+                  });
+                } else if (message.type === 'NEW_EVENT') {
+                  const newEvent = message.payload as RadioEvent;
+                  setRadioEvents(events => {
+                    if (events.some(x => x.id === newEvent.id)) return events;
+                    return [newEvent, ...events].slice(0, 100);
                   });
                 } else if (message.type === 'ERROR') {
                   setErrorMsg(message.payload);
@@ -1001,11 +1023,12 @@ function App() {
                 {/* Right Column: Transmission Log (Expanded) */}
                 <Grid size={{ xs: 12, md: 8, lg: 9 }} sx={{ height: { xs: '500px', md: '100%' }, overflow: 'hidden' }}>
                     <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column', bgcolor: '#0a0a0a', border: '1px solid #222', borderRadius: 2, overflowY: 'auto' }}>
-                        <TransmissionLog 
-                            liveLogs={callLog} 
-                            playingId={playingId} 
-                            onPlay={playRawAudio} 
-                            onDelete={deleteEntry} 
+                        {fireTones.length > 0 && <EventLog events={radioEvents} onClear={clearEvents} />}
+                        <TransmissionLog
+                            liveLogs={callLog}
+                            playingId={playingId}
+                            onPlay={playRawAudio}
+                            onDelete={deleteEntry}
                         />
                     </Paper>
                 </Grid>

--- a/client/src/components/EventLog.tsx
+++ b/client/src/components/EventLog.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { Box, Typography, IconButton, Collapse, List, ListItem, Tooltip } from '@mui/material';
+import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
+import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import type { RadioEvent } from '../types';
+
+interface EventLogProps {
+    events: RadioEvent[];
+    onClear: () => void;
+}
+
+const formatDetail = (e: RadioEvent): string => {
+    if (e.toneA != null && e.toneB) return `${e.toneA.toFixed(0)} / ${e.toneB.toFixed(0)} Hz`;
+    if (e.toneA != null) return `${e.toneA.toFixed(0)} Hz`;
+    return '';
+};
+
+export default function EventLog({ events, onClear }: EventLogProps) {
+    const [open, setOpen] = useState(true);
+
+    return (
+        <Box sx={{ borderBottom: '1px solid #222', flexShrink: 0 }}>
+            <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="space-between"
+                sx={{ px: 1.5, py: 1, cursor: 'pointer' }}
+                onClick={() => setOpen(o => !o)}
+            >
+                <Box display="flex" alignItems="center" gap={1}>
+                    <NotificationsActiveIcon sx={{ color: '#ffb74d', fontSize: 18 }} />
+                    <Typography sx={{ color: '#eee', fontWeight: 'bold', fontSize: '0.8rem', letterSpacing: 0.5 }}>
+                        FIRE TONE-OUTS
+                    </Typography>
+                    <Typography sx={{ color: '#888', fontSize: '0.75rem' }}>({events.length})</Typography>
+                </Box>
+                <Box display="flex" alignItems="center">
+                    {events.length > 0 && (
+                        <Tooltip title="Clear events">
+                            <IconButton
+                                size="small"
+                                onClick={(ev) => { ev.stopPropagation(); onClear(); }}
+                                sx={{ color: '#888' }}
+                            >
+                                <DeleteSweepIcon fontSize="small" />
+                            </IconButton>
+                        </Tooltip>
+                    )}
+                    <IconButton size="small" sx={{ color: '#888' }}>
+                        {open ? <ExpandLessIcon fontSize="small" /> : <ExpandMoreIcon fontSize="small" />}
+                    </IconButton>
+                </Box>
+            </Box>
+
+            <Collapse in={open} timeout="auto" unmountOnExit>
+                {events.length === 0 ? (
+                    <Typography sx={{ color: '#666', fontSize: '0.75rem', px: 1.5, pb: 1.5 }}>
+                        No fire tone-outs detected yet.
+                    </Typography>
+                ) : (
+                    <List dense disablePadding sx={{ maxHeight: 200, overflowY: 'auto' }}>
+                        {events.map(e => {
+                            return (
+                                <ListItem
+                                    key={e.id}
+                                    sx={{ px: 1.5, py: 0.5, borderTop: '1px solid #161616' }}
+                                >
+                                    <Box display="flex" alignItems="center" gap={1} width="100%">
+                                        <Typography
+                                            variant="caption"
+                                            sx={{
+                                                color: '#ffb74d', fontWeight: 'bold', fontSize: '9px',
+                                                bgcolor: 'transparent', border: '1px solid #8a5a2b',
+                                                px: 0.6, py: 0.1, borderRadius: 0.5, letterSpacing: 0.5, flexShrink: 0,
+                                            }}
+                                        >
+                                            TONE
+                                        </Typography>
+                                        <Box flexGrow={1} minWidth={0}>
+                                            <Typography sx={{ color: '#eee', fontSize: '0.8rem', lineHeight: 1.2 }} noWrap>
+                                                {e.label}
+                                            </Typography>
+                                            <Typography sx={{ color: '#999', fontSize: '0.7rem' }} noWrap>
+                                                {formatDetail(e)}
+                                                {e.alphaTag ? ` · ${e.alphaTag}` : e.frequency ? ` · ${e.frequency.toFixed(4)} MHz` : ''}
+                                            </Typography>
+                                        </Box>
+                                        <Typography sx={{ color: '#666', fontSize: '0.7rem', flexShrink: 0 }}>
+                                            {new Date(e.timestamp).toLocaleTimeString()}
+                                        </Typography>
+                                    </Box>
+                                </ListItem>
+                            );
+                        })}
+                    </List>
+                )}
+            </Collapse>
+        </Box>
+    );
+}

--- a/client/src/components/FireToneManager.tsx
+++ b/client/src/components/FireToneManager.tsx
@@ -68,23 +68,23 @@ const FireToneManager: React.FC<Props> = ({ open, onClose, tones, onSave, onDele
                                 required autoFocus
                             />
                             <Box display="flex" gap={2}>
-                                <TextField 
-                                    label="Tone A (Hz)" 
-                                    type="number" 
+                                <TextField
+                                    label="Tone A (Hz)"
+                                    type="number"
                                     inputProps={{ step: "0.1" }}
-                                    value={editing.frequencyA} 
-                                    onChange={e => handleChange('frequencyA', parseFloat(e.target.value))} 
-                                    required 
+                                    value={editing.frequencyA}
+                                    onChange={e => handleChange('frequencyA', parseFloat(e.target.value))}
+                                    required
                                     sx={{ flex: 1 }}
                                 />
-                                <TextField 
-                                    label="Tone B (Hz)" 
-                                    type="number" 
+                                <TextField
+                                    label="Tone B (Hz)"
+                                    type="number"
                                     inputProps={{ step: "0.1" }}
-                                    value={editing.frequencyB} 
-                                    onChange={e => handleChange('frequencyB', parseFloat(e.target.value))} 
-                                    required 
+                                    value={editing.frequencyB || ''}
+                                    onChange={e => handleChange('frequencyB', parseFloat(e.target.value) || 0)}
                                     sx={{ flex: 1 }}
+                                    helperText="Leave blank for a single (long) tone"
                                 />
                             </Box>
                             <TextField 
@@ -120,7 +120,9 @@ const FireToneManager: React.FC<Props> = ({ open, onClose, tones, onSave, onDele
                                     <Box display="flex" alignItems="center" gap={2}>
                                         <Typography variant="subtitle1" fontWeight="bold">{tone.name}</Typography>
                                         <Typography variant="body2" color="error" fontFamily="monospace">
-                                            {tone.frequencyA} / {tone.frequencyB} Hz
+                                            {tone.frequencyB > 0
+                                                ? `${tone.frequencyA} / ${tone.frequencyB} Hz`
+                                                : `${tone.frequencyA} Hz (single tone)`}
                                         </Typography>
                                     </Box>
                                 }

--- a/client/src/components/ScannerDisplay.tsx
+++ b/client/src/components/ScannerDisplay.tsx
@@ -291,18 +291,18 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                 />
                             )}
                             {state.lastDetectedTone && (
-                                <Chip 
-                                    label={`ALERT: ${state.lastDetectedTone}`} 
-                                    size="small" 
+                                <Chip
+                                    label={`ALERT: ${state.lastDetectedTone}`}
+                                    size="small"
                                     color="error"
                                     variant="filled"
-                                    sx={{ 
+                                    sx={{
                                         height: 20,
                                         fontSize: '0.7rem',
                                         fontWeight: 'bold',
                                         fontFamily: 'monospace',
                                         animation: 'pulse 1s infinite'
-                                    }} 
+                                    }}
                                 />
                             )}
                         </Box>

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -84,6 +84,18 @@ export interface FireToneSet {
     description?: string;
 }
 
+export interface RadioEvent {
+    id: string;
+    timestamp: string;
+    type: 'TONE_OUT';
+    label: string;
+    frequency: number;
+    alphaTag?: string;
+    toneA?: number;
+    toneB?: number;
+    transmissionId?: string;
+}
+
 declare global {
     interface Window {
         audioCtx?: AudioContext;

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+set -e # Exit immediately if a command exits with a non-zero status
+
+# ==========================================
+# OpenScanner macOS Setup (Development / Desktop)
+# ==========================================
+# Installs dependencies via Homebrew, builds whisper.cpp and the DSD-FME radio
+# decoder from source, builds the .NET backend (which also builds the React
+# client), and prints how to run the app.
+#
+# macOS has no systemd, so this script does NOT install a background service.
+# Use --deps-only to install dependencies and exit without building.
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_step() { echo -e "\n${BLUE}${BOLD}==> $1${NC}"; }
+log_success() { echo -e "${GREEN}[OK] $1${NC}"; }
+log_warn() { echo -e "${YELLOW}[WARN] $1${NC}"; }
+log_error() { echo -e "${RED}[ERROR] $1${NC}"; }
+
+# Parse Arguments
+DEPS_ONLY=false
+for arg in "$@"; do
+  case $arg in
+    --deps-only) DEPS_ONLY=true ; shift ;;
+  esac
+done
+
+if [ "$(uname)" != "Darwin" ]; then
+    log_error "This script is for macOS. On Linux/Raspberry Pi use ./scripts/install_service.sh"
+    exit 1
+fi
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+NPROC=$(sysctl -n hw.ncpu)
+
+log_step "Initializing Setup"
+log_info "Project Root: $PROJECT_ROOT"
+log_info "CPU cores: $NPROC"
+
+# ----------------------------------------------------------------
+# 1. Homebrew
+# ----------------------------------------------------------------
+log_step "Checking Homebrew..."
+if ! command -v brew &> /dev/null; then
+    log_error "Homebrew is required. Install it from https://brew.sh and re-run this script."
+    exit 1
+fi
+log_success "Found Homebrew: $(brew --prefix)"
+
+# ----------------------------------------------------------------
+# 2. System Dependencies (Homebrew)
+# ----------------------------------------------------------------
+log_step "Installing System Libraries..."
+# rtl-sdr: rtl_sdr / rtl_fm tools + driver
+# ffmpeg:  audio conversion in the decode/record/transcribe pipelines
+# coreutils: provides gstdbuf (the GNU stdbuf used to tune pipe buffering)
+# itpp / libsndfile / portaudio / ncurses / libusb / codec2: DSD-FME deps
+# pulseaudio: provides libpulse client libs that DSD-FME links against (it only
+#   pipes audio via stdin/stdout in OpenScanner, but the lib is a build-time dep)
+# gpsd: optional GPS support (gpsd listens on localhost:2947)
+BREW_PKGS="rtl-sdr ffmpeg coreutils cmake git node jq itpp libsndfile portaudio ncurses libusb codec2 pulseaudio gpsd"
+log_info "brew install $BREW_PKGS"
+brew install $BREW_PKGS
+log_success "Libraries installed."
+
+# ----------------------------------------------------------------
+# 3. .NET 10 SDK
+# ----------------------------------------------------------------
+log_step "Checking .NET SDK..."
+DOTNET_OK=false
+if command -v dotnet &> /dev/null; then
+    MAJOR_VER=$(dotnet --version | cut -d. -f1)
+    if [ "$MAJOR_VER" -ge 10 ]; then
+        DOTNET_OK=true
+        log_success "Found .NET SDK: $(dotnet --version)"
+    fi
+fi
+
+if [ "$DOTNET_OK" = false ]; then
+    log_info "Installing .NET 10 SDK to \$HOME/.dotnet via the official installer..."
+    curl -sSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
+    bash /tmp/dotnet-install.sh --channel 10.0
+    export DOTNET_ROOT="$HOME/.dotnet"
+    export PATH="$DOTNET_ROOT:$PATH"
+    log_success ".NET 10 SDK installed to $DOTNET_ROOT"
+    log_warn "Add this to your shell profile so 'dotnet' is always found:"
+    echo '   export DOTNET_ROOT="$HOME/.dotnet"'
+    echo '   export PATH="$DOTNET_ROOT:$PATH"'
+fi
+
+# nbgv (Nerdbank.GitVersioning) tool used during the build
+export PATH="$PATH:$HOME/.dotnet/tools"
+if ! command -v nbgv &> /dev/null; then
+    log_info "Installing nbgv versioning tool..."
+    dotnet tool install -g nbgv || log_warn "Could not install nbgv globally; build may still succeed."
+fi
+
+# ----------------------------------------------------------------
+# 4. Whisper.cpp (AI transcription)
+# ----------------------------------------------------------------
+log_step "Checking Whisper.cpp..."
+if [ ! -d "$PROJECT_ROOT/whisper.cpp" ]; then
+    log_info "Cloning whisper.cpp..."
+    git clone https://github.com/ggerganov/whisper.cpp.git "$PROJECT_ROOT/whisper.cpp"
+fi
+
+if [ ! -f "$PROJECT_ROOT/whisper.cpp/build/bin/whisper-cli" ]; then
+    log_info "Building whisper.cpp..."
+    cd "$PROJECT_ROOT/whisper.cpp"
+    cmake -B build
+    cmake --build build --config Release -j"$NPROC"
+    log_success "Whisper.cpp built."
+fi
+
+WHISPER_MODEL=$(grep '"Model":' "$PROJECT_ROOT/server/OpenScanner.Server/appsettings.json" | head -n 1 | cut -d'"' -f4 || echo "small.en")
+log_info "Transcription Model: $WHISPER_MODEL"
+if [ ! -f "$PROJECT_ROOT/whisper.cpp/models/ggml-$WHISPER_MODEL.bin" ]; then
+    log_info "Downloading Whisper model ($WHISPER_MODEL)..."
+    cd "$PROJECT_ROOT/whisper.cpp"
+    bash ./models/download-ggml-model.sh "$WHISPER_MODEL"
+    log_success "Whisper model downloaded."
+fi
+cd "$PROJECT_ROOT"
+
+# ----------------------------------------------------------------
+# 5. DSD-FME + mbelib (digital voice decoding) — built from source
+# ----------------------------------------------------------------
+log_step "Checking Radio Dependencies (dsd-fme)..."
+if ! command -v dsd-fme &> /dev/null; then
+    log_info "dsd-fme not found. Building from source..."
+    mkdir -p "$PROJECT_ROOT/build_deps"
+    cd "$PROJECT_ROOT/build_deps"
+
+    # mbelib
+    if [ ! -f /usr/local/include/mbelib.h ] && [ ! -f /opt/homebrew/include/mbelib.h ]; then
+        log_info "Building mbelib..."
+        [ -d mbelib ] || git clone https://github.com/szechyjs/mbelib.git
+        cd mbelib
+        rm -rf build && mkdir -p build && cd build
+        # mbelib targets an ancient CMake minimum that modern CMake rejects.
+        cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
+        make -j"$NPROC"
+        sudo make install
+        cd ../..
+    fi
+
+    # dsd-fme
+    log_info "Building dsd-fme..."
+    [ -d dsd-fme ] || git clone https://github.com/lwvmobile/dsd-fme.git
+    cd dsd-fme
+    git pull origin "$(git branch --show-current)" || true
+    rm -rf build && mkdir -p build && cd build
+    # Homebrew's ncurses and pulseaudio are keg-only, so their headers and
+    # pkg-config files aren't on the default search paths. Point CMake/pkg-config
+    # at them explicitly, pass the Homebrew prefix so the other deps (itpp,
+    # codec2, libsndfile, portaudio) are found, and set the legacy CMake policy
+    # floor in case dsd-fme's minimum is too old.
+    NCURSES_PREFIX="$(brew --prefix ncurses)"
+    export PKG_CONFIG_PATH="$(brew --prefix pulseaudio)/lib/pkgconfig:$NCURSES_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH"
+    cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
+          -DCMAKE_PREFIX_PATH="$(brew --prefix)" \
+          -DCURSES_NEED_NCURSES=TRUE \
+          -DCURSES_INCLUDE_PATH="$NCURSES_PREFIX/include" \
+          -DCURSES_LIBRARY="$NCURSES_PREFIX/lib/libncurses.dylib" \
+          ..
+    make -j"$NPROC"
+    sudo make install
+    cd "$PROJECT_ROOT"
+    log_success "Radio dependencies installed."
+else
+    log_success "Radio dependencies found: $(command -v dsd-fme)"
+fi
+
+if [ "$DEPS_ONLY" = true ]; then
+    log_success "Dependencies installed. Skipping build (--deps-only)."
+    exit 0
+fi
+
+# ----------------------------------------------------------------
+# 6. Build Application (.NET build also compiles the React client)
+# ----------------------------------------------------------------
+log_step "Building Application..."
+cd "$PROJECT_ROOT/server/OpenScanner.Server"
+if dotnet build -c Release; then
+    log_success "Build succeeded."
+else
+    log_error "Build failed."
+    exit 1
+fi
+
+# ----------------------------------------------------------------
+# 7. Done
+# ----------------------------------------------------------------
+echo ""
+echo "================================================="
+log_success "Setup Complete!"
+echo "================================================="
+echo -e "   ${BOLD}Run OpenScanner:${NC}"
+echo "     cd $PROJECT_ROOT/server/OpenScanner.Server"
+echo "     dotnet run -c Release --urls \"http://0.0.0.0:8080\""
+echo ""
+echo -e "   Then open: ${BOLD}http://localhost:8080${NC}  (Swagger: /swagger)"
+echo ""
+echo -e "   ${BOLD}No SDR hardware?${NC} Run with the mock radio source by setting"
+echo -e "   \"Radio\": { \"Provider\": \"Mock\" } in appsettings.Development.json."
+echo "================================================="

--- a/server/OpenScanner.Server/Controllers/EventsController.cs
+++ b/server/OpenScanner.Server/Controllers/EventsController.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenScanner.Server.Models;
+using OpenScanner.Server.Interfaces;
+
+namespace OpenScanner.Server.Controllers;
+
+/// <summary>
+/// Controller for accessing the radio event log — fire tone-out and MDC1200 detections.
+/// </summary>
+[ApiController]
+[Route("api/events")]
+[Produces("application/json")]
+public class EventsController : ControllerBase
+{
+    private readonly IDatabase _db;
+
+    public EventsController(IDatabase db)
+    {
+        _db = db;
+    }
+
+    /// <summary>
+    /// Retrieves the most recent radio events (newest first).
+    /// </summary>
+    /// <returns>A list of the latest 100 radio events.</returns>
+    [HttpGet("")]
+    [ProducesResponseType(typeof(IEnumerable<RadioEvent>), StatusCodes.Status200OK)]
+    public async Task<IEnumerable<RadioEvent>> GetEvents()
+    {
+        return await _db.GetRadioEventsAsync(100);
+    }
+
+    /// <summary>
+    /// Clears all stored radio events.
+    /// </summary>
+    [HttpDelete("")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> ClearEvents()
+    {
+        await _db.ClearRadioEventsAsync();
+        return Ok();
+    }
+}

--- a/server/OpenScanner.Server/Controllers/FiretonesController.cs
+++ b/server/OpenScanner.Server/Controllers/FiretonesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenScanner.Server.Models;
 using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Services;
 
 namespace OpenScanner.Server.Controllers;
 
@@ -13,10 +14,12 @@ namespace OpenScanner.Server.Controllers;
 public class FiretonesController : ControllerBase
 {
     private readonly IDatabase _db;
+    private readonly ToneDetector _toneDetector;
 
-    public FiretonesController(IDatabase db)
+    public FiretonesController(IDatabase db, ToneDetector toneDetector)
     {
         _db = db;
+        _toneDetector = toneDetector;
     }
 
     /// <summary>
@@ -41,6 +44,7 @@ public class FiretonesController : ControllerBase
     {
         var id = await _db.AddFireToneAsync(tone);
         tone.Id = id;
+        _toneDetector.ReloadTones();
         return CreatedAtAction(nameof(GetFireTones), new { id }, tone);
     }
 
@@ -55,6 +59,7 @@ public class FiretonesController : ControllerBase
     {
         tone.Id = id;
         await _db.UpdateFireToneAsync(tone);
+        _toneDetector.ReloadTones();
         return Ok();
     }
 
@@ -67,6 +72,7 @@ public class FiretonesController : ControllerBase
     public async Task<IActionResult> DeleteFireTone(int id)
     {
         await _db.DeleteFireToneAsync(id);
+        _toneDetector.ReloadTones();
         return Ok();
     }
 }

--- a/server/OpenScanner.Server/Controllers/ScannerController.cs
+++ b/server/OpenScanner.Server/Controllers/ScannerController.cs
@@ -88,14 +88,146 @@ public class ScannerController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves the current real-time state of the scanner.
+    /// </summary>
+    /// <returns>The current <see cref="ScannerState"/>.</returns>
+    [HttpGet("scanner")]
+    [ProducesResponseType(typeof(ScannerState), StatusCodes.Status200OK)]
+    public ScannerState GetStatus() => _radio.GetState();
+
+    /// <summary>
+    /// Turns the scanner on (start) or off (stop).
+    /// </summary>
+    /// <param name="request">Whether the scanner should be enabled.</param>
+    [HttpPut("scanner/power")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult SetPower([FromBody] PowerRequest request)
+    {
+        if (request.Enabled) _radio.Start();
+        else _radio.Stop();
+        return Ok();
+    }
+
+    /// <summary>
+    /// Holds the scanner on a specific frequency, un-avoiding it if necessary.
+    /// </summary>
+    /// <param name="request">The frequency to hold, in MHz.</param>
+    [HttpPut("scanner/hold")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> Hold([FromBody] HoldRequest request)
+    {
+        await HoldFrequencyInternal(request.Frequency);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Releases any active hold and resumes normal scanning.
+    /// </summary>
+    [HttpDelete("scanner/hold")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult ReleaseHold()
+    {
+        _radio.ResumeScan();
+        return Ok();
+    }
+
+    /// <summary>
+    /// Sets the squelch threshold.
+    /// </summary>
+    /// <param name="request">The squelch threshold, in dB.</param>
+    [HttpPut("scanner/squelch")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult SetSquelch([FromBody] SquelchRequest request)
+    {
+        _radio.SetSquelch(request.Value);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Temporarily avoids a frequency for a given duration.
+    /// </summary>
+    /// <param name="request">The frequency to avoid and how long to avoid it.</param>
+    [HttpPost("scanner/avoids")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    public IActionResult AddAvoid([FromBody] AvoidRequest request)
+    {
+        _radio.AvoidFrequency(request.Frequency, request.Duration);
+        return Accepted();
+    }
+
+    /// <summary>
+    /// Starts recording raw IQ data to a file.
+    /// </summary>
+    /// <param name="request">An optional label for the dump filename.</param>
+    [HttpPost("scanner/iq-dump")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult StartIqDump([FromBody] IqDumpRequest? request)
+    {
+        _radio.StartDumping(request?.Label ?? "sample");
+        return Ok();
+    }
+
+    /// <summary>
+    /// Stops recording raw IQ data.
+    /// </summary>
+    [HttpDelete("scanner/iq-dump")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult StopIqDump()
+    {
+        _radio.StopDumping();
+        return Ok();
+    }
+
+    /// <summary>
+    /// Starts high-bandwidth RF spectrum debug mode.
+    /// </summary>
+    /// <param name="request">The center frequency (MHz) and optional hardware gain (dB).</param>
+    [HttpPost("scanner/debug-spectrum")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult StartDebugSpectrum([FromBody] DebugSpectrumRequest request)
+    {
+        _radio.StartDebugSpectrum(request.Frequency, request.Gain);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Holds the scanner on a frequency, un-avoiding a matching channel first.
+    /// </summary>
+    private async Task HoldFrequencyInternal(double frequency)
+    {
+        var channels = await _db.GetAllChannelsAsync();
+        foreach (var ch in channels)
+        {
+            if (Math.Abs(ch.Frequency - frequency) < 0.0001)
+            {
+                if (ch.Avoid)
+                {
+                    ch.Avoid = false;
+                    await _db.UpdateChannelAsync(ch);
+                    _radio.ReloadChannels();
+                }
+                break;
+            }
+        }
+        _radio.HoldFrequency(frequency);
+    }
+
+    /// <summary>
     /// Sends a direct control command to the scanner service.
     /// </summary>
+    /// <remarks>
+    /// Deprecated: use the resource-oriented <c>/api/scanner/*</c> endpoints instead.
+    /// This action-dispatch endpoint is retained for backward compatibility.
+    /// </remarks>
     /// <param name="body">JSON payload with 'action' (start, stop, scan, hold, set_squelch) and optional parameters.</param>
     [HttpPost("control")]
+    [Obsolete("Use the resource-oriented /api/scanner/* endpoints instead.")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> ControlScanner([FromBody] JsonElement body)
     {
+        Response.Headers.Append("Deprecation", "true");
+        Response.Headers.Append("Link", "</api/scanner>; rel=\"successor-version\"");
         if (!body.TryGetProperty("action", out var actionProp))
             return BadRequest("Action is required");
 
@@ -132,22 +264,7 @@ public class ScannerController : ControllerBase
                 
                 if (targetFreq.HasValue)
                 {
-                    // Check if channel is avoided, if so, un-avoid it
-                    var channels = await _db.GetAllChannelsAsync();
-                    foreach (var ch in channels)
-                    {
-                        if (Math.Abs(ch.Frequency - targetFreq.Value) < 0.0001)
-                        {
-                            if (ch.Avoid)
-                            {
-                                ch.Avoid = false;
-                                await _db.UpdateChannelAsync(ch);
-                                _radio.ReloadChannels();
-                            }
-                            break;
-                        }
-                    }
-                    _radio.HoldFrequency(targetFreq.Value);
+                    await HoldFrequencyInternal(targetFreq.Value);
                 }
                 break;
             case "set_squelch":
@@ -190,3 +307,21 @@ public class ScannerController : ControllerBase
         return Ok();
     }
 }
+
+/// <summary>Request to turn the scanner on or off.</summary>
+public record PowerRequest(bool Enabled);
+
+/// <summary>Request to hold the scanner on a frequency (MHz).</summary>
+public record HoldRequest(double Frequency);
+
+/// <summary>Request to set the squelch threshold (dB).</summary>
+public record SquelchRequest(double Value);
+
+/// <summary>Request to temporarily avoid a frequency (MHz) for a duration (seconds).</summary>
+public record AvoidRequest(double Frequency, double Duration = 10);
+
+/// <summary>Request to start an IQ dump with an optional filename label.</summary>
+public record IqDumpRequest(string? Label = null);
+
+/// <summary>Request to start RF spectrum debug mode at a center frequency (MHz) with optional gain (dB).</summary>
+public record DebugSpectrumRequest(double Frequency, double? Gain = null);

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -92,6 +92,21 @@ public class Database : IDatabase
         ");
 
         conn.Execute(@"
+            CREATE TABLE IF NOT EXISTS radio_events (
+                id TEXT PRIMARY KEY,
+                timestamp TEXT,
+                type TEXT,
+                label TEXT,
+                frequency REAL,
+                alphaTag TEXT,
+                toneA REAL,
+                toneB REAL,
+                unitId INTEGER,
+                transmissionId TEXT
+            );
+        ");
+
+        conn.Execute(@"
             CREATE TABLE IF NOT EXISTS settings (
                 key TEXT PRIMARY KEY,
                 value TEXT
@@ -312,6 +327,31 @@ public class Database : IDatabase
     {
         using var conn = GetConnection();
         await conn.ExecuteAsync("DELETE FROM fire_tones WHERE id=@Id", new { Id = id });
+    }
+
+    /// <inheritdoc />
+    public async Task AddRadioEventAsync(RadioEvent e)
+    {
+        using var conn = GetConnection();
+        await conn.ExecuteAsync(
+            @"INSERT INTO radio_events (id, timestamp, type, label, frequency, alphaTag, toneA, toneB, unitId, transmissionId)
+              VALUES (@Id, @Timestamp, @Type, @Label, @Frequency, @AlphaTag, @ToneA, @ToneB, @UnitId, @TransmissionId)",
+            e);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<RadioEvent>> GetRadioEventsAsync(int limit = 100)
+    {
+        using var conn = GetConnection();
+        return await conn.QueryAsync<RadioEvent>(
+            "SELECT * FROM radio_events ORDER BY timestamp DESC LIMIT @Limit", new { Limit = limit });
+    }
+
+    /// <inheritdoc />
+    public async Task ClearRadioEventsAsync()
+    {
+        using var conn = GetConnection();
+        await conn.ExecuteAsync("DELETE FROM radio_events");
     }
 
     /// <inheritdoc />

--- a/server/OpenScanner.Server/Decoders/AM.cs
+++ b/server/OpenScanner.Server/Decoders/AM.cs
@@ -15,7 +15,7 @@ public class AM : DSDBase
         int captureRate = 24000;
 
         // AM Pipeline with moderate squelch and increased gain for better signal handling
-        return $"stdbuf -o0 rtl_fm -f {channel.Frequency}M -M am -s {captureRate} -r {captureRate} -g 42 -p 0 -l 50 -t 30 - | /usr/bin/ffmpeg -f s16le -ar {captureRate} -ac 1 -i - -af 'highpass=f=300,lowpass=f=4000,volume=5.0' -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+        return $"{PlatformTools.Stdbuf("-o0")}{PlatformTools.RtlFm} -f {channel.Frequency}M -M am -s {captureRate} -r {captureRate} -g 42 -p 0 -l 50 -t 30 - | {PlatformTools.Ffmpeg} -f s16le -ar {captureRate} -ac 1 -i - -af 'highpass=f=300,lowpass=f=4000,volume=5.0' -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }
 
     protected override Task OnStarted(CancellationToken token)

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -32,9 +32,9 @@ public class DMR : DSDBase
         string rtlMode = "fm";
         string dsdArgs = "-fs -ma -V 1"; // DMR TDMA Simplex, auto modulation, slot 1
 
-        string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
+        string source = InputSource ?? $"{PlatformTools.RtlFm} -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
 
-        return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 2 -probesize 32 -analyzeduration 0 -i - -af volume=2.0 -f s16le -ar 48000 -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+        return $"{PlatformTools.Stdbuf("-o0")}{source} | {PlatformTools.Stdbuf("-i0 -o0")}{PlatformTools.DsdFme} {dsdArgs} -i - -o - -s {outputRate} | {PlatformTools.Stdbuf("-o0")}{PlatformTools.Ffmpeg} -f s16le -ar {dsdOutputRate} -ac 2 -probesize 32 -analyzeduration 0 -i - -af volume=2.0 -f s16le -ar 48000 -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }
 
     protected override void ParseMetadata(string line)

--- a/server/OpenScanner.Server/Decoders/NFM.cs
+++ b/server/OpenScanner.Server/Decoders/NFM.cs
@@ -19,7 +19,7 @@ public class NFM : DSDBase
         
         // NFM decoder with optimized squelch and gain settings
         // Simplified pipeline: no parallel MDC processing to avoid audio artifacts
-        return $"stdbuf -o0 rtl_fm -f {channel.Frequency}M -M fm -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -";
+        return $"{PlatformTools.Stdbuf("-o0")}{PlatformTools.RtlFm} -f {channel.Frequency}M -M fm -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -";
     }
 
     protected override Task OnStarted(CancellationToken token)

--- a/server/OpenScanner.Server/Decoders/P25.cs
+++ b/server/OpenScanner.Server/Decoders/P25.cs
@@ -30,9 +30,9 @@ public class P25 : DSDBase
         string rtlMode = "fm";
         string dsdArgs = "-f1"; // P25 Phase 1
 
-        string source = InputSource ?? $"rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -M {rtlMode} -";
+        string source = InputSource ?? $"{PlatformTools.RtlFm} -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -M {rtlMode} -";
 
-        return $"stdbuf -o0 {source} | stdbuf -i0 -o0 /usr/local/bin/dsd-fme {dsdArgs} -i - -o - -s {outputRate} | stdbuf -o0 /usr/bin/ffmpeg -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+        return $"{PlatformTools.Stdbuf("-o0")}{source} | {PlatformTools.Stdbuf("-i0 -o0")}{PlatformTools.DsdFme} {dsdArgs} -i - -o - -s {outputRate} | {PlatformTools.Stdbuf("-o0")}{PlatformTools.Ffmpeg} -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }
 
     protected override void ParseMetadata(string line)

--- a/server/OpenScanner.Server/Decoders/WFM.cs
+++ b/server/OpenScanner.Server/Decoders/WFM.cs
@@ -19,7 +19,7 @@ public class WFM : DSDBase
         int outputRate = 48000;
         string rtlMode = "wbfm";
         // WFM with moderate squelch and increased gain for better signal handling
-        return $"stdbuf -o0 rtl_fm -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -M {rtlMode} -";
+        return $"{PlatformTools.Stdbuf("-o0")}{PlatformTools.RtlFm} -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -M {rtlMode} -";
     }
 
     protected override Task OnStarted(CancellationToken token)

--- a/server/OpenScanner.Server/Devices/FileAudioProvider.cs
+++ b/server/OpenScanner.Server/Devices/FileAudioProvider.cs
@@ -1,0 +1,120 @@
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Devices;
+
+/// <summary>
+/// Streams scenario audio from real recorded files in <c>TestData/</c>. P25
+/// events are piped through the real P25 decoder (via ffmpeg at native rate);
+/// other modes stream the WAV payload directly, throttled to real time. This is
+/// the provider used when the app runs with <c>Radio:Provider=Mock</c> for a
+/// realistic hands-on demo without hardware.
+/// </summary>
+public class FileAudioProvider : IMockAudioProvider
+{
+    // ~33 ms of 48 kHz s16le mono audio.
+    private const int ChunkBytes = 3200;
+    private static readonly TimeSpan ChunkInterval = TimeSpan.FromMilliseconds(33);
+
+    private readonly ILogger<FileAudioProvider> _logger;
+    private readonly IDecoderFactory _decoderFactory;
+    private readonly TimeProvider _timeProvider;
+
+    public FileAudioProvider(
+        ILogger<FileAudioProvider> logger,
+        IDecoderFactory decoderFactory,
+        TimeProvider timeProvider)
+    {
+        _logger = logger;
+        _decoderFactory = decoderFactory;
+        _timeProvider = timeProvider;
+    }
+
+    public async Task StreamAsync(ScenarioEvent evt, Action<byte[]> onChunk, CancellationToken token)
+    {
+        if (string.IsNullOrEmpty(evt.AudioFile))
+        {
+            _logger.LogWarning(
+                "[FileAudioProvider] Event at {Frequency} MHz has no AudioFile; nothing to play.",
+                evt.Frequency);
+            return;
+        }
+
+        // Files are copied next to the assembly via CopyToOutputDirectory, so a
+        // single deterministic resolution is enough (no working-dir guessing).
+        var path = Path.Combine(AppContext.BaseDirectory, "TestData", evt.AudioFile);
+        if (!File.Exists(path))
+        {
+            _logger.LogError("[FileAudioProvider] Audio file not found: {Path}", path);
+            return;
+        }
+
+        if (token.IsCancellationRequested) return;
+
+        _logger.LogInformation(
+            "[FileAudioProvider] Playing {Path} (decoder: {Decoder})",
+            path, evt.DecoderType ?? "none");
+
+        if (string.Equals(evt.DecoderType, "P25", StringComparison.OrdinalIgnoreCase))
+        {
+            await StreamViaDecoderAsync(evt, path, onChunk, token);
+        }
+        else
+        {
+            await StreamRawAsync(path, onChunk, token);
+        }
+    }
+
+    private async Task StreamViaDecoderAsync(
+        ScenarioEvent evt, string path, Action<byte[]> onChunk, CancellationToken token)
+    {
+        IDecoder decoder;
+        try
+        {
+            decoder = _decoderFactory.GetDecoder("P25");
+        }
+        catch (ObjectDisposedException)
+        {
+            return; // Shutting down.
+        }
+
+        // -re makes ffmpeg read at native rate, so the decoder runs in real time
+        // instead of flooding the client.
+        decoder.InputSource =
+            $"{PlatformTools.Ffmpeg} -re -i \"{path}\" -f s16le -ar 48000 -ac 1 -loglevel quiet -";
+
+        void Handler(byte[] chunk) => onChunk(chunk);
+        decoder.OnAudio += Handler;
+        try
+        {
+            var dummyChannel = new Channel { Frequency = evt.Frequency };
+            await decoder.StartAsync(dummyChannel, token);
+        }
+        finally
+        {
+            decoder.OnAudio -= Handler;
+            decoder.Stop();
+        }
+    }
+
+    private async Task StreamRawAsync(string path, Action<byte[]> onChunk, CancellationToken token)
+    {
+        var buffer = new byte[ChunkBytes];
+        using var fs = File.OpenRead(path);
+
+        // Skip the 44-byte WAV header if present.
+        if (path.EndsWith(".wav", StringComparison.OrdinalIgnoreCase) && fs.Length > 44)
+            fs.Position = 44;
+
+        int bytesRead;
+        while ((bytesRead = await fs.ReadAsync(buffer.AsMemory(0, buffer.Length), token)) > 0)
+        {
+            var chunk = new byte[bytesRead];
+            Array.Copy(buffer, chunk, bytesRead);
+            onChunk(chunk);
+
+            // Throttle to real time so playback sounds natural in the demo.
+            await Task.Delay(ChunkInterval, _timeProvider, token);
+        }
+    }
+}

--- a/server/OpenScanner.Server/Devices/MockRadioSource.cs
+++ b/server/OpenScanner.Server/Devices/MockRadioSource.cs
@@ -22,6 +22,8 @@ public class MockRadioSource : BackgroundService, IRadioSource
 
     private readonly ILogger<MockRadioSource> _logger;
     private readonly ToneDetector _toneDetector;
+    private readonly Mdc1200Decoder _mdc;
+    private readonly IDatabase _db;
     private readonly IRecordingService _recordingService;
     private readonly IChannelService _channelService;
     private readonly IMockAudioProvider _audioProvider;
@@ -30,6 +32,7 @@ public class MockRadioSource : BackgroundService, IRadioSource
     public event Action<ScannerState>? OnStateChanged;
     public event Action<CallLog>? OnNewLog;
     public event Action<byte[]>? OnAudio;
+    public event Action<RadioEvent>? OnNewEvent;
 
     private ScannerState _state = new("IDLE", 0);
     private List<ScenarioEvent> _scenarioEvents = new();
@@ -53,6 +56,8 @@ public class MockRadioSource : BackgroundService, IRadioSource
     public MockRadioSource(
         ILogger<MockRadioSource> logger,
         ToneDetector toneDetector,
+        Mdc1200Decoder mdc,
+        IDatabase db,
         IRecordingService recordingService,
         IChannelService channelService,
         IMockAudioProvider audioProvider,
@@ -60,6 +65,8 @@ public class MockRadioSource : BackgroundService, IRadioSource
     {
         _logger = logger;
         _toneDetector = toneDetector;
+        _mdc = mdc;
+        _db = db;
         _recordingService = recordingService;
         _channelService = channelService;
         _audioProvider = audioProvider;
@@ -67,7 +74,42 @@ public class MockRadioSource : BackgroundService, IRadioSource
 
         _recordingService.OnNewLog += log => OnNewLog?.Invoke(log);
 
+        _toneDetector.OnToneDetected += tone =>
+        {
+            UpdateState(_state with { LastDetectedTone = tone.Name });
+            RaiseRadioEvent(new RadioEvent
+            {
+                Type = "TONE_OUT",
+                Label = tone.Name,
+                ToneA = tone.FrequencyA,
+                ToneB = tone.FrequencyB
+            });
+        };
+
+        _mdc.OnPacket += pkt =>
+        {
+            // Attribute the MDC1200 unit ID to the current transmission like a P25 radio ID.
+            UpdateState(_state with { SourceID = pkt.UnitId });
+        };
+
         LoadDefaultScenario();
+    }
+
+    /// <summary>
+    /// Stamps channel context onto a detected signaling event, persists it, and broadcasts it.
+    /// </summary>
+    private void RaiseRadioEvent(RadioEvent e)
+    {
+        e.Id = Guid.NewGuid().ToString();
+        e.Timestamp = _timeProvider.GetUtcNow().UtcDateTime.ToString("o");
+        e.Frequency = _state.CurrentChannel?.Frequency ?? _state.CurrentFrequency ?? 0;
+        e.AlphaTag = _state.CurrentChannel?.AlphaTag;
+
+        _db.AddRadioEventAsync(e).ContinueWith(
+            t => _logger.LogError(t.Exception, "Failed to persist radio event"),
+            TaskContinuationOptions.OnlyOnFaulted);
+
+        OnNewEvent?.Invoke(e);
     }
 
     /// <summary>Number of times the simulation loop has parked waiting for time to pass.</summary>
@@ -325,6 +367,7 @@ public class MockRadioSource : BackgroundService, IRadioSource
         OnAudio?.Invoke(chunk);
         _recordingService.ProcessAudio(chunk);
         _toneDetector.ProcessAudio(chunk);
+        _mdc.ProcessAudio(chunk);
         AppendPreRoll(chunk);
     }
 

--- a/server/OpenScanner.Server/Devices/MockRadioSource.cs
+++ b/server/OpenScanner.Server/Devices/MockRadioSource.cs
@@ -1,116 +1,97 @@
-using System.Diagnostics;
 using OpenScanner.Server.Interfaces;
 using OpenScanner.Server.Models;
 using OpenScanner.Server.Services;
 
 namespace OpenScanner.Server.Devices;
 
+/// <summary>
+/// A hardware-free radio source that replays a list of <see cref="ScenarioEvent"/>s
+/// as if they were live transmissions. Used both to demo the app without an
+/// RTL-SDR dongle and to back the device tests.
+///
+/// Timing is driven entirely through an injected <see cref="TimeProvider"/> and
+/// audio through an injected <see cref="IMockAudioProvider"/>, so tests can run
+/// on a <c>FakeTimeProvider</c> with synthetic audio for fast, deterministic
+/// results, while the running app uses the system clock and real file playback.
+/// </summary>
 public class MockRadioSource : BackgroundService, IRadioSource
 {
+    // Loop keeps running this long past the last event before restarting the scenario.
+    private const double LoopTailSeconds = 10;
+    private const double FreqMatchTolerance = 0.001;
+
     private readonly ILogger<MockRadioSource> _logger;
-    private readonly IDatabase _db;
-    private readonly GpsService _gps;
     private readonly ToneDetector _toneDetector;
-    private readonly IDecoderFactory _decoderFactory;
-    private readonly ITranscriptionService _transcriptionService;
     private readonly IRecordingService _recordingService;
     private readonly IChannelService _channelService;
+    private readonly IMockAudioProvider _audioProvider;
+    private readonly TimeProvider _timeProvider;
 
     public event Action<ScannerState>? OnStateChanged;
     public event Action<CallLog>? OnNewLog;
     public event Action<byte[]>? OnAudio;
 
-    private ScannerState _state = new ScannerState("IDLE", 0);
+    private ScannerState _state = new("IDLE", 0);
     private List<ScenarioEvent> _scenarioEvents = new();
-    private DateTime _startTime;
+    private readonly Dictionary<double, DateTimeOffset> _avoidUntil = new();
+
+    private DateTimeOffset _startTime;
     private bool _isRunning;
     private bool _manualOverride;
+    private ScenarioEvent? _lockedEvent; // the event we have already locked onto / streamed
     private CancellationTokenSource? _currentTaskCts;
+    private Task? _simulationTask;
 
-    // Audio buffering
+    // Number of times the loop has parked on a timer. Lets tests deterministically
+    // wait for the loop to reach a known-quiescent point before advancing the clock.
+    private int _parkCount;
+
+    // Audio pre-roll buffer (rolling window of recent audio).
     private readonly LinkedList<byte[]> _preRollBuffer = new();
-    private const int PreRollMaxBytes = 96000 * 2; 
+    private const int PreRollMaxBytes = 96000 * 2;
 
     public MockRadioSource(
         ILogger<MockRadioSource> logger,
-        IDatabase db,
-        GpsService gps,
         ToneDetector toneDetector,
-        IDecoderFactory decoderFactory,
-        ITranscriptionService transcriptionService,
         IRecordingService recordingService,
-        IChannelService channelService)
+        IChannelService channelService,
+        IMockAudioProvider audioProvider,
+        TimeProvider timeProvider)
     {
         _logger = logger;
-        _db = db;
-        _gps = gps;
         _toneDetector = toneDetector;
-        _decoderFactory = decoderFactory;
-        _transcriptionService = transcriptionService;
         _recordingService = recordingService;
         _channelService = channelService;
+        _audioProvider = audioProvider;
+        _timeProvider = timeProvider;
 
-        _state = new ScannerState("IDLE", 0);
+        _recordingService.OnNewLog += log => OnNewLog?.Invoke(log);
 
-        _recordingService.OnNewLog += (log) => OnNewLog?.Invoke(log);
-        
-        // Try to load default scenario
-        var scenarioPath = Path.Combine(AppContext.BaseDirectory, "TestData", "scenario.json");
-        
-        if (File.Exists(scenarioPath))
-        {
-             try 
-             {
-                 var json = File.ReadAllText(scenarioPath);
-                 var options = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-                 
-                 // Try array first
-                 try 
-                 {
-                     var events = System.Text.Json.JsonSerializer.Deserialize<List<ScenarioEvent>>(json, options);
-                     if (events != null) _scenarioEvents = events;
-                 }
-                 catch (System.Text.Json.JsonException)
-                 {
-                     // Try object wrapper
-                     var wrapper = System.Text.Json.JsonSerializer.Deserialize<ScenarioWrapper>(json, options);
-                     if (wrapper?.Events != null) _scenarioEvents = wrapper.Events;
-                 }
-             }
-             catch (Exception ex)
-             {
-                 _logger.LogWarning(ex, "Failed to load default scenario");
-             }
-        }
+        LoadDefaultScenario();
     }
 
-    public void SetScenario(List<ScenarioEvent> events)
-    {
-        _scenarioEvents = events;
-    }
+    /// <summary>Number of times the simulation loop has parked waiting for time to pass.</summary>
+    public int ParkCount => Volatile.Read(ref _parkCount);
+
+    public void SetScenario(List<ScenarioEvent> events) => _scenarioEvents = events;
 
     public ScannerState GetState() => _state;
 
-    public void ReloadChannels()
-    {
-        _channelService.ReloadChannels();
-    }
+    public void ReloadChannels() => _channelService.ReloadChannels();
 
-    public void SetSquelch(double db)
-    {
-        UpdateState(_state with { Squelch = db });
-    }
+    public void SetSquelch(double db) => UpdateState(_state with { Squelch = db });
 
     public void Start()
     {
         if (_isRunning) return;
         _isRunning = true;
-        _startTime = DateTime.UtcNow;
+        _startTime = _timeProvider.GetUtcNow();
         _manualOverride = false;
+        _lockedEvent = null;
         UpdateState(_state with { Status = "SCANNING", IsHardwareConnected = true });
-        
+
         _currentTaskCts = new CancellationTokenSource();
-        Task.Run(() => SimulationLoop(_currentTaskCts.Token));
+        _simulationTask = Task.Run(() => SimulationLoop(_currentTaskCts.Token));
     }
 
     public void Stop()
@@ -120,15 +101,28 @@ public class MockRadioSource : BackgroundService, IRadioSource
         UpdateState(_state with { Status = "IDLE", IsHardwareConnected = true });
     }
 
+    /// <summary>Cancels the simulation loop and awaits its completion. Intended for shutdown/tests.</summary>
+    public async Task StopAsync()
+    {
+        Stop();
+        if (_simulationTask != null)
+        {
+            try { await _simulationTask; }
+            catch (OperationCanceledException) { }
+        }
+    }
+
     public void HoldFrequency(double freq)
     {
         _manualOverride = true;
+        _lockedEvent = null;
         UpdateState(_state with { ManualHoldFrequency = freq, Status = "MONITORING", CurrentFrequency = freq });
     }
 
     public void ResumeScan()
     {
         _manualOverride = false;
+        _lockedEvent = null;
         UpdateState(_state with { Status = "SCANNING", ManualHoldFrequency = null });
     }
 
@@ -139,18 +133,50 @@ public class MockRadioSource : BackgroundService, IRadioSource
 
     public void AvoidFrequency(double freq, double durationSeconds)
     {
-        _logger.LogInformation($"Mock: Avoiding {freq} for {durationSeconds}s");
+        _avoidUntil[freq] = _timeProvider.GetUtcNow().AddSeconds(durationSeconds);
+        _logger.LogInformation("Mock: Avoiding {Frequency} for {Duration}s", freq, durationSeconds);
     }
 
     public void StartDumping(string label) { }
     public void StopDumping() { }
-    public byte[][] GetPreRollBuffer() => Array.Empty<byte[]>();
 
-    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    public byte[][] GetPreRollBuffer()
     {
-        // Auto-start the mock simulation on startup
+        lock (_preRollBuffer)
+        {
+            return _preRollBuffer.ToArray();
+        }
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        // Auto-start the simulation when hosted by the app.
         Start();
-        await Task.CompletedTask;
+        return Task.CompletedTask;
+    }
+
+    /// <summary>Total length of the scenario (end time of its last event), or 0 if empty.</summary>
+    internal double ScenarioLength =>
+        _scenarioEvents.Count > 0 ? _scenarioEvents.Max(e => e.Time + e.Duration) : 0;
+
+    /// <summary>
+    /// Pure lookup: the event active at <paramref name="elapsedSeconds"/> into the
+    /// scenario, or null. No timing, threading, or side effects — directly unit-testable.
+    /// </summary>
+    internal ScenarioEvent? GetActiveEvent(double elapsedSeconds) =>
+        _scenarioEvents.FirstOrDefault(e =>
+            elapsedSeconds >= e.Time && elapsedSeconds < e.Time + e.Duration);
+
+    /// <summary>Whether <paramref name="freq"/> is currently within an active avoid window.</summary>
+    internal bool IsAvoided(double freq)
+    {
+        var now = _timeProvider.GetUtcNow();
+        foreach (var (avoidFreq, until) in _avoidUntil)
+        {
+            if (Math.Abs(avoidFreq - freq) < FreqMatchTolerance && until > now)
+                return true;
+        }
+        return false;
     }
 
     private async Task SimulationLoop(CancellationToken token)
@@ -159,221 +185,171 @@ public class MockRadioSource : BackgroundService, IRadioSource
         {
             while (!token.IsCancellationRequested && _isRunning)
             {
-                var elapsed = (DateTime.UtcNow - _startTime).TotalSeconds;
+                var elapsed = (_timeProvider.GetUtcNow() - _startTime).TotalSeconds;
 
-                // Loop scenario if we passed the end (max time + 10s buffer)
-                var maxTime = _scenarioEvents.Any() ? _scenarioEvents.Max(e => e.Time + e.Duration) : 0;
-                if (maxTime > 0 && elapsed > maxTime + 10)
+                // Loop the scenario once we've run past the end (plus a tail).
+                if (ScenarioLength > 0 && elapsed > ScenarioLength + LoopTailSeconds)
                 {
-                    _startTime = DateTime.UtcNow;
-                    _logger.LogInformation("[MockRadioSource] Scenario loop resetting...");
+                    _startTime = _timeProvider.GetUtcNow();
+                    _lockedEvent = null;
+                    _logger.LogInformation("[MockRadioSource] Scenario loop resetting.");
                     elapsed = 0;
                 }
 
-                // Find active event
-                var activeEvent = _scenarioEvents.FirstOrDefault(e => 
-                    elapsed >= e.Time && elapsed < (e.Time + e.Duration));
+                var active = GetActiveEvent(elapsed);
+                var canHear = active != null && CanHear(active);
 
-                if (activeEvent != null)
+                if (canHear)
                 {
-                    // Check if we should hear it
-                    bool canHear = false;
-                    if (_manualOverride)
-                    {
-                        if (Math.Abs((_state.ManualHoldFrequency ?? 0) - activeEvent.Frequency) < 0.001) canHear = true;
-                    }
-                    else
-                    {
-                        // In scanning mode, we "stop" on it
-                        canHear = true;
-                    }
-
-                    if (canHear)
-                    {
-                        if (_state.Status != "RECEIVING" && _state.Status != "MONITORING")
-                        {
-                            // Lock onto it
-                            var channel = _channelService.Channels.FirstOrDefault(c => Math.Abs(c.Frequency - activeEvent.Frequency) < 0.001);
-                            
-                            // Check if avoided
-                            if (channel != null && channel.Avoid && !_manualOverride)
-                            {
-                                canHear = false;
-                            }
-                            else
-                            {
-                                if (channel == null)
-                                {
-                                    // Mock channel if not found
-                                    channel = new Channel(activeEvent.Frequency, "Mock", "Mock Channel", activeEvent.DecoderType ?? "FM", "FM");
-                                }
-
-                                UpdateState(_state with { 
-                                    Status = _manualOverride ? "MONITORING" : "RECEIVING",
-                                    CurrentFrequency = activeEvent.Frequency,
-                                    CurrentChannel = channel,
-                                    SourceID = activeEvent.SourceId,
-                                    TargetID = activeEvent.TargetId
-                                });
-                                
-                                // Start recording via service
-                                if (!_recordingService.IsRecording)
-                                {
-                                    _recordingService.StartRecording(channel, activeEvent.SourceId, activeEvent.TargetId, _preRollBuffer);
-                                }
-                            }
-                        }
-
-                        if (canHear)
-                        {
-                            // Simulate Audio
-                            if (!string.IsNullOrEmpty(activeEvent.AudioFile))
-                            {
-                                try
-                                {
-                                    await PlayAudioFile(activeEvent, token);
-                                }
-                                catch (ObjectDisposedException)
-                                {
-                                    // Normal during shutdown
-                                    break;
-                                }
-                            }
-                            else
-                            {
-                                _logger.LogWarning($"[MockRadioSource] Event active but AudioFile is null/empty. Check scenario JSON mapping. Frequency: {activeEvent.Frequency}");
-                                // Generate silence or noise
-                                await Task.Delay(100, token);
-                            }
-                        }
-                    }
-                    else
-                    {
-                        if (!_manualOverride && _state.Status == "RECEIVING")
-                        {
-                            // Lost signal
-                             UpdateState(_state with { Status = "SCANNING", CurrentChannel = null });
-                             if (_state.CurrentChannel != null) _recordingService.StopRecording(_state.CurrentChannel, null);
-                        }
-                    }
+                    await ReceiveAsync(active!, token);
                 }
                 else
                 {
-                    // No active event
-                    if (!_manualOverride && _state.Status == "RECEIVING")
-                    {
-                        UpdateState(_state with { Status = "SCANNING", CurrentChannel = null });
-                        if (_state.CurrentChannel != null) _recordingService.StopRecording(_state.CurrentChannel, null);
-                    }
+                    LoseSignalIfReceiving();
                 }
 
-                await Task.Delay(100, token);
+                await DelayUntilNextBoundary(elapsed, active, token);
             }
         }
         catch (OperationCanceledException) { }
+        catch (ObjectDisposedException) { /* normal during shutdown */ }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Simulation loop error");
+            _logger.LogError(ex, "[MockRadioSource] Simulation loop error");
         }
     }
 
-    private async Task PlayAudioFile(ScenarioEvent evt, CancellationToken token)
+    private bool CanHear(ScenarioEvent evt)
     {
-        string filename = evt.AudioFile!;
-        
-        // Robust path resolution - prioritize AppContext.BaseDirectory
-        var path = Path.Combine(AppContext.BaseDirectory, "TestData", filename);
-        
-        // Fallback for development/legacy support if needed, but primary should be enough with CopyToOutputDirectory
-        if (!File.Exists(path))
+        if (_manualOverride)
         {
-            path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", filename);
+            // In manual hold we only hear the frequency we're parked on.
+            return Math.Abs((_state.ManualHoldFrequency ?? 0) - evt.Frequency) < FreqMatchTolerance;
         }
-        
-        // Final fallback: try filename directly
-        if (!File.Exists(path) && File.Exists(filename)) path = filename;
 
-        if (File.Exists(path))
+        // While scanning, a temporarily-avoided or channel-avoided frequency is skipped.
+        if (IsAvoided(evt.Frequency)) return false;
+
+        var channel = FindChannel(evt.Frequency);
+        return channel is not { Avoid: true };
+    }
+
+    private async Task ReceiveAsync(ScenarioEvent evt, CancellationToken token)
+    {
+        // Lock on the first time we hear this event instance.
+        if (!ReferenceEquals(_lockedEvent, evt))
         {
-            _logger.LogInformation($"[MockRadioSource] SUCCESS: Playing audio file from: {path} (Decoder: {evt.DecoderType ?? "None"})");
+            _lockedEvent = evt;
+            var channel = FindChannel(evt.Frequency)
+                ?? new Channel(evt.Frequency, "Mock", "Mock Channel", evt.DecoderType ?? "FM", "FM");
 
-            if (token.IsCancellationRequested) return;
-
-            if (evt.DecoderType?.ToUpper() == "P25")
+            UpdateState(_state with
             {
-                // Use Real Decoder
-                IDecoder decoder;
-                try
-                {
-                    decoder = _decoderFactory.GetDecoder("P25");
-                }
-                catch (ObjectDisposedException)
-                {
-                    return; // Shutdown
-                }
-                
-                // Use ffmpeg with -re (read at native rate) to simulate real-time input.
-                // This prevents the decoder from running too fast and flooding the client.
-                decoder.InputSource = $"/usr/bin/ffmpeg -re -i \"{path}\" -f s16le -ar 48000 -ac 1 -loglevel quiet -";
-                
-                // Hook up events
-                Action<byte[]> audioHandler = (chunk) => 
-                {
-                    OnAudio?.Invoke(chunk);
-                    _recordingService.ProcessAudio(chunk);
-                    _toneDetector.ProcessAudio(chunk);
-                };
-                
-                decoder.OnAudio += audioHandler;
+                Status = _manualOverride ? "MONITORING" : "RECEIVING",
+                CurrentFrequency = evt.Frequency,
+                CurrentChannel = channel,
+                SourceID = evt.SourceId,
+                TargetID = evt.TargetId
+            });
 
-                try 
-                {
-                    // Create dummy channel for decoder context
-                    var dummyChannel = new Channel { Frequency = evt.Frequency };
-                    await decoder.StartAsync(dummyChannel, token);
-                }
-                finally
-                {
-                    decoder.OnAudio -= audioHandler;
-                    decoder.Stop();
-                }
-            }
-            else
+            if (!_recordingService.IsRecording)
             {
-                // Direct Playback (Simulated/Demodulated Audio)
-                // For real fidelity, we should respect sample rate.
-                // Assuming 48k 16bit mono for now as per system standard.
-                var buffer = new byte[3200]; // ~33ms
-                using var fs = File.OpenRead(path);
-                // Skip header if wav
-                if (path.EndsWith(".wav") && fs.Length > 44) fs.Position = 44;
-
-                int bytesRead;
-                long totalBytes = 0;
-                while ((bytesRead = await fs.ReadAsync(buffer, 0, buffer.Length, token)) > 0)
-                {
-                    totalBytes += bytesRead;
-                    // Log every ~100 chunks to avoid spam, but confirm activity
-                    if (totalBytes % (3200 * 50) == 0) 
-                    {
-                        _logger.LogInformation($"[MockRadioSource] Streaming audio... Total: {totalBytes} bytes");
-                    }
-
-                    var chunk = new byte[bytesRead];
-                    Array.Copy(buffer, chunk, bytesRead);
-                    
-                    OnAudio?.Invoke(chunk);
-                    _recordingService.ProcessAudio(chunk);
-                    _toneDetector.ProcessAudio(chunk);
-                    
-                    // Throttle
-                    await Task.Delay(33, token);
-                }
+                ClearPreRoll();
+                _recordingService.StartRecording(channel, evt.SourceId, evt.TargetId, _preRollBuffer);
             }
+
+            await _audioProvider.StreamAsync(evt, HandleAudioChunk, token);
+        }
+    }
+
+    private void LoseSignalIfReceiving()
+    {
+        if (_lockedEvent == null) return;
+
+        var channel = _state.CurrentChannel;
+        _lockedEvent = null;
+        _recordingService.StopRecording(channel!, null);
+
+        if (!_manualOverride)
+        {
+            // Back to scanning; manual hold stays parked on its frequency.
+            UpdateState(_state with { Status = "SCANNING", CurrentChannel = null });
+        }
+    }
+
+    /// <summary>
+    /// Delays until the next scenario transition (current event's end, or the next
+    /// event's start, or the loop reset point). Precise scheduling means transitions
+    /// land exactly instead of being quantized to a poll interval.
+    /// </summary>
+    private async Task DelayUntilNextBoundary(double elapsed, ScenarioEvent? active, CancellationToken token)
+    {
+        double next;
+        if (active != null)
+        {
+            next = active.Time + active.Duration; // wait out the current event
         }
         else
         {
-            _logger.LogWarning($"Audio file not found: {filename}. Checked: {path}");
+            double? nextStart = null;
+            foreach (var e in _scenarioEvents)
+            {
+                if (e.Time > elapsed && (nextStart == null || e.Time < nextStart))
+                    nextStart = e.Time;
+            }
+            next = nextStart ?? (ScenarioLength > 0 ? ScenarioLength + LoopTailSeconds : elapsed + LoopTailSeconds);
+        }
+
+        var waitSeconds = Math.Max(next - elapsed, 0.001);
+        await ParkAsync(TimeSpan.FromSeconds(waitSeconds), token);
+    }
+
+    /// <summary>
+    /// Waits <paramref name="delay"/> of (possibly virtual) time. The timer is
+    /// registered before <see cref="_parkCount"/> is bumped, so once a test observes
+    /// the incremented count it knows the timer exists and it's safe to advance the clock.
+    /// </summary>
+    private async Task ParkAsync(TimeSpan delay, CancellationToken token)
+    {
+        var tcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var timer = _timeProvider.CreateTimer(_ => tcs.TrySetResult(), null, delay, Timeout.InfiniteTimeSpan);
+        using var registration = token.Register(() => tcs.TrySetResult());
+
+        Interlocked.Increment(ref _parkCount);
+        await tcs.Task;
+        token.ThrowIfCancellationRequested();
+    }
+
+    private void HandleAudioChunk(byte[] chunk)
+    {
+        OnAudio?.Invoke(chunk);
+        _recordingService.ProcessAudio(chunk);
+        _toneDetector.ProcessAudio(chunk);
+        AppendPreRoll(chunk);
+    }
+
+    private Channel? FindChannel(double frequency) =>
+        _channelService.Channels.FirstOrDefault(c => Math.Abs(c.Frequency - frequency) < FreqMatchTolerance);
+
+    private void AppendPreRoll(byte[] chunk)
+    {
+        lock (_preRollBuffer)
+        {
+            _preRollBuffer.AddLast(chunk);
+            var total = _preRollBuffer.Sum(b => b.Length);
+            while (total > PreRollMaxBytes && _preRollBuffer.First != null)
+            {
+                total -= _preRollBuffer.First.Value.Length;
+                _preRollBuffer.RemoveFirst();
+            }
+        }
+    }
+
+    private void ClearPreRoll()
+    {
+        lock (_preRollBuffer)
+        {
+            _preRollBuffer.Clear();
         }
     }
 
@@ -381,6 +357,33 @@ public class MockRadioSource : BackgroundService, IRadioSource
     {
         _state = newState;
         OnStateChanged?.Invoke(_state);
+    }
+
+    private void LoadDefaultScenario()
+    {
+        var scenarioPath = Path.Combine(AppContext.BaseDirectory, "TestData", "scenario.json");
+        if (!File.Exists(scenarioPath)) return;
+
+        try
+        {
+            var json = File.ReadAllText(scenarioPath);
+            var options = new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true };
+
+            try
+            {
+                var events = System.Text.Json.JsonSerializer.Deserialize<List<ScenarioEvent>>(json, options);
+                if (events != null) _scenarioEvents = events;
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                var wrapper = System.Text.Json.JsonSerializer.Deserialize<ScenarioWrapper>(json, options);
+                if (wrapper?.Events != null) _scenarioEvents = wrapper.Events;
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load default scenario");
+        }
     }
 
     private class ScenarioWrapper

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -202,7 +202,7 @@ public class RtlDevice : BackgroundService, IRadioSource
         await Task.Delay(250, token);
 
         int sampleRate = 2400000; 
-        var binPath = "/usr/bin/rtl_sdr";
+        var binPath = PlatformTools.RtlSdr;
         var args = $"-f {freq}M -s {sampleRate} -g {gain} -b 1 -";
 
         _logger.LogInformation($"Debug Spectrum HW: {binPath} {args}");
@@ -548,7 +548,7 @@ public class RtlDevice : BackgroundService, IRadioSource
         // Start rtl_sdr wideband capture and distribute IQ to all pipelines
         await Task.Delay(250, token); // USB settle time
 
-        var binPath = "/usr/bin/rtl_sdr";
+        var binPath = PlatformTools.RtlSdr;
         var args = $"-f {bank.CenterFrequency:F3}M -s {sampleRate} -g 20 -b 1 -";
         _logger.LogInformation($"Parallel Scanner: {binPath} {args}");
 
@@ -867,7 +867,7 @@ public class RtlDevice : BackgroundService, IRadioSource
 
         // Standard stable sample rate for R820T tuner
         int scanRate = 1024000; 
-        var binPath = "/usr/bin/rtl_sdr";
+        var binPath = PlatformTools.RtlSdr;
         // -b 1: Use 1 buffer to reduce latency and improve startup reliability
         var args = $"-f {centerFreqMhz:F3}M -s {scanRate} -g 20 -b 1 -";
 

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -336,10 +336,16 @@ public class RtlDevice : BackgroundService, IRadioSource
     {
         var dataDir = Path.Combine(Directory.GetCurrentDirectory(), "../../data/samples");
         if (!Directory.Exists(dataDir)) Directory.CreateDirectory(dataDir);
-        
-        _iqDumpPath = Path.Combine(dataDir, $"{label}_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.iq");
+
+        // Sanitize the user-supplied label to a safe filename token: this strips path
+        // separators and "." so it cannot traverse directories (path injection) and
+        // removes control characters/newlines that could forge log entries.
+        var safeLabel = System.Text.RegularExpressions.Regex.Replace(label ?? "", "[^A-Za-z0-9_-]", "_");
+        if (safeLabel.Length == 0) safeLabel = "dump";
+
+        _iqDumpPath = Path.Combine(dataDir, $"{safeLabel}_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.iq");
         _iqDumpStream = new FileStream(_iqDumpPath, FileMode.Create);
-        _logger.LogInformation($"Started IQ dumping to {_iqDumpPath}");
+        _logger.LogInformation("Started IQ dumping to {Path}", _iqDumpPath);
     }
 
     /// <inheritdoc />

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -343,7 +343,10 @@ public class RtlDevice : BackgroundService, IRadioSource
         var safeLabel = System.Text.RegularExpressions.Regex.Replace(label ?? "", "[^A-Za-z0-9_-]", "_");
         if (safeLabel.Length == 0) safeLabel = "dump";
 
-        _iqDumpPath = Path.Combine(dataDir, $"{safeLabel}_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.iq");
+        // Path.GetFileName strips any residual directory component, guaranteeing the
+        // result stays inside dataDir.
+        var fileName = Path.GetFileName($"{safeLabel}_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.iq");
+        _iqDumpPath = Path.Combine(dataDir, fileName);
         _iqDumpStream = new FileStream(_iqDumpPath, FileMode.Create);
         _logger.LogInformation("Started IQ dumping to {Path}", _iqDumpPath);
     }

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -17,6 +17,7 @@ public class RtlDevice : BackgroundService, IRadioSource
     private readonly ILogger<RtlDevice> _logger;
     private readonly GpsService _gps;
     private readonly ToneDetector _toneDetector;
+    private readonly Mdc1200Decoder _mdc;
     private readonly IDecoderFactory _decoderFactory;
     private readonly ITranscriptionService _transcriptionService;
     private readonly IRecordingService _recordingService;
@@ -30,6 +31,9 @@ public class RtlDevice : BackgroundService, IRadioSource
     
     /// <inheritdoc />
     public event Action<byte[]>? OnAudio;
+
+    /// <inheritdoc />
+    public event Action<RadioEvent>? OnNewEvent;
 
     private ScannerState _state = new ScannerState("IDLE", 0);
     private bool _manualOverride = false;
@@ -69,9 +73,10 @@ public class RtlDevice : BackgroundService, IRadioSource
     public RtlDevice(
         IDatabase db, 
         ILogger<RtlDevice> logger, 
-        GpsService gps, 
-        ToneDetector toneDetector, 
-        IDecoderFactory decoderFactory, 
+        GpsService gps,
+        ToneDetector toneDetector,
+        Mdc1200Decoder mdc,
+        IDecoderFactory decoderFactory,
         ITranscriptionService transcriptionService, 
         IRecordingService recordingService,
         IChannelService channelService)
@@ -80,6 +85,7 @@ public class RtlDevice : BackgroundService, IRadioSource
         _logger = logger;
         _gps = gps;
         _toneDetector = toneDetector;
+        _mdc = mdc;
         _decoderFactory = decoderFactory;
         _transcriptionService = transcriptionService;
         _recordingService = recordingService;
@@ -95,6 +101,21 @@ public class RtlDevice : BackgroundService, IRadioSource
         _toneDetector.OnToneDetected += (tone) => {
             _lastDetectedTone = tone.Name;
             UpdateState(_state with { LastDetectedTone = tone.Name });
+            RaiseRadioEvent(new RadioEvent
+            {
+                Type = "TONE_OUT",
+                Label = tone.Name,
+                ToneA = tone.FrequencyA,
+                ToneB = tone.FrequencyB
+            });
+        };
+
+        _mdc.OnPacket += (pkt) => {
+            // Treat the MDC1200 unit ID like a P25 radio ID: attribute it to the current
+            // transmission via the normal activity path so it lands on the recording's
+            // SourceID, rather than logging a separate signaling event.
+            if (_state.CurrentChannel != null)
+                HandleActivity(_state.CurrentChannel, src: pkt.UnitId, tone: pkt.IsEmergency ? "EMRG" : null);
         };
 
         _recordingService.OnNewLog += (log) => {
@@ -363,6 +384,24 @@ public class RtlDevice : BackgroundService, IRadioSource
     {
         _state = newState;
         OnStateChanged?.Invoke(_state);
+    }
+
+    /// <summary>
+    /// Stamps the current channel context onto a detected signaling event, persists it,
+    /// and broadcasts it to clients. Fire-and-forget persistence mirrors the recording path.
+    /// </summary>
+    private void RaiseRadioEvent(RadioEvent e)
+    {
+        e.Id = Guid.NewGuid().ToString();
+        e.Timestamp = DateTime.UtcNow.ToString("o");
+        e.Frequency = _state.CurrentChannel?.Frequency ?? _state.CurrentFrequency ?? 0;
+        e.AlphaTag = _state.CurrentChannel?.AlphaTag;
+
+        _db.AddRadioEventAsync(e).ContinueWith(
+            t => _logger.LogError(t.Exception, "Failed to persist radio event"),
+            TaskContinuationOptions.OnlyOnFaulted);
+
+        OnNewEvent?.Invoke(e);
     }
 
     private void StopScanning()
@@ -733,6 +772,7 @@ public class RtlDevice : BackgroundService, IRadioSource
     private void HandleParallelAudio(Channel channel, byte[] audio)
     {
         _toneDetector.ProcessAudio(audio);
+        _mdc.ProcessAudio(audio);
 
         // Convert mono s16le to stereo s16le with per-channel panning
         var (leftGain, rightGain) = _parallelPanMap.GetValueOrDefault(channel.Frequency, (0.5, 0.5));
@@ -1306,8 +1346,10 @@ public class RtlDevice : BackgroundService, IRadioSource
         if (_state.CurrentChannel != null)
         {
             _recordingService.StopRecording(_state.CurrentChannel, _lastDetectedTone);
+            // Clear the detected tone so it doesn't bleed onto the next transmission.
+            _lastDetectedTone = null;
         }
-        
+
         if (_currentDecoder != null)
         {
             _currentDecoder.Stop();
@@ -1351,8 +1393,9 @@ public class RtlDevice : BackgroundService, IRadioSource
                     }
                 }
 
-                // Analyze for Fire Tone Outs
+                // Analyze for Fire Tone Outs and MDC1200 signaling
                 _toneDetector.ProcessAudio(chunk);
+                _mdc.ProcessAudio(chunk);
                 OnAudio?.Invoke(chunk);
 
                 _recordingService.ProcessAudio(chunk);
@@ -1408,6 +1451,8 @@ public class RtlDevice : BackgroundService, IRadioSource
                 if (_state.CurrentChannel != null)
                 {
                     _recordingService.StopRecording(_state.CurrentChannel, _lastDetectedTone);
+                    // Clear the detected tone so it doesn't bleed onto the next transmission.
+                    _lastDetectedTone = null;
                 }
 
                 if (_manualOverride) UpdateState(_state with { Status = "MONITORING" });

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -334,7 +334,7 @@ public class RtlDevice : BackgroundService, IRadioSource
     /// <inheritdoc />
     public void StartDumping(string label)
     {
-        var dataDir = Path.Combine(Directory.GetCurrentDirectory(), "../../data/samples");
+        var dataDir = Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../../data/samples"));
         if (!Directory.Exists(dataDir)) Directory.CreateDirectory(dataDir);
 
         // Sanitize the user-supplied label to a safe filename token: this strips path
@@ -343,11 +343,16 @@ public class RtlDevice : BackgroundService, IRadioSource
         var safeLabel = System.Text.RegularExpressions.Regex.Replace(label ?? "", "[^A-Za-z0-9_-]", "_");
         if (safeLabel.Length == 0) safeLabel = "dump";
 
-        // Path.GetFileName strips any residual directory component, guaranteeing the
-        // result stays inside dataDir.
         var fileName = Path.GetFileName($"{safeLabel}_{DateTimeOffset.UtcNow.ToUnixTimeSeconds()}.iq");
-        _iqDumpPath = Path.Combine(dataDir, fileName);
-        _iqDumpStream = new FileStream(_iqDumpPath, FileMode.Create);
+        var fullPath = Path.GetFullPath(Path.Combine(dataDir, fileName));
+
+        // Canonicalize and verify the resolved path stays inside the samples directory,
+        // so a crafted label can never escape it (path-injection barrier).
+        if (!fullPath.StartsWith(dataDir + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+            throw new InvalidOperationException("Invalid IQ dump path");
+
+        _iqDumpPath = fullPath;
+        _iqDumpStream = new FileStream(fullPath, FileMode.Create);
         _logger.LogInformation("Started IQ dumping to {Path}", _iqDumpPath);
     }
 

--- a/server/OpenScanner.Server/Devices/SyntheticAudioProvider.cs
+++ b/server/OpenScanner.Server/Devices/SyntheticAudioProvider.cs
@@ -1,0 +1,48 @@
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Devices;
+
+/// <summary>
+/// Produces deterministic synthetic PCM audio for a scenario event with no file
+/// I/O and no external processes, making it safe and repeatable for tests. The
+/// chunk count is a pure function of <see cref="ScenarioEvent.Duration"/>, and
+/// all chunks are emitted synchronously so tests can assert on them immediately
+/// after an event is detected (no clock advancing required to pump audio).
+/// </summary>
+public class SyntheticAudioProvider : IMockAudioProvider
+{
+    private const int SampleRate = 48000;
+    private const int ChunkBytes = 3200;                       // ~33 ms, s16le mono
+    private const int SamplesPerChunk = ChunkBytes / 2;
+    private const double ChunkSeconds = SamplesPerChunk / (double)SampleRate;
+    private const double ToneHz = 440.0;
+    private const short Amplitude = 8000;
+
+    public Task StreamAsync(ScenarioEvent evt, Action<byte[]> onChunk, CancellationToken token)
+    {
+        var duration = evt.Duration > 0 ? evt.Duration : ChunkSeconds;
+        var chunkCount = Math.Max(1, (int)Math.Round(duration / ChunkSeconds));
+
+        double phase = 0;
+        double phaseStep = 2 * Math.PI * ToneHz / SampleRate;
+
+        for (var i = 0; i < chunkCount; i++)
+        {
+            token.ThrowIfCancellationRequested();
+
+            var chunk = new byte[ChunkBytes];
+            for (var s = 0; s < SamplesPerChunk; s++)
+            {
+                var sample = (short)(Math.Sin(phase) * Amplitude);
+                phase += phaseStep;
+                chunk[s * 2] = (byte)(sample & 0xFF);
+                chunk[s * 2 + 1] = (byte)((sample >> 8) & 0xFF);
+            }
+
+            onChunk(chunk);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/server/OpenScanner.Server/Interfaces/IDatabase.cs
+++ b/server/OpenScanner.Server/Interfaces/IDatabase.cs
@@ -166,6 +166,25 @@ public interface IDatabase
     /// <param name="id">The ID of the tone set to delete.</param>
     Task DeleteFireToneAsync(int id);
 
+    // Radio Events (fire tone-out and MDC1200 detections)
+
+    /// <summary>
+    /// Persists a decoded signaling event (fire tone-out or MDC1200 packet).
+    /// </summary>
+    /// <param name="e">The event to store.</param>
+    Task AddRadioEventAsync(RadioEvent e);
+
+    /// <summary>
+    /// Retrieves the most recent radio events, newest first.
+    /// </summary>
+    /// <param name="limit">Maximum number of events to return.</param>
+    Task<IEnumerable<RadioEvent>> GetRadioEventsAsync(int limit = 100);
+
+    /// <summary>
+    /// Clears all stored radio events.
+    /// </summary>
+    Task ClearRadioEventsAsync();
+
     // Settings
 
     /// <summary>

--- a/server/OpenScanner.Server/Interfaces/IMockAudioProvider.cs
+++ b/server/OpenScanner.Server/Interfaces/IMockAudioProvider.cs
@@ -1,0 +1,19 @@
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Interfaces;
+
+/// <summary>
+/// Supplies the audio for a <see cref="ScenarioEvent"/> played back by
+/// <c>MockRadioSource</c>. Abstracting this out lets the running app stream
+/// real recorded audio (files / ffmpeg) while tests inject deterministic,
+/// dependency-free synthetic audio.
+/// </summary>
+public interface IMockAudioProvider
+{
+    /// <summary>
+    /// Streams the audio for <paramref name="evt"/>, invoking
+    /// <paramref name="onChunk"/> for each PCM chunk (48 kHz s16le mono).
+    /// Implementations may pace playback in real time or emit synchronously.
+    /// </summary>
+    Task StreamAsync(ScenarioEvent evt, Action<byte[]> onChunk, CancellationToken token);
+}

--- a/server/OpenScanner.Server/Interfaces/IRadioSource.cs
+++ b/server/OpenScanner.Server/Interfaces/IRadioSource.cs
@@ -23,6 +23,11 @@ public interface IRadioSource
     event Action<byte[]>? OnAudio;
 
     /// <summary>
+    /// Event triggered when a signaling event (fire tone-out or MDC1200) is detected.
+    /// </summary>
+    event Action<RadioEvent>? OnNewEvent;
+
+    /// <summary>
     /// Gets the current state of the scanner.
     /// </summary>
     /// <returns>The current <see cref="ScannerState"/>.</returns>

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -245,6 +245,64 @@ public class FireToneSet
 }
 
 /// <summary>
+/// A decoded signaling event surfaced to the event log — either a fire tone-out
+/// (two-tone / Quick Call II) detection or an MDC1200 data packet.
+/// </summary>
+public class RadioEvent
+{
+    /// <summary>Unique identifier for the event.</summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>Timestamp of the detection (ISO 8601).</summary>
+    public string Timestamp { get; set; } = string.Empty;
+
+    /// <summary>Event discriminator: "TONE_OUT", "MDC_PTT", or "MDC_EMERGENCY".</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Human-friendly label (tone set name, or MDC unit/op description).</summary>
+    public string Label { get; set; } = string.Empty;
+
+    /// <summary>Frequency the event was detected on, in MHz.</summary>
+    public double Frequency { get; set; }
+
+    /// <summary>Channel alpha tag at the time of detection, if known.</summary>
+    public string? AlphaTag { get; set; }
+
+    /// <summary>Fire tone-out Tone A frequency in Hz (TONE_OUT only).</summary>
+    public double? ToneA { get; set; }
+
+    /// <summary>Fire tone-out Tone B frequency in Hz (TONE_OUT only).</summary>
+    public double? ToneB { get; set; }
+
+    /// <summary>MDC1200 unit (radio) ID (MDC_* only).</summary>
+    public int? UnitId { get; set; }
+
+    /// <summary>Id of the transmission recording this event coincided with, if any.</summary>
+    public string? TransmissionId { get; set; }
+}
+
+/// <summary>
+/// A decoded MDC1200 data packet.
+/// </summary>
+public class Mdc1200Packet
+{
+    /// <summary>16-bit unit (radio) ID.</summary>
+    public int UnitId { get; set; }
+
+    /// <summary>MDC opcode.</summary>
+    public int Op { get; set; }
+
+    /// <summary>MDC argument byte.</summary>
+    public int Arg { get; set; }
+
+    /// <summary>True when the packet represents an emergency.</summary>
+    public bool IsEmergency { get; set; }
+
+    /// <summary>Human-friendly description of the op/arg.</summary>
+    public string Description { get; set; } = string.Empty;
+}
+
+/// <summary>
 /// GPS Telemetry data.
 /// </summary>
 public record GpsData(

--- a/server/OpenScanner.Server/PlatformTools.cs
+++ b/server/OpenScanner.Server/PlatformTools.cs
@@ -1,0 +1,87 @@
+namespace OpenScanner.Server;
+
+/// <summary>
+/// Resolves paths to external command-line tools (rtl_sdr, rtl_fm, ffmpeg,
+/// dsd-fme, stdbuf) in a cross-platform way so OpenScanner can run on Linux
+/// (Raspberry Pi) and macOS without hardcoded absolute paths.
+///
+/// Resolution order for each tool: the current PATH, then a list of well-known
+/// install directories (Homebrew on Apple Silicon / Intel, then the standard
+/// Linux locations). If the tool cannot be found, the bare name is returned so
+/// the OS can still resolve it at exec time and produce a clear error.
+/// </summary>
+public static class PlatformTools
+{
+    // Directories checked in addition to PATH. Homebrew first (macOS), then the
+    // historical Linux install locations.
+    private static readonly string[] WellKnownDirs =
+    {
+        "/opt/homebrew/bin", // Homebrew, Apple Silicon
+        "/usr/local/bin",    // Homebrew (Intel) / source builds (dsd-fme)
+        "/usr/bin",
+        "/bin",
+    };
+
+    private static readonly Dictionary<string, string> _cache = new();
+    private static readonly object _lock = new();
+
+    /// <summary>
+    /// Returns an absolute path to <paramref name="tool"/> if found on PATH or
+    /// in a well-known directory; otherwise returns <paramref name="tool"/>
+    /// unchanged so it resolves via PATH at process-start time.
+    /// </summary>
+    public static string Resolve(string tool)
+    {
+        lock (_lock)
+        {
+            if (_cache.TryGetValue(tool, out var cached)) return cached;
+
+            var resolved = FindOnDisk(tool) ?? tool;
+            _cache[tool] = resolved;
+            return resolved;
+        }
+    }
+
+    private static string? FindOnDisk(string tool)
+    {
+        var pathDirs = (Environment.GetEnvironmentVariable("PATH") ?? string.Empty)
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+        foreach (var dir in pathDirs.Concat(WellKnownDirs))
+        {
+            var candidate = Path.Combine(dir, tool);
+            if (File.Exists(candidate)) return candidate;
+        }
+        return null;
+    }
+
+    public static string RtlSdr => Resolve("rtl_sdr");
+    public static string RtlFm => Resolve("rtl_fm");
+    public static string Ffmpeg => Resolve("ffmpeg");
+    public static string DsdFme => Resolve("dsd-fme");
+
+    /// <summary>
+    /// Returns a <c>stdbuf &lt;args&gt; </c> command prefix (with trailing
+    /// space) for tuning pipe buffering, or an empty string when stdbuf is not
+    /// available. macOS has no stdbuf by default; <c>gstdbuf</c> (Homebrew
+    /// coreutils) is used when present.
+    /// </summary>
+    public static string Stdbuf(string args)
+    {
+        var bin = StdbufBin;
+        return bin == null ? string.Empty : $"{bin} {args} ";
+    }
+
+    private static string? StdbufBin
+    {
+        get
+        {
+            foreach (var name in new[] { "stdbuf", "gstdbuf" })
+            {
+                var path = FindOnDisk(name);
+                if (path != null) return path;
+            }
+            return null;
+        }
+    }
+}

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -34,6 +34,7 @@ builder.Services.AddSingleton<IDatabase, Database>();
 builder.Services.AddSingleton<GpsService>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<GpsService>());
 builder.Services.AddSingleton<ToneDetector>();
+builder.Services.AddSingleton<Mdc1200Decoder>();
 
 builder.Services.AddTransient<OpenScanner.Server.Decoders.P25>();
 builder.Services.AddTransient<OpenScanner.Server.Decoders.DMR>();

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -29,6 +29,7 @@ var memoryLoggerProvider = new MemoryLoggerProvider();
 builder.Logging.AddProvider(memoryLoggerProvider);
 builder.Services.AddSingleton<ILoggerProvider>(memoryLoggerProvider);
 
+builder.Services.AddSingleton(TimeProvider.System);
 builder.Services.AddSingleton<IDatabase, Database>();
 builder.Services.AddSingleton<GpsService>();
 builder.Services.AddHostedService(sp => sp.GetRequiredService<GpsService>());
@@ -47,6 +48,7 @@ builder.Services.AddSingleton<IChannelService, ChannelService>();
 var radioProvider = builder.Configuration["Radio:Provider"] ?? "RTL-SDR";
 if (radioProvider == "Mock")
 {
+    builder.Services.AddSingleton<IMockAudioProvider, FileAudioProvider>();
     builder.Services.AddSingleton<IRadioSource, MockRadioSource>();
     builder.Services.AddHostedService(sp => (MockRadioSource)sp.GetRequiredService<IRadioSource>());
 }

--- a/server/OpenScanner.Server/Services/Mdc1200Decoder.cs
+++ b/server/OpenScanner.Server/Services/Mdc1200Decoder.cs
@@ -1,0 +1,259 @@
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Services;
+
+/// <summary>
+/// Native MDC1200 (Motorola Data Communications) decoder. Consumes mono 16-bit
+/// PCM audio and recovers 1200-baud MSK data bursts (PTT ID, emergency, etc.).
+///
+/// This is an independent implementation written from the public MDC1200 protocol
+/// facts (sync word, CRC-16-CCITT, 7x16 interleave, 112-bit frame) — it is not a
+/// port of any GPL-licensed source, so it stays compatible with this project's
+/// MIT license.
+///
+/// The demodulator samples the sign of the audio at the 1200-baud bit clock across
+/// several timing phases (the XOR-precoded MSK burst is designed so the polarity at
+/// bit centres reproduces the on-air bit stream), searches for the sync word, then
+/// collects, de-interleaves and CRC-checks the frame.
+/// </summary>
+public class Mdc1200Decoder
+{
+    private readonly ILogger<Mdc1200Decoder> _logger;
+
+    // Number of parallel bit-timing hypotheses. More phases = more robust bit-clock
+    // recovery at the cost of CPU. The reference decoders use a similar small bank.
+    private const int PhaseCount = 6;
+
+    // Sync word: high byte 0x07 followed by the 32-bit low word 0x092a446f (40 bits total).
+    private const uint SyncHigh = 0x07;
+    private const uint SyncLow = 0x092a446f;
+
+    // Maximum Hamming distance from the 40-bit sync word to accept a match.
+    private const int SyncThreshold = 5;
+
+    // 32-bit phase accumulator increment per input sample for a 1200 Hz bit clock at 48 kHz.
+    // The accumulator wraps once per bit period (2^32 / Incr48k == 40 samples == 48000/1200).
+    private const uint Incr48k = 107374182;
+
+    private readonly uint _increment;
+    private readonly PhaseSlot[] _slots = new PhaseSlot[PhaseCount];
+
+    /// <summary>Raised when a valid MDC1200 frame is decoded (CRC verified).</summary>
+    public event Action<Mdc1200Packet>? OnPacket;
+
+    public Mdc1200Decoder(ILogger<Mdc1200Decoder> logger, int sampleRate = 48000)
+    {
+        _logger = logger;
+        _increment = sampleRate == 48000
+            ? Incr48k
+            : (uint)(1200L * 2 * (0x80000000L / sampleRate));
+
+        for (int i = 0; i < PhaseCount; i++)
+        {
+            _slots[i] = new PhaseSlot
+            {
+                // Stagger the initial phase of each slot so their bit instants fall at
+                // different points relative to the incoming symbol timing.
+                Accumulator = (uint)(i * (0x80000000L / PhaseCount) * 2),
+                State = SlotState.Hunting
+            };
+        }
+    }
+
+    /// <summary>
+    /// Processes a chunk of mono 16-bit little-endian PCM audio.
+    /// </summary>
+    public void ProcessAudio(byte[] pcmData)
+    {
+        int sampleCount = pcmData.Length / 2;
+        for (int i = 0; i < sampleCount; i++)
+        {
+            short sample = (short)(pcmData[i * 2] | (pcmData[i * 2 + 1] << 8));
+            AdvanceSample(sample);
+        }
+    }
+
+    private void AdvanceSample(short sample)
+    {
+        bool positive = sample > 0;
+
+        foreach (var slot in _slots)
+        {
+            uint previous = slot.Accumulator;
+            slot.Accumulator += _increment;
+            // Wrap of the phase accumulator marks a bit-sampling instant.
+            if (slot.Accumulator >= previous)
+                continue;
+
+            bool bit = positive;
+            if (slot.Inverted)
+                bit = !bit;
+
+            ShiftBit(slot, bit);
+        }
+    }
+
+    private void ShiftBit(PhaseSlot slot, bool bit)
+    {
+        switch (slot.State)
+        {
+            case SlotState.Hunting:
+                // Roll the incoming bit into the 40-bit sync register (8 high + 32 low).
+                slot.SyncHigh = ((slot.SyncHigh << 1) | (slot.SyncLow >> 31)) & 0xFF;
+                slot.SyncLow = (slot.SyncLow << 1) | (bit ? 1u : 0u);
+
+                int distance = PopCount((SyncHigh ^ slot.SyncHigh) & 0xFF)
+                             + PopCount(SyncLow ^ slot.SyncLow);
+
+                if (distance <= SyncThreshold)
+                {
+                    BeginCollecting(slot);
+                }
+                else if (distance >= 40 - SyncThreshold)
+                {
+                    // Matched the inverted sync word: the stream polarity is flipped.
+                    slot.Inverted = !slot.Inverted;
+                    BeginCollecting(slot);
+                }
+                break;
+
+            case SlotState.Collecting:
+                slot.Bits[slot.BitCount++] = bit;
+                if (slot.BitCount >= 112)
+                {
+                    TryDecodeFrame(slot);
+                    slot.State = SlotState.Hunting;
+                }
+                break;
+        }
+    }
+
+    private static void BeginCollecting(PhaseSlot slot)
+    {
+        slot.State = SlotState.Collecting;
+        slot.BitCount = 0;
+    }
+
+    private void TryDecodeFrame(PhaseSlot slot)
+    {
+        // De-interleave the 112 collected bits (7 rows x 16 columns) into 14 bytes.
+        var linear = new bool[112];
+        int idx = 0;
+        for (int col = 0; col < 16; col++)
+        {
+            for (int row = 0; row < 7; row++)
+            {
+                linear[idx++] = slot.Bits[row * 16 + col];
+            }
+        }
+
+        var data = new byte[14];
+        for (int b = 0; b < 14; b++)
+        {
+            byte value = 0;
+            for (int bitPos = 0; bitPos < 8; bitPos++)
+            {
+                if (linear[b * 8 + bitPos])
+                    value |= (byte)(1 << bitPos);
+            }
+            data[b] = value;
+        }
+
+        ushort computed = Crc(data, 4);
+        ushort received = (ushort)(data[4] | (data[5] << 8));
+        if (computed != received)
+            return;
+
+        int op = data[0];
+        int arg = data[1];
+        int unitId = (data[2] << 8) | data[3];
+
+        var packet = BuildPacket(op, arg, unitId);
+        _logger.LogInformation(
+            "MDC1200 decoded: unit={UnitId:X4} op={Op:X2} arg={Arg:X2} ({Desc})",
+            unitId, op, arg, packet.Description);
+        OnPacket?.Invoke(packet);
+    }
+
+    /// <summary>
+    /// Maps a decoded op/arg to a friendly description. MDC opcode meanings vary by
+    /// fleet; only widely-documented ones are named, the rest fall back to raw hex.
+    /// </summary>
+    private static Mdc1200Packet BuildPacket(int op, int arg, int unitId)
+    {
+        bool emergency = op == 0x00 && arg == 0x03;
+        string description = (op, arg) switch
+        {
+            (0x01, _) => "PTT ID",
+            (0x00, 0x03) => "Emergency",
+            (0x22, _) => "Radio Check",
+            (0x03, _) => "Message",
+            (0x12, _) => "Status Request",
+            _ => $"MDC op={op:X2} arg={arg:X2}"
+        };
+
+        return new Mdc1200Packet
+        {
+            UnitId = unitId,
+            Op = op,
+            Arg = arg,
+            IsEmergency = emergency,
+            Description = description
+        };
+    }
+
+    /// <summary>
+    /// CRC-16-CCITT as used by MDC1200: input bytes bit-reflected, polynomial 0x1021,
+    /// initial value 0x0000, result reflected and inverted.
+    /// </summary>
+    internal static ushort Crc(byte[] data, int length)
+    {
+        ushort crc = 0x0000;
+        for (int i = 0; i < length; i++)
+        {
+            ushort c = Reflect(data[i], 8);
+            for (int mask = 0x80; mask != 0; mask >>= 1)
+            {
+                bool bit = (crc & 0x8000) != 0;
+                crc <<= 1;
+                if ((c & mask) != 0)
+                    bit = !bit;
+                if (bit)
+                    crc ^= 0x1021;
+            }
+        }
+        crc = Reflect(crc, 16);
+        crc ^= 0xFFFF;
+        return crc;
+    }
+
+    private static ushort Reflect(ushort value, int bits)
+    {
+        ushort result = 0;
+        for (int i = 0; i < bits; i++)
+        {
+            if ((value & (1 << i)) != 0)
+                result |= (ushort)(1 << (bits - 1 - i));
+        }
+        return result;
+    }
+
+    private static int PopCount(uint value) => System.Numerics.BitOperations.PopCount(value);
+
+    private enum SlotState
+    {
+        Hunting,
+        Collecting
+    }
+
+    private sealed class PhaseSlot
+    {
+        public uint Accumulator;
+        public bool Inverted;
+        public SlotState State;
+        public uint SyncHigh;
+        public uint SyncLow;
+        public int BitCount;
+        public readonly bool[] Bits = new bool[112];
+    }
+}

--- a/server/OpenScanner.Server/Services/RecordingService.cs
+++ b/server/OpenScanner.Server/Services/RecordingService.cs
@@ -170,7 +170,7 @@ public class RecordingService : IRecordingService
                  var wavPath = Path.ChangeExtension(recordingPath, ".wav");
                  try 
                  {
-                     var convertStart = new ProcessStartInfo("/usr/bin/ffmpeg")
+                     var convertStart = new ProcessStartInfo(PlatformTools.Ffmpeg)
                      {
                          RedirectStandardOutput = true,
                          RedirectStandardError = true,
@@ -418,7 +418,7 @@ public class RecordingService : IRecordingService
             var wavPath = Path.ChangeExtension(recordingPath, ".wav");
             try
             {
-                var convertStart = new ProcessStartInfo("/usr/bin/ffmpeg")
+                var convertStart = new ProcessStartInfo(PlatformTools.Ffmpeg)
                 {
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,

--- a/server/OpenScanner.Server/Services/ToneDetector.cs
+++ b/server/OpenScanner.Server/Services/ToneDetector.cs
@@ -14,10 +14,29 @@ public class ToneDetector
     private List<FireToneSet> _activeToneSets = new();
     private readonly int _sampleRate = 48000;
     
-    // Detection state
+    // Two-tone (Quick Call II) detection state
     private string? _detectedToneAName;
     private DateTime _toneADetectedTime = DateTime.MinValue;
     private double _lastToneAFreq;
+
+    // Single (long) tone detection state, keyed by tone set name. Some agencies page
+    // with a single sustained tone instead of a two-tone A/B sequence; a FireToneSet
+    // with FrequencyB <= 0 is treated as single-tone.
+    private readonly Dictionary<string, SingleToneRun> _singleToneRuns = new();
+
+    // A single tone must be continuously present for at least this long before it fires,
+    // which rejects the brief tones that occur in speech.
+    private const double SingleToneMinDurationSeconds = 1.0;
+
+    // Momentary dropouts shorter than this don't reset a sustained-tone run.
+    private const double SingleToneGapToleranceSeconds = 0.3;
+
+    private struct SingleToneRun
+    {
+        public DateTime Start;
+        public DateTime LastSeen;
+        public bool Fired;
+    }
 
     /// <summary>
     /// Event triggered when a complete 2-tone sequence is detected.
@@ -69,11 +88,20 @@ public class ToneDetector
             samples[i] = s / 32768f;
         }
 
+        var now = DateTime.UtcNow;
+
         // Check for active tones in this chunk
         // Standard FTO: Tone A (approx 1s) followed by Tone B (approx 3s)
-        
+
         foreach (var toneSet in _activeToneSets)
         {
+            // A tone set with no second frequency is a single (long) tone page.
+            if (toneSet.FrequencyB <= 0)
+            {
+                HandleSingleTone(toneSet, samples, now);
+                continue;
+            }
+
             // check Tone A
             bool toneAPresent = IsFrequencyPresent(samples, toneSet.FrequencyA);
             
@@ -105,6 +133,45 @@ public class ToneDetector
         if (_detectedToneAName != null && (DateTime.UtcNow - _toneADetectedTime).TotalSeconds > 3.0)
         {
             _detectedToneAName = null;
+        }
+    }
+
+    /// <summary>
+    /// Detects a single sustained tone. Fires once FrequencyA has been continuously
+    /// present for <see cref="SingleToneMinDurationSeconds"/>, then stays quiet until
+    /// the tone drops out so a long page only fires a single event.
+    /// </summary>
+    private void HandleSingleTone(FireToneSet toneSet, float[] samples, DateTime now)
+    {
+        bool present = IsFrequencyPresent(samples, toneSet.FrequencyA);
+
+        if (present)
+        {
+            if (!_singleToneRuns.TryGetValue(toneSet.Name, out var run) ||
+                (now - run.LastSeen).TotalSeconds > SingleToneGapToleranceSeconds)
+            {
+                // No active run (or the previous one lapsed): start a fresh one.
+                run = new SingleToneRun { Start = now, LastSeen = now, Fired = false };
+            }
+            else
+            {
+                run.LastSeen = now;
+            }
+
+            if (!run.Fired && (now - run.Start).TotalSeconds >= SingleToneMinDurationSeconds)
+            {
+                _logger.LogInformation($"ToneDetector: DETECTED single-tone {toneSet.Name} ({toneSet.FrequencyA} Hz)");
+                OnToneDetected?.Invoke(toneSet);
+                run.Fired = true;
+            }
+
+            _singleToneRuns[toneSet.Name] = run;
+        }
+        else if (_singleToneRuns.TryGetValue(toneSet.Name, out var run) &&
+                 (now - run.LastSeen).TotalSeconds > SingleToneGapToleranceSeconds)
+        {
+            // Tone has been absent long enough — end the run so it can re-fire later.
+            _singleToneRuns.Remove(toneSet.Name);
         }
     }
 

--- a/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
+++ b/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
@@ -41,6 +41,7 @@ public class WebSocketBroadcaster
         _logger = logger;
         _radio.OnStateChanged += BroadcastState;
         _radio.OnNewLog += BroadcastLog;
+        _radio.OnNewEvent += BroadcastEvent;
         _radio.OnAudio += BroadcastAudio;
     }
 
@@ -169,6 +170,12 @@ public class WebSocketBroadcaster
     private void BroadcastLog(CallLog log)
     {
         var msg = new { type = "NEW_LOG", payload = log };
+        _ = BroadcastJson(msg);
+    }
+
+    private void BroadcastEvent(RadioEvent e)
+    {
+        var msg = new { type = "NEW_EVENT", payload = e };
         _ = BroadcastJson(msg);
     }
 

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -242,7 +242,7 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
             return null;
         }
 
-        var convertStart = new ProcessStartInfo("/usr/bin/ffmpeg")
+        var convertStart = new ProcessStartInfo(PlatformTools.Ffmpeg)
         {
             RedirectStandardOutput = true,
             RedirectStandardError = true,

--- a/server/OpenScanner.Tests/Controllers/EventsControllerTests.cs
+++ b/server/OpenScanner.Tests/Controllers/EventsControllerTests.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using OpenScanner.Server.Controllers;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+using Xunit;
+
+namespace OpenScanner.Tests.Controllers;
+
+public class EventsControllerTests
+{
+    private readonly Mock<IDatabase> _dbMock = new();
+    private readonly EventsController _controller;
+
+    public EventsControllerTests()
+    {
+        _controller = new EventsController(_dbMock.Object);
+    }
+
+    [Fact]
+    public async Task GetEvents_ReturnsEvents()
+    {
+        var events = new List<RadioEvent>
+        {
+            new() { Id = "1", Type = "TONE_OUT", Label = "Station 1" },
+            new() { Id = "2", Type = "MDC_PTT", Label = "PTT ID", UnitId = 0x1234 },
+        };
+        _dbMock.Setup(db => db.GetRadioEventsAsync(100)).ReturnsAsync(events);
+
+        var result = await _controller.GetEvents();
+
+        Assert.Equal(2, result.Count());
+    }
+
+    [Fact]
+    public async Task ClearEvents_ClearsAndReturnsOk()
+    {
+        var result = await _controller.ClearEvents() as OkResult;
+
+        Assert.NotNull(result);
+        _dbMock.Verify(db => db.ClearRadioEventsAsync(), Times.Once);
+    }
+}

--- a/server/OpenScanner.Tests/Controllers/FiretonesControllerTests.cs
+++ b/server/OpenScanner.Tests/Controllers/FiretonesControllerTests.cs
@@ -1,8 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using Moq;
 using OpenScanner.Server.Controllers;
 using OpenScanner.Server.Interfaces;
 using OpenScanner.Server.Models;
+using OpenScanner.Server.Services;
 using Xunit;
 
 namespace OpenScanner.Tests.Controllers;
@@ -10,12 +12,15 @@ namespace OpenScanner.Tests.Controllers;
 public class FiretonesControllerTests
 {
     private readonly Mock<IDatabase> _dbMock;
+    private readonly ToneDetector _toneDetector;
     private readonly FiretonesController _controller;
 
     public FiretonesControllerTests()
     {
         _dbMock = new Mock<IDatabase>();
-        _controller = new FiretonesController(_dbMock.Object);
+        _dbMock.Setup(db => db.GetAllFireTonesAsync()).ReturnsAsync(Array.Empty<FireToneSet>());
+        _toneDetector = new ToneDetector(_dbMock.Object, new Mock<ILogger<ToneDetector>>().Object);
+        _controller = new FiretonesController(_dbMock.Object, _toneDetector);
     }
 
     [Fact]
@@ -70,5 +75,32 @@ public class FiretonesControllerTests
         // Assert
         Assert.NotNull(result);
         _dbMock.Verify(db => db.DeleteFireToneAsync(2), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddFireTone_ReloadsDetector()
+    {
+        // The detector loads tones once in its constructor; a successful add must
+        // trigger a reload so the running detector picks up the new tone set.
+        _dbMock.Setup(db => db.AddFireToneAsync(It.IsAny<FireToneSet>())).ReturnsAsync(1);
+
+        await _controller.AddFireTone(new FireToneSet { Name = "New Station" });
+
+        // ReloadTones fetches the tone list again (fire-and-forget); poll for it.
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                _dbMock.Verify(db => db.GetAllFireTonesAsync(), Times.AtLeast(2));
+                return;
+            }
+            catch (MockException)
+            {
+                await Task.Delay(20);
+            }
+        }
+
+        _dbMock.Verify(db => db.GetAllFireTonesAsync(), Times.AtLeast(2));
     }
 }

--- a/server/OpenScanner.Tests/Controllers/ScannerControllerTests.cs
+++ b/server/OpenScanner.Tests/Controllers/ScannerControllerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 using OpenScanner.Server.Controllers;
@@ -18,7 +19,13 @@ public class ScannerControllerTests
     {
         _dbMock = new Mock<IDatabase>();
         _radioMock = new Mock<IRadioSource>();
-        _controller = new ScannerController(_dbMock.Object, _radioMock.Object);
+        _controller = new ScannerController(_dbMock.Object, _radioMock.Object)
+        {
+            ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext()
+            }
+        };
     }
 
     [Fact]
@@ -79,6 +86,139 @@ public class ScannerControllerTests
         _dbMock.Verify(db => db.DeleteChannelAsync(5), Times.Once);
         _radioMock.Verify(r => r.ReloadChannels(), Times.Once);
     }
+
+    // --- REST endpoints ---
+
+    [Fact]
+    public void GetStatus_ReturnsRadioState()
+    {
+        var state = new ScannerState("SCANNING", -50);
+        _radioMock.Setup(r => r.GetState()).Returns(state);
+
+        var result = _controller.GetStatus();
+
+        Assert.Equal("SCANNING", result.Status);
+    }
+
+    [Fact]
+    public void SetPower_Enabled_CallsStart()
+    {
+        var result = _controller.SetPower(new PowerRequest(true)) as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.Start(), Times.Once);
+        _radioMock.Verify(r => r.Stop(), Times.Never);
+    }
+
+    [Fact]
+    public void SetPower_Disabled_CallsStop()
+    {
+        var result = _controller.SetPower(new PowerRequest(false)) as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.Stop(), Times.Once);
+        _radioMock.Verify(r => r.Start(), Times.Never);
+    }
+
+    [Fact]
+    public async Task Hold_HoldsFrequency()
+    {
+        _dbMock.Setup(db => db.GetAllChannelsAsync()).ReturnsAsync(new List<Channel>());
+
+        var result = await _controller.Hold(new HoldRequest(155.5)) as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.HoldFrequency(155.5), Times.Once);
+    }
+
+    [Fact]
+    public async Task Hold_UnAvoidsMatchingChannel()
+    {
+        var channel = new Channel { Id = 1, Frequency = 155.5, Avoid = true };
+        _dbMock.Setup(db => db.GetAllChannelsAsync()).ReturnsAsync(new List<Channel> { channel });
+
+        var result = await _controller.Hold(new HoldRequest(155.5)) as OkResult;
+
+        Assert.NotNull(result);
+        _dbMock.Verify(db => db.UpdateChannelAsync(It.Is<Channel>(c => c.Id == 1 && !c.Avoid)), Times.Once);
+        _radioMock.Verify(r => r.ReloadChannels(), Times.Once);
+        _radioMock.Verify(r => r.HoldFrequency(155.5), Times.Once);
+    }
+
+    [Fact]
+    public void ReleaseHold_ResumesScan()
+    {
+        var result = _controller.ReleaseHold() as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.ResumeScan(), Times.Once);
+    }
+
+    [Fact]
+    public void SetSquelch_CallsRadioSetSquelch()
+    {
+        var result = _controller.SetSquelch(new SquelchRequest(-40)) as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.SetSquelch(-40), Times.Once);
+    }
+
+    [Fact]
+    public void AddAvoid_CallsRadioAvoidFrequency()
+    {
+        var result = _controller.AddAvoid(new AvoidRequest(155.5, 15)) as AcceptedResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.AvoidFrequency(155.5, 15), Times.Once);
+    }
+
+    [Fact]
+    public void AddAvoid_DefaultsDurationTo10()
+    {
+        var result = _controller.AddAvoid(new AvoidRequest(155.5)) as AcceptedResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.AvoidFrequency(155.5, 10), Times.Once);
+    }
+
+    [Fact]
+    public void StartIqDump_UsesProvidedLabel()
+    {
+        var result = _controller.StartIqDump(new IqDumpRequest("test")) as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.StartDumping("test"), Times.Once);
+    }
+
+    [Fact]
+    public void StartIqDump_DefaultsLabelWhenMissing()
+    {
+        var result = _controller.StartIqDump(null) as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.StartDumping("sample"), Times.Once);
+    }
+
+    [Fact]
+    public void StopIqDump_CallsRadioStopDump()
+    {
+        var result = _controller.StopIqDump() as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.StopDumping(), Times.Once);
+    }
+
+    [Fact]
+    public void StartDebugSpectrum_CallsRadioStartDebugSpectrum()
+    {
+        var result = _controller.StartDebugSpectrum(new DebugSpectrumRequest(162.400, 30)) as OkResult;
+
+        Assert.NotNull(result);
+        _radioMock.Verify(r => r.StartDebugSpectrum(162.400, 30), Times.Once);
+    }
+
+    // --- Legacy /api/control shim (deprecated) ---
+#pragma warning disable CS0618 // Intentionally testing the deprecated shim
 
     [Fact]
     public async Task ControlScanner_Start_CallsRadioStart()
@@ -169,4 +309,5 @@ public class ScannerControllerTests
         Assert.NotNull(result);
         Assert.Equal("Action is required", result.Value);
     }
+#pragma warning restore CS0618
 }

--- a/server/OpenScanner.Tests/Decoders/DecoderFactoryTests.cs
+++ b/server/OpenScanner.Tests/Decoders/DecoderFactoryTests.cs
@@ -1,0 +1,61 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenScanner.Server.Decoders;
+using OpenScanner.Server.Interfaces;
+using Xunit;
+
+namespace OpenScanner.Tests;
+
+public class DecoderFactoryTests
+{
+    private readonly IDecoderFactory _factory;
+
+    public DecoderFactoryTests()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(b => b.SetMinimumLevel(LogLevel.Critical));
+        services.AddTransient<P25>();
+        services.AddTransient<DMR>();
+        services.AddTransient<NFM>();
+        services.AddTransient<AM>();
+        services.AddTransient<WFM>();
+        services.AddSingleton<IDecoderFactory, DecoderFactory>();
+        _factory = services.BuildServiceProvider().GetRequiredService<IDecoderFactory>();
+    }
+
+    [Theory]
+    [InlineData("P25", typeof(P25))]
+    [InlineData("DMR", typeof(DMR))]
+    [InlineData("NFM", typeof(NFM))]
+    [InlineData("FM", typeof(NFM))]   // FM aliases to NFM
+    [InlineData("AM", typeof(AM))]
+    [InlineData("WFM", typeof(WFM))]
+    public void GetDecoder_MapsModeToType(string mode, Type expected)
+    {
+        Assert.IsType(expected, _factory.GetDecoder(mode));
+    }
+
+    [Theory]
+    [InlineData("p25", typeof(P25))]
+    [InlineData("am", typeof(AM))]
+    public void GetDecoder_IsCaseInsensitive(string mode, Type expected)
+    {
+        Assert.IsType(expected, _factory.GetDecoder(mode));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("something-unknown")]
+    public void GetDecoder_UnknownOrNull_DefaultsToNfm(string? mode)
+    {
+        Assert.IsType<NFM>(_factory.GetDecoder(mode));
+    }
+
+    [Fact]
+    public void GetDecoder_ReturnsFreshTransientInstances()
+    {
+        // Decoders are registered transient, so each request is a new instance.
+        Assert.NotSame(_factory.GetDecoder("NFM"), _factory.GetDecoder("NFM"));
+    }
+}

--- a/server/OpenScanner.Tests/Devices/AudioProviderTests.cs
+++ b/server/OpenScanner.Tests/Devices/AudioProviderTests.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using OpenScanner.Server.Devices;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+using Xunit;
+
+namespace OpenScanner.Tests;
+
+public class SyntheticAudioProviderTests
+{
+    private readonly SyntheticAudioProvider _provider = new();
+
+    // ChunkSeconds = (3200 bytes / 2 bytes-per-sample) / 48000 Hz = 1/30 s.
+    // So the deterministic chunk count is round(duration * 30).
+    [Theory]
+    [InlineData(1.0, 30)]
+    [InlineData(2.0, 60)]
+    [InlineData(4.8, 144)]
+    [InlineData(0.0, 1)]   // zero/negative duration still yields one chunk
+    public async Task StreamAsync_EmitsDeterministicChunkCount(double duration, int expected)
+    {
+        var chunks = 0;
+        await _provider.StreamAsync(
+            new ScenarioEvent { Duration = duration, Frequency = 155.0 },
+            _ => chunks++,
+            CancellationToken.None);
+
+        Assert.Equal(expected, chunks);
+    }
+
+    [Fact]
+    public async Task StreamAsync_ProducesFullSizeChunks()
+    {
+        var sizes = new List<int>();
+        await _provider.StreamAsync(
+            new ScenarioEvent { Duration = 1.0 },
+            c => sizes.Add(c.Length),
+            CancellationToken.None);
+
+        Assert.NotEmpty(sizes);
+        Assert.All(sizes, s => Assert.Equal(3200, s));
+    }
+
+    [Fact]
+    public async Task StreamAsync_IsBytewiseDeterministic()
+    {
+        var first = new List<byte[]>();
+        var second = new List<byte[]>();
+        var evt = new ScenarioEvent { Duration = 0.5 };
+
+        await _provider.StreamAsync(evt, first.Add, CancellationToken.None);
+        await _provider.StreamAsync(evt, second.Add, CancellationToken.None);
+
+        Assert.Equal(first.Count, second.Count);
+        for (var i = 0; i < first.Count; i++)
+            Assert.Equal(first[i], second[i]);
+    }
+
+    [Fact]
+    public async Task StreamAsync_CancelledToken_ThrowsAndEmitsNothing()
+    {
+        var chunks = 0;
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            _provider.StreamAsync(new ScenarioEvent { Duration = 2.0 }, _ => chunks++, cts.Token));
+
+        Assert.Equal(0, chunks);
+    }
+}
+
+public class FileAudioProviderTests
+{
+    private readonly FileAudioProvider _provider;
+    private readonly FakeTimeProvider _time = new();
+
+    public FileAudioProviderTests()
+    {
+        var logger = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Critical))
+            .CreateLogger<FileAudioProvider>();
+        _provider = new FileAudioProvider(logger, new Mock<IDecoderFactory>().Object, _time);
+    }
+
+    [Fact]
+    public async Task StreamAsync_NoAudioFile_EmitsNothing()
+    {
+        var chunks = 0;
+        await _provider.StreamAsync(
+            new ScenarioEvent { AudioFile = null, Frequency = 155.0 },
+            _ => chunks++,
+            CancellationToken.None);
+
+        Assert.Equal(0, chunks);
+    }
+
+    [Fact]
+    public async Task StreamAsync_MissingFile_EmitsNothingAndDoesNotThrow()
+    {
+        var chunks = 0;
+        await _provider.StreamAsync(
+            new ScenarioEvent { AudioFile = "definitely_not_here.wav", Frequency = 155.0, DecoderType = "FM" },
+            _ => chunks++,
+            CancellationToken.None);
+
+        Assert.Equal(0, chunks);
+    }
+
+    [Fact]
+    public async Task StreamAsync_RawWav_StreamsOneChunkPerFrame()
+    {
+        // 3 full 3200-byte frames after the 44-byte WAV header.
+        const int frames = 3;
+        var testDataDir = Path.Combine(AppContext.BaseDirectory, "TestData");
+        Directory.CreateDirectory(testDataDir);
+        var name = $"synthetic_{Guid.NewGuid():N}.wav";
+        var path = Path.Combine(testDataDir, name);
+        await File.WriteAllBytesAsync(path, new byte[44 + frames * 3200]);
+
+        try
+        {
+            var chunks = 0;
+            var evt = new ScenarioEvent { AudioFile = name, Frequency = 155.0, DecoderType = "FM" };
+            var task = _provider.StreamAsync(evt, _ => Interlocked.Increment(ref chunks), CancellationToken.None);
+
+            // Pump the fake clock so the per-frame throttle delays release.
+            var sw = Stopwatch.StartNew();
+            while (!task.IsCompleted && sw.ElapsedMilliseconds < 2000)
+            {
+                _time.Advance(TimeSpan.FromMilliseconds(33));
+                await Task.Delay(2);
+            }
+            await task;
+
+            Assert.Equal(frames, chunks);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+}

--- a/server/OpenScanner.Tests/Devices/MixedScanTests.cs
+++ b/server/OpenScanner.Tests/Devices/MixedScanTests.cs
@@ -31,6 +31,7 @@ public class MixedScanTests
             logger.Object,
             gps.Object,
             toneDetector.Object,
+            new Mdc1200Decoder(new Mock<ILogger<Mdc1200Decoder>>().Object),
             decoderFactory.Object,
             transcription.Object,
             recording.Object,
@@ -190,6 +191,7 @@ public class MixedScanTests
 
         var device = new RtlDevice(
             db.Object, logger.Object, gps.Object, toneDetector.Object,
+            new Mdc1200Decoder(new Mock<ILogger<Mdc1200Decoder>>().Object),
             decoderFactory.Object, transcription.Object, recording.Object, channelService.Object);
 
         // Lock onto the channel — this triggers StartDecoding after a 150ms delay
@@ -250,6 +252,7 @@ public class MixedScanTests
 
         var device = new RtlDevice(
             db.Object, logger.Object, gps.Object, toneDetector.Object,
+            new Mdc1200Decoder(new Mock<ILogger<Mdc1200Decoder>>().Object),
             decoderFactory.Object, transcription.Object, recording.Object, channelService.Object);
 
         device.HoldFrequency(155.0);

--- a/server/OpenScanner.Tests/Devices/MockScenarioTests.cs
+++ b/server/OpenScanner.Tests/Devices/MockScenarioTests.cs
@@ -41,6 +41,8 @@ public class MockScenarioTests
         _source = new MockRadioSource(
             _logger,
             _toneDetectorMock.Object,
+            new Mdc1200Decoder(new Mock<ILogger<Mdc1200Decoder>>().Object),
+            _dbMock.Object,
             _recordingServiceMock.Object,
             _channelServiceMock.Object,
             new SyntheticAudioProvider(),
@@ -183,6 +185,81 @@ public class MockScenarioTests
 
         Assert.Equal("SCANNING", _source.GetState().Status);
         Assert.Equal(0, audioChunks);
+
+        await _source.StopAsync();
+    }
+
+    // --- Edge cases ---
+
+    [Fact]
+    public void GetActiveEvent_OverlappingEvents_ReturnsFirstMatch()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 1, Frequency = 155.0, Duration = 5 },
+            new() { Time = 2, Frequency = 156.0, Duration = 5 }, // overlaps the first
+        });
+
+        Assert.Equal(155.0, _source.GetActiveEvent(3.0)!.Frequency);
+    }
+
+    [Fact]
+    public void ScenarioLength_EmptyScenario_IsZero()
+    {
+        _source.SetScenario(new List<ScenarioEvent>());
+        Assert.Equal(0, _source.ScenarioLength);
+        Assert.Null(_source.GetActiveEvent(0));
+    }
+
+    [Fact]
+    public void IsAvoided_IsTrueWithinWindow_AndExpiresAfterDuration()
+    {
+        _source.AvoidFrequency(155.0, 2);
+
+        Assert.True(_source.IsAvoided(155.0));
+        Assert.False(_source.IsAvoided(156.0)); // only the avoided frequency
+
+        _time.Advance(TimeSpan.FromSeconds(2.5));
+        Assert.False(_source.IsAvoided(155.0)); // window expired
+    }
+
+    [Fact]
+    public async Task ScanMode_AfterAvoidExpires_ReceivesAgain()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 5, Frequency = 155.000, Duration = 3 }
+        });
+
+        await StartAndSettle();
+        _source.AvoidFrequency(155.000, 2); // expires well before the event at t=5
+
+        await AdvanceAndSettle(TimeSpan.FromSeconds(5));
+
+        Assert.Equal("RECEIVING", _source.GetState().Status);
+
+        await _source.StopAsync();
+    }
+
+    [Fact]
+    public async Task ManualHold_AvoidIsIgnored_StillReceives()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 1, Frequency = 155.000, Duration = 3 }
+        });
+
+        var audioChunks = 0;
+        _source.OnAudio += _ => Interlocked.Increment(ref audioChunks);
+
+        await StartAndSettle();
+        _source.HoldFrequency(155.000);
+        _source.AvoidFrequency(155.000, 100); // avoid is a scan-mode concept only
+
+        await AdvanceAndSettle(TimeSpan.FromSeconds(1));
+
+        Assert.Equal("MONITORING", _source.GetState().Status);
+        Assert.True(audioChunks > 0, "manual hold should still receive an avoided frequency");
 
         await _source.StopAsync();
     }

--- a/server/OpenScanner.Tests/Devices/MockScenarioTests.cs
+++ b/server/OpenScanner.Tests/Devices/MockScenarioTests.cs
@@ -1,179 +1,212 @@
-using System.Collections.Concurrent;
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
-using OpenScanner.Server;
 using OpenScanner.Server.Models;
 using OpenScanner.Server.Services;
 using OpenScanner.Server.Interfaces;
 using OpenScanner.Server.Devices;
-using OpenScanner.Server.Decoders;
 using Xunit;
 
 namespace OpenScanner.Tests;
 
+/// <summary>
+/// Deterministic tests for <see cref="MockRadioSource"/>. Simulation time is driven
+/// by a <see cref="FakeTimeProvider"/> and audio by <see cref="SyntheticAudioProvider"/>,
+/// so a multi-second transmission is exercised by advancing the fake clock instantly —
+/// no real waiting, no ffmpeg, no audio files.
+/// </summary>
 public class MockScenarioTests
 {
     private readonly ILogger<MockRadioSource> _logger;
-    private readonly Mock<IDatabase> _dbMock = new();
-    private readonly Mock<GpsService> _gpsServiceMock;
     private readonly Mock<ToneDetector> _toneDetectorMock;
-    private readonly Mock<ITranscriptionService> _transcriptionServiceMock = new();
     private readonly Mock<IRecordingService> _recordingServiceMock = new();
     private readonly Mock<IChannelService> _channelServiceMock = new();
+    private readonly Mock<IDatabase> _dbMock = new();
+    private readonly FakeTimeProvider _time = new();
     private readonly MockRadioSource _source;
 
     public MockScenarioTests()
     {
-        var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
+        var loggerFactory = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Warning));
         _logger = loggerFactory.CreateLogger<MockRadioSource>();
-        
-        _gpsServiceMock = new Mock<GpsService>(new Mock<ILogger<GpsService>>().Object);
         _toneDetectorMock = new Mock<ToneDetector>(_dbMock.Object, new Mock<ILogger<ToneDetector>>().Object);
-        
-        var services = new ServiceCollection();
-        services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug)); 
-        services.AddTransient<P25>();
-        services.AddTransient<NFM>();
-        services.AddTransient<AM>();
-        services.AddTransient<WFM>();
-        services.AddSingleton<IDecoderFactory, DecoderFactory>();
-        var serviceProvider = services.BuildServiceProvider();
-        var decoderFactory = serviceProvider.GetRequiredService<IDecoderFactory>();
 
-        // Setup default channels
-        var channels = new List<Channel>
+        // Default channel used by most tests.
+        _channelServiceMock.Setup(x => x.Channels).Returns(new List<Channel>
         {
-            new Channel(155.000, "Police", "Test Channel", "P25", "RM", "123 NAC", "Law", "TEST1")
-        };
-        _dbMock.Setup(db => db.GetAllChannelsAsync()).ReturnsAsync(channels);
-        _channelServiceMock.Setup(x => x.Channels).Returns(channels);
-        
-        _source = new MockRadioSource(
-            _logger, 
-            _dbMock.Object, 
-            _gpsServiceMock.Object, 
-            _toneDetectorMock.Object, 
-            decoderFactory,
-            _transcriptionServiceMock.Object,
-            _recordingServiceMock.Object,
-            _channelServiceMock.Object);
-    }
-
-    [Fact]
-    public async Task Scenario_DetectsSignal_AndDecodesP25()
-    {
-        // Arrange
-        var events = new List<ScenarioEvent>
-        {
-            new ScenarioEvent
-            {
-                Time = 1, // Start after 1 second
-                Frequency = 155.000,
-                AudioFile = "p25_raw.wav",
-                Duration = 4,
-                SourceId = 101,
-                TargetId = 202,
-                DecoderType = "P25"
-            }
-        };
-        _source.SetScenario(events);
-        
-        var audioReceived = false;
-        
-        _source.OnAudio += (data) => audioReceived = true;
-
-        // Act
-        _source.Start();
-        
-        // Wait for event start (1s) + processing/decoding
-        await Task.Delay(3000); 
-
-        // Assert - Should be receiving
-        var state = _source.GetState();
-        Assert.Equal("RECEIVING", state.Status);
-        Assert.True(audioReceived, "Should have received audio data");
-        
-        _source.Stop();
-    }
-
-    [Fact]
-    public async Task Scenario_DoesNotDetect_WhenOnDifferentHold()
-    {
-        // Arrange
-        var events = new List<ScenarioEvent>
-        {
-            new ScenarioEvent { Time = 0.5, Frequency = 155.000, AudioFile = "test_48k.wav", Duration = 2 }
-        };
-        _source.SetScenario(events);
-        
-        // Mock channel service to find the channel we are holding on
-        _channelServiceMock.Setup(x => x.Channels).Returns(new List<Channel> 
-        { 
-             new Channel(155.000, "Police", "Test Channel", "FM", "FM"),
-             new Channel(156.000, "Marine", "Marine Channel", "FM", "FM")
+            new(155.000, "Police", "Test Channel", "FM", "FM")
         });
-        
-        _source.Start();
-        
-        // Allow service to start and settle in SCANNING
-        await Task.Delay(100); 
-        
-        // Act
-        _source.HoldFrequency(156.000); // Hold on different freq (Status -> MONITORING)
-        
-        // Wait for event time (0.5s)
-        await Task.Delay(1500);
 
-        // Assert
-        var state = _source.GetState();
-        Assert.Equal("MONITORING", state.Status);
-        Assert.Equal(156.000, state.CurrentFrequency); // Should still be on hold freq
-        
-        _source.Stop();
+        _source = new MockRadioSource(
+            _logger,
+            _toneDetectorMock.Object,
+            _recordingServiceMock.Object,
+            _channelServiceMock.Object,
+            new SyntheticAudioProvider(),
+            _time);
+    }
+
+    // --- Pure event-selection logic (no clock, no threads) ---
+
+    [Fact]
+    public void GetActiveEvent_ReturnsEventOnlyWithinItsWindow()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 1, Frequency = 155.0, Duration = 2 },
+            new() { Time = 5, Frequency = 156.0, Duration = 1 },
+        });
+
+        Assert.Null(_source.GetActiveEvent(0.99));
+        Assert.Equal(155.0, _source.GetActiveEvent(1.0)!.Frequency);
+        Assert.Equal(155.0, _source.GetActiveEvent(2.99)!.Frequency);
+        Assert.Null(_source.GetActiveEvent(3.0));           // end is exclusive
+        Assert.Null(_source.GetActiveEvent(4.5));
+        Assert.Equal(156.0, _source.GetActiveEvent(5.0)!.Frequency);
+        Assert.Null(_source.GetActiveEvent(6.0));
     }
 
     [Fact]
-    public async Task Scenario_PlaysGoldenSample_Correctly()
+    public void ScenarioLength_IsEndOfLastEvent()
     {
-        // Arrange
-        var events = new List<ScenarioEvent>
+        _source.SetScenario(new List<ScenarioEvent>
         {
-            new ScenarioEvent
-            {
-                Time = 0.5,
-                Frequency = 155.000,
-                AudioFile = "test_8k.wav",
-                Duration = 4.8,
-                SourceId = 999,
-                TargetId = 888
-            }
-        };
-        _source.SetScenario(events);
-        
-        _channelServiceMock.Setup(x => x.Channels).Returns(new List<Channel> 
-        { 
-             new Channel(155.000, "Police", "Test Channel", "FM", "FM")
+            new() { Time = 1, Frequency = 155.0, Duration = 2 },   // ends at 3
+            new() { Time = 5, Frequency = 156.0, Duration = 4 },   // ends at 9
+        });
+
+        Assert.Equal(9, _source.ScenarioLength);
+    }
+
+    // --- End-to-end simulation, deterministically clocked ---
+
+    [Fact]
+    public async Task ScanMode_DetectsSignal_EmitsAudio_ThenResumesScanning()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 1, Frequency = 155.000, Duration = 4, SourceId = 101, TargetId = 202 }
         });
 
         var audioChunks = 0;
-        _source.OnAudio += (data) => audioChunks++;
+        _source.OnAudio += _ => Interlocked.Increment(ref audioChunks);
 
-        // Act
-        _source.Start();
-        
-        await Task.Delay(100); // Allow start
-        _source.HoldFrequency(155.000); // Lock on immediately
+        await StartAndSettle();
 
-        // Wait for event start time (0.5s) + playback (File is ~4.8s) + buffer
-        await Task.Delay(6000);
+        // Jump to the event: scanner should lock on and stream its audio.
+        await AdvanceAndSettle(TimeSpan.FromSeconds(1));
 
-        // Assert
-        Assert.True(audioChunks > 10, $"Should have received audio chunks (Got {audioChunks})");
-        
+        var state = _source.GetState();
+        Assert.Equal("RECEIVING", state.Status);
+        Assert.Equal(155.000, state.CurrentFrequency);
+        Assert.Equal(101, state.SourceID);
+        Assert.Equal(202, state.TargetID);
+        Assert.True(audioChunks > 0, $"expected audio chunks, got {audioChunks}");
+
+        // Jump past the end: scanner should drop the signal and resume scanning.
+        await AdvanceAndSettle(TimeSpan.FromSeconds(4));
+
+        Assert.Equal("SCANNING", _source.GetState().Status);
+        _recordingServiceMock.Verify(r => r.StopRecording(It.IsAny<Channel>(), It.IsAny<string?>()), Times.Once);
+
+        await _source.StopAsync();
+    }
+
+    [Fact]
+    public async Task ManualHold_OnDifferentFrequency_DoesNotReceive()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 0.5, Frequency = 155.000, Duration = 2 }
+        });
+        _channelServiceMock.Setup(x => x.Channels).Returns(new List<Channel>
+        {
+            new(155.000, "Police", "Test Channel", "FM", "FM"),
+            new(156.000, "Marine", "Marine Channel", "FM", "FM")
+        });
+
+        var audioChunks = 0;
+        _source.OnAudio += _ => Interlocked.Increment(ref audioChunks);
+
+        await StartAndSettle();
+        _source.HoldFrequency(156.000); // Hold on a different frequency.
+
+        await AdvanceAndSettle(TimeSpan.FromSeconds(0.5)); // Event fires on 155.
+
         var state = _source.GetState();
         Assert.Equal("MONITORING", state.Status);
+        Assert.Equal(156.000, state.CurrentFrequency);
+        Assert.Equal(0, audioChunks);
 
-        _source.Stop();
+        await _source.StopAsync();
+    }
+
+    [Fact]
+    public async Task ManualHold_OnMatchingFrequency_ReceivesAndBuffersPreRoll()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 0.5, Frequency = 155.000, Duration = 4.8, SourceId = 999, TargetId = 888 }
+        });
+
+        var audioChunks = 0;
+        _source.OnAudio += _ => Interlocked.Increment(ref audioChunks);
+
+        await StartAndSettle();
+        _source.HoldFrequency(155.000);
+
+        await AdvanceAndSettle(TimeSpan.FromSeconds(0.5));
+
+        Assert.True(audioChunks > 10, $"expected steady audio, got {audioChunks}");
+        Assert.Equal("MONITORING", _source.GetState().Status);
+        Assert.NotEmpty(_source.GetPreRollBuffer());
+
+        await _source.StopAsync();
+    }
+
+    [Fact]
+    public async Task ScanMode_AvoidedFrequency_IsSkipped()
+    {
+        _source.SetScenario(new List<ScenarioEvent>
+        {
+            new() { Time = 1, Frequency = 155.000, Duration = 3 }
+        });
+
+        var audioChunks = 0;
+        _source.OnAudio += _ => Interlocked.Increment(ref audioChunks);
+
+        await StartAndSettle();
+        _source.AvoidFrequency(155.000, 10); // Avoid it for the whole event.
+
+        await AdvanceAndSettle(TimeSpan.FromSeconds(1));
+
+        Assert.Equal("SCANNING", _source.GetState().Status);
+        Assert.Equal(0, audioChunks);
+
+        await _source.StopAsync();
+    }
+
+    // --- Helpers: drive the loop deterministically via the fake clock ---
+
+    private async Task StartAndSettle()
+    {
+        _source.Start();
+        await WaitFor(() => _source.ParkCount >= 1);
+    }
+
+    private async Task AdvanceAndSettle(TimeSpan span)
+    {
+        var before = _source.ParkCount;
+        _time.Advance(span);
+        await WaitFor(() => _source.ParkCount > before);
+    }
+
+    private static async Task WaitFor(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var sw = Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            await Task.Delay(2);
+        Assert.True(condition(), "loop did not reach the expected state in time");
     }
 }

--- a/server/OpenScanner.Tests/Integration/ScannerApiTests.cs
+++ b/server/OpenScanner.Tests/Integration/ScannerApiTests.cs
@@ -1,0 +1,142 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace OpenScanner.Tests;
+
+/// <summary>
+/// A WebApplicationFactory that points the app at a throwaway SQLite file so the
+/// integration tests never touch the developer's real database.
+/// </summary>
+public class TempDbWebAppFactory : WebApplicationFactory<Program>, IDisposable
+{
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"openscanner_it_{Guid.NewGuid():N}.db");
+
+    protected override IHost CreateHost(IHostBuilder builder)
+    {
+        builder.ConfigureHostConfiguration(cfg =>
+        {
+            cfg.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = $"Data Source={_dbPath}"
+            });
+        });
+        return base.CreateHost(builder);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        try { if (File.Exists(_dbPath)) File.Delete(_dbPath); } catch { /* best effort */ }
+    }
+}
+
+public class ScannerApiTests : IClassFixture<TempDbWebAppFactory>
+{
+    private readonly HttpClient _client;
+
+    public ScannerApiTests(TempDbWebAppFactory factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task Channels_CrudRoundTrip()
+    {
+        var freq = 151.1375; // unlikely to collide with seed data
+
+        // Create
+        var create = await _client.PostAsJsonAsync("/api/channels", new
+        {
+            frequency = freq,
+            alphaTag = "IntTest",
+            description = "integration",
+            mode = "NFM"
+        });
+        Assert.Equal(HttpStatusCode.Created, create.StatusCode);
+        var created = await create.Content.ReadFromJsonAsync<JsonElement>();
+        var id = created.GetProperty("id").GetInt32();
+        Assert.True(id > 0);
+
+        // Read
+        var list = await _client.GetFromJsonAsync<JsonElement>("/api/channels");
+        Assert.Contains(list.EnumerateArray(), c => c.GetProperty("frequency").GetDouble() == freq);
+
+        // Update
+        var update = await _client.PutAsJsonAsync($"/api/channels/{id}", new
+        {
+            id,
+            frequency = freq,
+            alphaTag = "IntTestUpdated",
+            description = "integration",
+            mode = "NFM"
+        });
+        Assert.Equal(HttpStatusCode.OK, update.StatusCode);
+
+        // Delete
+        var delete = await _client.DeleteAsync($"/api/channels/{id}");
+        Assert.Equal(HttpStatusCode.OK, delete.StatusCode);
+
+        var after = await _client.GetFromJsonAsync<JsonElement>("/api/channels");
+        Assert.DoesNotContain(after.EnumerateArray(), c => c.GetProperty("frequency").GetDouble() == freq);
+    }
+
+    [Fact]
+    public async Task GetScannerStatus_ReturnsState()
+    {
+        var state = await _client.GetFromJsonAsync<JsonElement>("/api/scanner");
+        Assert.True(state.TryGetProperty("status", out var status));
+        Assert.False(string.IsNullOrEmpty(status.GetString()));
+    }
+
+    [Fact]
+    public async Task SetSquelch_Returns200()
+    {
+        var res = await _client.PutAsJsonAsync("/api/scanner/squelch", new { value = -42.0 });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task Hold_PutThenDelete_Succeed()
+    {
+        var hold = await _client.PutAsJsonAsync("/api/scanner/hold", new { frequency = 155.55 });
+        Assert.Equal(HttpStatusCode.OK, hold.StatusCode);
+
+        var release = await _client.DeleteAsync("/api/scanner/hold");
+        Assert.Equal(HttpStatusCode.OK, release.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddAvoid_Returns202()
+    {
+        var res = await _client.PostAsJsonAsync("/api/scanner/avoids", new { frequency = 154.4, duration = 5.0 });
+        Assert.Equal(HttpStatusCode.Accepted, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task SetPower_Off_Returns200()
+    {
+        var res = await _client.PutAsJsonAsync("/api/scanner/power", new { enabled = false });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+    }
+
+    [Fact]
+    public async Task LegacyControl_Stop_Returns200_WithDeprecationHeader()
+    {
+        var res = await _client.PostAsJsonAsync("/api/control", new { action = "stop" });
+        Assert.Equal(HttpStatusCode.OK, res.StatusCode);
+        Assert.True(res.Headers.Contains("Deprecation"), "legacy control endpoint should advertise deprecation");
+    }
+
+    [Fact]
+    public async Task LegacyControl_UnknownAction_Returns400()
+    {
+        var res = await _client.PostAsJsonAsync("/api/control", new { action = "bogus" });
+        Assert.Equal(HttpStatusCode.BadRequest, res.StatusCode);
+    }
+}

--- a/server/OpenScanner.Tests/OpenScanner.Tests.csproj
+++ b/server/OpenScanner.Tests/OpenScanner.Tests.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.1" />
+    <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.7.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.9.50">

--- a/server/OpenScanner.Tests/Services/ChannelServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/ChannelServiceTests.cs
@@ -1,0 +1,95 @@
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+using OpenScanner.Server.Services;
+using Xunit;
+
+namespace OpenScanner.Tests;
+
+public class ChannelServiceTests
+{
+    private readonly Mock<IDatabase> _db = new();
+    private readonly ILogger<ChannelService> _logger =
+        LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Critical)).CreateLogger<ChannelService>();
+
+    private static readonly Channel[] AllChannels =
+    {
+        new(155.000, "A", "Chan A"),
+        new(156.000, "B", "Chan B"),
+    };
+
+    private static readonly Channel[] LocalChannels =
+    {
+        new(154.000, "Local", "Nearby"),
+    };
+
+    [Fact]
+    public async Task Constructor_LoadsChannelsFromDatabase()
+    {
+        _db.Setup(d => d.GetAllChannelsAsync()).ReturnsAsync(AllChannels);
+
+        var service = new ChannelService(_db.Object, _logger);
+
+        await WaitFor(() => service.Channels.Count == 2);
+        Assert.Contains(service.Channels, c => c.Frequency == 155.000);
+    }
+
+    [Fact]
+    public async Task CheckGeoRefresh_FirstFix_LoadsNearbyChannels()
+    {
+        _db.Setup(d => d.GetAllChannelsAsync()).ReturnsAsync(AllChannels);
+        _db.Setup(d => d.GetChannelsNearAsync(It.IsAny<double>(), It.IsAny<double>()))
+           .ReturnsAsync(LocalChannels);
+        var service = new ChannelService(_db.Object, _logger);
+        await WaitFor(() => service.Channels.Count == 2);
+
+        service.CheckGeoRefresh(43.0, -71.0);
+
+        await WaitFor(() => service.Channels.Count == 1 && service.Channels[0].AlphaTag == "Local");
+        _db.Verify(d => d.GetChannelsNearAsync(43.0, -71.0), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckGeoRefresh_SmallMove_DoesNotReload()
+    {
+        _db.Setup(d => d.GetAllChannelsAsync()).ReturnsAsync(AllChannels);
+        _db.Setup(d => d.GetChannelsNearAsync(It.IsAny<double>(), It.IsAny<double>()))
+           .ReturnsAsync(LocalChannels);
+        var service = new ChannelService(_db.Object, _logger);
+        await WaitFor(() => service.Channels.Count == 2);
+
+        service.CheckGeoRefresh(43.0, -71.0);           // first fix -> refresh
+        await WaitFor(() => service.Channels.Count == 1);
+        service.CheckGeoRefresh(43.0001, -71.0001);      // ~30 ft away, under 1 mile
+
+        await Task.Delay(50); // give any erroneous refresh a chance to happen
+        _db.Verify(d => d.GetChannelsNearAsync(It.IsAny<double>(), It.IsAny<double>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckGeoRefresh_LargeMove_ReloadsAgain()
+    {
+        _db.Setup(d => d.GetAllChannelsAsync()).ReturnsAsync(AllChannels);
+        _db.Setup(d => d.GetChannelsNearAsync(It.IsAny<double>(), It.IsAny<double>()))
+           .ReturnsAsync(LocalChannels);
+        var service = new ChannelService(_db.Object, _logger);
+        await WaitFor(() => service.Channels.Count == 2);
+
+        service.CheckGeoRefresh(43.0, -71.0);            // first fix
+        service.CheckGeoRefresh(44.0, -72.0);            // ~85 miles away
+
+        await WaitFor(() => true);
+        _db.Verify(d => d.GetChannelsNearAsync(43.0, -71.0), Times.Once);
+        _db.Verify(d => d.GetChannelsNearAsync(44.0, -72.0), Times.Once);
+    }
+
+    private static async Task WaitFor(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var sw = Stopwatch.StartNew();
+        while (!condition() && sw.ElapsedMilliseconds < timeoutMs)
+            await Task.Delay(5);
+        Assert.True(condition(), "condition not met within timeout");
+    }
+}

--- a/server/OpenScanner.Tests/Services/ChannelServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/ChannelServiceTests.cs
@@ -71,16 +71,20 @@ public class ChannelServiceTests
     [Fact]
     public async Task CheckGeoRefresh_LargeMove_ReloadsAgain()
     {
+        // Record each nearby-lookup so we can wait for the fire-and-forget refreshes
+        // to actually run before verifying, instead of racing them.
+        var calls = new System.Collections.Concurrent.ConcurrentBag<(double Lat, double Lon)>();
         _db.Setup(d => d.GetAllChannelsAsync()).ReturnsAsync(AllChannels);
         _db.Setup(d => d.GetChannelsNearAsync(It.IsAny<double>(), It.IsAny<double>()))
-           .ReturnsAsync(LocalChannels);
+           .ReturnsAsync(LocalChannels)
+           .Callback<double, double>((lat, lon) => calls.Add((lat, lon)));
         var service = new ChannelService(_db.Object, _logger);
         await WaitFor(() => service.Channels.Count == 2);
 
         service.CheckGeoRefresh(43.0, -71.0);            // first fix
         service.CheckGeoRefresh(44.0, -72.0);            // ~85 miles away
 
-        await WaitFor(() => true);
+        await WaitFor(() => calls.Contains((43.0, -71.0)) && calls.Contains((44.0, -72.0)));
         _db.Verify(d => d.GetChannelsNearAsync(43.0, -71.0), Times.Once);
         _db.Verify(d => d.GetChannelsNearAsync(44.0, -72.0), Times.Once);
     }

--- a/server/OpenScanner.Tests/Services/Mdc1200DecoderTests.cs
+++ b/server/OpenScanner.Tests/Services/Mdc1200DecoderTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenScanner.Server.Models;
+using OpenScanner.Server.Services;
+using Xunit;
+
+namespace OpenScanner.Tests;
+
+public class Mdc1200DecoderTests
+{
+    private readonly Mock<ILogger<Mdc1200Decoder>> _loggerMock = new();
+
+    private const int SampleRate = 48000;
+    private const int SamplesPerBit = SampleRate / 1200; // 40
+
+    [Fact]
+    public void Decodes_Valid_Ptt_Id_Burst()
+    {
+        // Arrange: a PTT ID packet (op 0x01) from unit 0x1234.
+        int op = 0x01, arg = 0x80, unitId = 0x1234;
+        var audio = SynthesizeBurst(op, arg, unitId);
+
+        var decoder = new Mdc1200Decoder(_loggerMock.Object, SampleRate);
+        Mdc1200Packet? received = null;
+        decoder.OnPacket += p => received = p;
+
+        // Act
+        decoder.ProcessAudio(audio);
+
+        // Assert
+        Assert.NotNull(received);
+        Assert.Equal(unitId, received!.UnitId);
+        Assert.Equal(op, received.Op);
+        Assert.Equal(arg, received.Arg);
+        Assert.Equal("PTT ID", received.Description);
+        Assert.False(received.IsEmergency);
+    }
+
+    [Fact]
+    public void Flags_Emergency_Packet()
+    {
+        var audio = SynthesizeBurst(0x00, 0x03, 0xABCD);
+        var decoder = new Mdc1200Decoder(_loggerMock.Object, SampleRate);
+        Mdc1200Packet? received = null;
+        decoder.OnPacket += p => received = p;
+
+        decoder.ProcessAudio(audio);
+
+        Assert.NotNull(received);
+        Assert.True(received!.IsEmergency);
+        Assert.Equal(0xABCD, received.UnitId);
+    }
+
+    [Fact]
+    public void Ignores_Noise()
+    {
+        var rng = new Random(1);
+        var noise = new byte[SampleRate]; // 1 second
+        for (int i = 0; i < noise.Length / 2; i++)
+        {
+            short s = (short)rng.Next(short.MinValue, short.MaxValue);
+            noise[i * 2] = (byte)(s & 0xFF);
+            noise[i * 2 + 1] = (byte)((s >> 8) & 0xFF);
+        }
+
+        var decoder = new Mdc1200Decoder(_loggerMock.Object, SampleRate);
+        bool fired = false;
+        decoder.OnPacket += _ => fired = true;
+
+        decoder.ProcessAudio(noise);
+
+        Assert.False(fired);
+    }
+
+    /// <summary>
+    /// Builds a test audio burst that the decoder's sign-at-bit-clock demodulator
+    /// recovers as the intended MDC1200 bit stream: leader, 40-bit sync word, then the
+    /// interleaved 112-bit frame. Each bit is emitted as one bit-period of a constant
+    /// sign (+ for 1, - for 0), which is exactly what the decoder samples.
+    /// </summary>
+    private static byte[] SynthesizeBurst(int op, int arg, int unitId)
+    {
+        var onair = new List<bool>();
+
+        // Leader: alternating bits give the decoder a clean bit clock and never match sync.
+        for (int i = 0; i < 32; i++)
+            onair.Add(i % 2 == 0);
+
+        // Sync word 0x07 092a446f, MSB-first (40 bits).
+        AppendBitsMsbFirst(onair, 0x07UL, 8);
+        AppendBitsMsbFirst(onair, 0x092a446fUL, 32);
+
+        // Frame: 14 bytes = op, arg, unitID hi/lo, CRC lo/hi, then unused parity bytes.
+        var data = new byte[14];
+        data[0] = (byte)op;
+        data[1] = (byte)arg;
+        data[2] = (byte)((unitId >> 8) & 0xFF);
+        data[3] = (byte)(unitId & 0xFF);
+        ushort crc = Mdc1200Decoder.Crc(data, 4);
+        data[4] = (byte)(crc & 0xFF);
+        data[5] = (byte)((crc >> 8) & 0xFF);
+
+        // Interleave the inverse of the decoder's de-interleave: decoder reads
+        // linear index L = col*7 + row from on-air position p = row*16 + col.
+        var frameBits = new bool[112];
+        for (int L = 0; L < 112; L++)
+        {
+            int b = L / 8;
+            int bitPos = L % 8;
+            bool value = (data[b] & (1 << bitPos)) != 0;
+
+            int col = L / 7;
+            int row = L % 7;
+            int p = row * 16 + col;
+            frameBits[p] = value;
+        }
+        onair.AddRange(frameBits);
+
+        return BitsToAudio(onair);
+    }
+
+    private static void AppendBitsMsbFirst(List<bool> bits, ulong value, int count)
+    {
+        for (int i = count - 1; i >= 0; i--)
+            bits.Add(((value >> i) & 1) != 0);
+    }
+
+    private static byte[] BitsToAudio(List<bool> bits)
+    {
+        const short amplitude = 12000;
+        var audio = new byte[bits.Count * SamplesPerBit * 2];
+        int idx = 0;
+        foreach (bool bit in bits)
+        {
+            short level = bit ? amplitude : (short)-amplitude;
+            for (int s = 0; s < SamplesPerBit; s++)
+            {
+                audio[idx++] = (byte)(level & 0xFF);
+                audio[idx++] = (byte)((level >> 8) & 0xFF);
+            }
+        }
+        return audio;
+    }
+}

--- a/server/OpenScanner.Tests/Services/RecordingServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/RecordingServiceTests.cs
@@ -1,0 +1,137 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+using OpenScanner.Server.Services;
+using Xunit;
+
+namespace OpenScanner.Tests;
+
+public class RecordingServiceTests
+{
+    private readonly Mock<IDatabase> _db = new();
+    private readonly Mock<ITranscriptionService> _transcription = new();
+    private readonly RecordingService _service;
+
+    public RecordingServiceTests()
+    {
+        var lf = LoggerFactory.Create(b => b.SetMinimumLevel(LogLevel.Critical));
+        var gps = new GpsService(lf.CreateLogger<GpsService>());
+        _service = new RecordingService(
+            _db.Object, lf.CreateLogger<RecordingService>(), _transcription.Object, gps);
+    }
+
+    private static Channel Chan(double freq = 155.0) => new(freq, "Test", "Test channel");
+
+    [Fact]
+    public void IsRecording_IsFalseInitially()
+    {
+        Assert.False(_service.IsRecording);
+    }
+
+    [Fact]
+    public void StartRecording_SetsIsRecording()
+    {
+        _service.StartRecording(Chan(), 1, 2, new LinkedList<byte[]>());
+        try
+        {
+            Assert.True(_service.IsRecording);
+        }
+        finally
+        {
+            _service.StopRecording(Chan(), null); // short -> aborts and cleans up file
+        }
+    }
+
+    [Fact]
+    public void StartRecording_WhenAlreadyRecording_IsIgnored()
+    {
+        _service.StartRecording(Chan(), 1, 2, new LinkedList<byte[]>());
+        try
+        {
+            // Second start must not replace the active stream.
+            _service.StartRecording(Chan(999.0), 3, 4, new LinkedList<byte[]>());
+            Assert.True(_service.IsRecording);
+        }
+        finally
+        {
+            _service.StopRecording(Chan(), null);
+        }
+    }
+
+    [Fact]
+    public void StopRecording_WhenNotRecording_DoesNothing()
+    {
+        _service.StopRecording(Chan(), null); // should be a no-op, no throw
+
+        Assert.False(_service.IsRecording);
+        _db.Verify(d => d.SaveTransmissionAsync(It.IsAny<CallLog>()), Times.Never);
+    }
+
+    [Fact]
+    public void StopRecording_ShortRecording_AbortsWithoutSavingOrLogging()
+    {
+        var newLogs = 0;
+        _service.OnNewLog += _ => newLogs++;
+
+        _service.StartRecording(Chan(), 1, 2, new LinkedList<byte[]>());
+        _service.StopRecording(Chan(), null); // ~0s duration -> aborted
+
+        Assert.False(_service.IsRecording);
+        Assert.Equal(0, newLogs);
+        _db.Verify(d => d.SaveTransmissionAsync(It.IsAny<CallLog>()), Times.Never);
+        _transcription.Verify(t => t.QueueTranscription(It.IsAny<CallLog>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public void ProcessAudio_WhenNotRecording_IsSafeNoOp()
+    {
+        // Neither legacy nor parallel forms should throw when nothing is recording.
+        _service.ProcessAudio(new byte[3200]);
+        _service.ProcessAudio(155.0, new byte[3200]);
+
+        Assert.False(_service.IsRecording);
+    }
+
+    [Fact]
+    public void StopParallelRecording_UnknownFrequency_DoesNothing()
+    {
+        _service.StopParallelRecording(999.0, null); // no throw
+
+        _db.Verify(d => d.SaveTransmissionAsync(It.IsAny<CallLog>()), Times.Never);
+    }
+
+    [Fact]
+    public void IsChannelRecording_TracksParallelRecordings()
+    {
+        Assert.False(_service.IsChannelRecording(155.0));
+
+        _service.StartParallelRecording(Chan(155.0), 1, 2, new LinkedList<byte[]>());
+        try
+        {
+            Assert.True(_service.IsChannelRecording(155.0));
+            Assert.False(_service.IsChannelRecording(156.0));
+        }
+        finally
+        {
+            _service.StopParallelRecording(155.0, null); // short -> aborts
+        }
+
+        Assert.False(_service.IsChannelRecording(155.0));
+    }
+
+    [Fact]
+    public void StartParallelRecording_SameFrequencyTwice_IsIgnored()
+    {
+        _service.StartParallelRecording(Chan(155.0), 1, 2, new LinkedList<byte[]>());
+        try
+        {
+            _service.StartParallelRecording(Chan(155.0), 3, 4, new LinkedList<byte[]>());
+            Assert.True(_service.IsChannelRecording(155.0));
+        }
+        finally
+        {
+            _service.StopParallelRecording(155.0, null);
+        }
+    }
+}

--- a/server/OpenScanner.Tests/Services/ToneDetectorTests.cs
+++ b/server/OpenScanner.Tests/Services/ToneDetectorTests.cs
@@ -95,6 +95,57 @@ public class ToneDetectorTests
         Assert.False(fired);
     }
 
+    [Fact]
+    public async Task Detects_SingleTone_WhenSustained()
+    {
+        // A tone set with no Tone B is a single (long) tone page.
+        var toneSet = new FireToneSet { Name = "Single Station", FrequencyA = 1010, FrequencyB = 0 };
+        _dbMock.Setup(db => db.GetAllFireTonesAsync()).ReturnsAsync(new[] { toneSet });
+
+        var detector = new ToneDetector(_dbMock.Object, _loggerMock.Object);
+        var reload = DateTime.UtcNow.AddSeconds(2);
+        while (detector.ToneCount == 0 && DateTime.UtcNow < reload)
+            await Task.Delay(10);
+
+        int fireCount = 0;
+        FireToneSet? detected = null;
+        detector.OnToneDetected += (t) => { detected = t; fireCount++; };
+
+        // Feed 100ms tone chunks continuously for ~1.5s, mimicking live audio arrival.
+        var chunk = GenerateSineWave(1010, 0.1, 48000);
+        var deadline = DateTime.UtcNow.AddSeconds(1.6);
+        while (DateTime.UtcNow < deadline)
+        {
+            detector.ProcessAudio(chunk);
+            await Task.Delay(80);
+        }
+
+        Assert.NotNull(detected);
+        Assert.Equal("Single Station", detected!.Name);
+        // A single sustained page must fire exactly once, not repeatedly per chunk.
+        Assert.Equal(1, fireCount);
+    }
+
+    [Fact]
+    public async Task SingleTone_TooShort_DoesNotFire()
+    {
+        var toneSet = new FireToneSet { Name = "Single Station", FrequencyA = 1010, FrequencyB = 0 };
+        _dbMock.Setup(db => db.GetAllFireTonesAsync()).ReturnsAsync(new[] { toneSet });
+
+        var detector = new ToneDetector(_dbMock.Object, _loggerMock.Object);
+        var reload = DateTime.UtcNow.AddSeconds(2);
+        while (detector.ToneCount == 0 && DateTime.UtcNow < reload)
+            await Task.Delay(10);
+
+        bool fired = false;
+        detector.OnToneDetected += (_) => fired = true;
+
+        // A brief burst (well under the 1s minimum) must not fire.
+        detector.ProcessAudio(GenerateSineWave(1010, 0.1, 48000));
+
+        Assert.False(fired);
+    }
+
     private byte[] GenerateSineWave(double freq, double durationSec, int sampleRate)
     {
         int samples = (int)(sampleRate * durationSec);


### PR DESCRIPTION
## Summary

Adds two radio-signaling features on top of the existing scanner pipeline, plus the macOS-support / mock-RTL / REST-API work already on this branch.

### MDC1200 decoding
- **`Mdc1200Decoder`** — a native, **clean-room MIT** C# decoder (1200-baud MSK, sync-word search, 7×16 de-interleave, CRC-16-CCITT). Written from the public protocol facts, *not* ported from the GPLv2 reference, so the project stays MIT.
- Decoded unit IDs are attributed to the current transmission's `SourceID` via the same `HandleActivity` path as **P25/DMR radio IDs** — they show in the Transmission Log identically (MDC emergency packets raise the `EMRG` alert too).

### Fire tone-out event log
- New `radio_events` table, `IDatabase` methods, and **`GET/DELETE /api/events`** controller.
- `OnNewEvent` broadcast over the control WebSocket (`NEW_EVENT`).
- Client **"Fire Tone-Outs"** panel (`EventLog`), rendered only when the user has at least one tone set configured.

### Single (long) tone paging
- A `FireToneSet` with **no Tone B** is treated as a single-tone page and fires when the tone is sustained for ≥1s (with dropout tolerance) — for agencies that page with one tone. Verified against a real recording (~1010 Hz single tone).
- Tone B is now optional in the `FireToneManager` UI.

### Correctness fixes (bundled with touched code)
- Clear `_lastDetectedTone` after a recording stops so a detected tone no longer bleeds onto the next transmission.
- `FiretonesController` add/update/delete now call `ToneDetector.ReloadTones()` so edits apply without a server restart.

## Testing
- New unit tests: `Mdc1200DecoderTests` (decodes a synthesized PTT-ID burst, flags emergency, rejects noise), `EventsControllerTests`, `ToneDetectorTests` single-tone cases, and a `FiretonesController` ReloadTones test.
- Full server suite: **149/150** — the one failure is a pre-existing flaky `ChannelServiceTests.CheckGeoRefresh_LargeMove_ReloadsAgain` (passes in isolation, unrelated to these changes).
- Client type-checks and builds.
- Runtime: server boots in Mock mode with the new DI graph; `radio_events` table created; `/api/events` serves.

## Notes
- Also sweeps in pre-existing in-flight test files (`AudioProviderTests`, `ScannerApiTests`, `ChannelServiceTests`, `RecordingServiceTests`, `Decoders/DecoderFactoryTests`) that were already in the working tree.
- Server targets **.NET 10**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)