### PR TITLE
Compress recordings, link tone-outs to history, and add storage settings

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -75,6 +75,7 @@ function App() {
   const [fireTones, setFireTones] = useState<FireToneSet[]>([]);
   const [callLog, setCallLog] = useState<CallLog[]>([]);
   const [radioEvents, setRadioEvents] = useState<RadioEvent[]>([]);
+  const [highlightLog, setHighlightLog] = useState<{ id: string; seq: number } | null>(null);
   const [audioAnalyser, setAudioAnalyser] = useState<AnalyserNode | undefined>(undefined);
   const [isManagerOpen, setIsManagerOpen] = useState(false);
   const [isToneManagerOpen, setIsToneManagerOpen] = useState(false);
@@ -1023,12 +1024,23 @@ function App() {
                 {/* Right Column: Transmission Log (Expanded) */}
                 <Grid size={{ xs: 12, md: 8, lg: 9 }} sx={{ height: { xs: '500px', md: '100%' }, overflow: 'hidden' }}>
                     <Paper sx={{ height: '100%', display: 'flex', flexDirection: 'column', bgcolor: '#0a0a0a', border: '1px solid #222', borderRadius: 2, overflowY: 'auto' }}>
-                        {fireTones.length > 0 && <EventLog events={radioEvents} onClear={clearEvents} />}
+                        {fireTones.length > 0 && (
+                            <EventLog
+                                events={radioEvents}
+                                onClear={clearEvents}
+                                onEventClick={(e) => {
+                                    if (e.transmissionId) {
+                                        setHighlightLog(h => ({ id: e.transmissionId!, seq: (h?.seq ?? 0) + 1 }));
+                                    }
+                                }}
+                            />
+                        )}
                         <TransmissionLog
                             liveLogs={callLog}
                             playingId={playingId}
                             onPlay={playRawAudio}
                             onDelete={deleteEntry}
+                            highlight={highlightLog}
                         />
                     </Paper>
                 </Grid>
@@ -1055,6 +1067,7 @@ function App() {
         <SettingsManager
             open={isSettingsOpen}
             onClose={() => setIsSettingsOpen(false)}
+            onRecordingsDeleted={() => setCallLog([])}
         />
 
         <Dialog 

--- a/client/src/components/EventLog.tsx
+++ b/client/src/components/EventLog.tsx
@@ -4,11 +4,13 @@ import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import LaunchIcon from '@mui/icons-material/Launch';
 import type { RadioEvent } from '../types';
 
 interface EventLogProps {
     events: RadioEvent[];
     onClear: () => void;
+    onEventClick?: (event: RadioEvent) => void;
 }
 
 const formatDetail = (e: RadioEvent): string => {
@@ -17,7 +19,7 @@ const formatDetail = (e: RadioEvent): string => {
     return '';
 };
 
-export default function EventLog({ events, onClear }: EventLogProps) {
+export default function EventLog({ events, onClear, onEventClick }: EventLogProps) {
     const [open, setOpen] = useState(true);
 
     return (
@@ -62,10 +64,18 @@ export default function EventLog({ events, onClear }: EventLogProps) {
                 ) : (
                     <List dense disablePadding sx={{ maxHeight: 200, overflowY: 'auto' }}>
                         {events.map(e => {
+                            const clickable = !!e.transmissionId && !!onEventClick;
                             return (
                                 <ListItem
                                     key={e.id}
-                                    sx={{ px: 1.5, py: 0.5, borderTop: '1px solid #161616' }}
+                                    onClick={clickable ? () => onEventClick!(e) : undefined}
+                                    title={clickable ? 'Jump to this recording in the history' : undefined}
+                                    sx={{
+                                        px: 1.5, py: 0.5, borderTop: '1px solid #161616',
+                                        cursor: clickable ? 'pointer' : 'default',
+                                        transition: 'background-color 0.15s',
+                                        '&:hover': clickable ? { bgcolor: 'rgba(255,183,77,0.08)' } : undefined,
+                                    }}
                                 >
                                     <Box display="flex" alignItems="center" gap={1} width="100%">
                                         <Typography
@@ -87,6 +97,9 @@ export default function EventLog({ events, onClear }: EventLogProps) {
                                                 {e.alphaTag ? ` · ${e.alphaTag}` : e.frequency ? ` · ${e.frequency.toFixed(4)} MHz` : ''}
                                             </Typography>
                                         </Box>
+                                        {clickable && (
+                                            <LaunchIcon sx={{ color: '#8a5a2b', fontSize: 14, flexShrink: 0 }} />
+                                        )}
                                         <Typography sx={{ color: '#666', fontSize: '0.7rem', flexShrink: 0 }}>
                                             {new Date(e.timestamp).toLocaleTimeString()}
                                         </Typography>

--- a/client/src/components/SettingsManager.tsx
+++ b/client/src/components/SettingsManager.tsx
@@ -1,29 +1,86 @@
 import React, { useState, useEffect } from 'react';
-import { 
-    Dialog, DialogTitle, DialogContent, DialogActions, 
+import {
+    Dialog, DialogTitle, DialogContent, DialogActions,
     Button, List, ListItem, ListItemText, ListItemSecondaryAction, Switch,
-    Box, CircularProgress, Alert, AlertTitle, Link, TextField
+    Box, CircularProgress, Alert, AlertTitle, Link, TextField,
+    Divider, Typography, LinearProgress
 } from '@mui/material';
 import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
+import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
+
+interface StorageInfo {
+    recordingsBytes: number;
+    recordingsCount: number;
+    databaseBytes: number;
+    diskFreeBytes: number;
+    diskTotalBytes: number;
+}
 
 interface Props {
     open: boolean;
     onClose: () => void;
+    onRecordingsDeleted?: () => void;
 }
 
-const SettingsManager: React.FC<Props> = ({ open, onClose }) => {
+const formatBytes = (bytes: number): string => {
+    if (!bytes || bytes < 0) return '0 B';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+// Resolve the backend base URL (dev server runs the client on :5173, API on :5212).
+const apiBase = (): string => {
+    const isDev = window.location.port === '5173';
+    const port = isDev ? '5212' : window.location.port || '80';
+    const protocol = window.location.protocol;
+    const backendHost = window.location.hostname;
+    const portSuffix = (port === '80' || port === '') ? '' : `:${port}`;
+    return `${protocol}//${backendHost}${portSuffix}`;
+};
+
+const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }) => {
     const [settings, setSettings] = useState<Record<string, string>>({});
     const [systemInfo, setSystemInfo] = useState<Record<string, string>>({});
     const [updateInfo, setUpdateInfo] = useState<{ latestVersion: string, url: string, body?: string } | null>(null);
     const [loading, setLoading] = useState(false);
+    const [storage, setStorage] = useState<StorageInfo | null>(null);
+    const [confirmDelete, setConfirmDelete] = useState(false);
+    const [deleting, setDeleting] = useState(false);
 
     useEffect(() => {
         if (open) {
             fetchSettings();
             fetchSystemInfo();
             fetchLatestVersion();
+            fetchStorage();
         }
     }, [open]);
+
+    const fetchStorage = async () => {
+        try {
+            const res = await fetch(`${apiBase()}/api/system/storage`);
+            if (res.ok) setStorage(await res.json());
+        } catch (error) {
+            console.error("Failed to fetch storage info", error);
+        }
+    };
+
+    const handleDeleteAllRecordings = async () => {
+        setDeleting(true);
+        try {
+            const res = await fetch(`${apiBase()}/api/history`, { method: 'DELETE' });
+            if (res.ok) {
+                setConfirmDelete(false);
+                onRecordingsDeleted?.();
+                await fetchStorage();
+            }
+        } catch (error) {
+            console.error("Failed to delete recordings", error);
+        } finally {
+            setDeleting(false);
+        }
+    };
 
     const fetchSettings = async () => {
         setLoading(true);
@@ -214,9 +271,62 @@ const SettingsManager: React.FC<Props> = ({ open, onClose }) => {
                                 />
                             </ListItem>
                         )}
+                        <Divider sx={{ my: 1 }} />
+                        <ListItem sx={{ display: 'block' }}>
+                            <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 1 }}>
+                                Storage
+                            </Typography>
+                            {storage ? (
+                                <Box>
+                                    {storage.diskTotalBytes > 0 && (
+                                        <Box sx={{ mb: 1.5 }}>
+                                            <Box display="flex" justifyContent="space-between">
+                                                <Typography variant="caption" color="text.secondary">
+                                                    Disk used
+                                                </Typography>
+                                                <Typography variant="caption" color="text.secondary">
+                                                    {formatBytes(storage.diskTotalBytes - storage.diskFreeBytes)} / {formatBytes(storage.diskTotalBytes)}
+                                                    {' '}({formatBytes(storage.diskFreeBytes)} free)
+                                                </Typography>
+                                            </Box>
+                                            <LinearProgress
+                                                variant="determinate"
+                                                value={Math.min(100, ((storage.diskTotalBytes - storage.diskFreeBytes) / storage.diskTotalBytes) * 100)}
+                                                sx={{ mt: 0.5, height: 6, borderRadius: 3 }}
+                                            />
+                                        </Box>
+                                    )}
+                                    <Box display="flex" justifyContent="space-between" sx={{ mb: 0.5 }}>
+                                        <Typography variant="body2" color="text.secondary">
+                                            Recordings ({storage.recordingsCount})
+                                        </Typography>
+                                        <Typography variant="body2">{formatBytes(storage.recordingsBytes)}</Typography>
+                                    </Box>
+                                    <Box display="flex" justifyContent="space-between">
+                                        <Typography variant="body2" color="text.secondary">Database</Typography>
+                                        <Typography variant="body2">{formatBytes(storage.databaseBytes)}</Typography>
+                                    </Box>
+                                    <Button
+                                        variant="outlined"
+                                        color="error"
+                                        size="small"
+                                        fullWidth
+                                        startIcon={<DeleteForeverIcon />}
+                                        onClick={() => setConfirmDelete(true)}
+                                        disabled={storage.recordingsCount === 0}
+                                        sx={{ mt: 1.5 }}
+                                    >
+                                        Delete All Recordings
+                                    </Button>
+                                </Box>
+                            ) : (
+                                <Typography variant="caption" color="text.secondary">Loading…</Typography>
+                            )}
+                        </ListItem>
+                        <Divider sx={{ my: 1 }} />
                         {systemInfo.Commit && (
                             <ListItem>
-                                <ListItemText 
+                                <ListItemText
                                     primary="Git Commit"
                                     secondary={systemInfo.Commit}
                                     secondaryTypographyProps={{ style: { fontFamily: 'monospace', fontSize: '0.75rem' } }}
@@ -237,6 +347,29 @@ const SettingsManager: React.FC<Props> = ({ open, onClose }) => {
             <DialogActions>
                 <Button onClick={onClose}>Close</Button>
             </DialogActions>
+
+            <Dialog open={confirmDelete} onClose={() => !deleting && setConfirmDelete(false)} maxWidth="xs" fullWidth>
+                <DialogTitle>Delete All Recordings?</DialogTitle>
+                <DialogContent>
+                    <Typography variant="body2">
+                        This permanently deletes all recorded audio files and their transmission
+                        history{storage ? ` (${storage.recordingsCount} recording${storage.recordingsCount === 1 ? '' : 's'}, ${formatBytes(storage.recordingsBytes)})` : ''}.
+                        This cannot be undone.
+                    </Typography>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={() => setConfirmDelete(false)} disabled={deleting}>Cancel</Button>
+                    <Button
+                        color="error"
+                        variant="contained"
+                        onClick={handleDeleteAllRecordings}
+                        disabled={deleting}
+                        startIcon={deleting ? <CircularProgress size={16} color="inherit" /> : <DeleteForeverIcon />}
+                    >
+                        {deleting ? 'Deleting…' : 'Delete All'}
+                    </Button>
+                </DialogActions>
+            </Dialog>
         </Dialog>
     );
 };

--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useContext, createContext } from 'react';
 import { 
     Box, 
     List, 
@@ -40,14 +40,24 @@ interface LogNodeProps {
     onFavoriteToggle: () => void;
 }
 
+/** A request to scroll to and flash a specific log. `seq` bumps on every request
+ *  so re-clicking the same event re-triggers the effect. */
+export interface HighlightRequest {
+    id: string;
+    seq: number;
+}
+
+const HighlightContext = createContext<HighlightRequest | null>(null);
+
 interface Props {
     liveLogs: CallLog[];
     playingId: string | null;
     onPlay: (id: string, path: string, duration?: number) => void;
     onDelete: (id: string) => void;
+    highlight?: HighlightRequest | null;
 }
 
-const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelete }) => {
+const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelete, highlight }) => {
     const [searchQuery, setSearchQuery] = useState('');
     const [searchResults, setSearchResults] = useState<CallLog[] | null>(null);
     const [years, setYears] = useState<string[]>([]);
@@ -57,6 +67,15 @@ const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelet
     const [powerDmsDept, setPowerDmsDept] = useState<string | null>(null);
 
     const handleFavoriteToggle = () => setFavoritesRefreshKey(k => k + 1);
+
+    // When a highlight targets a recent log, make sure the Recent Activity section
+    // is expanded so the item is rendered and can be scrolled into view.
+    useEffect(() => {
+        if (highlight && liveLogs.some(l => l.id === highlight.id)) {
+            setRecentOpen(true);
+            setSearchQuery('');
+        }
+    }, [highlight, liveLogs]);
 
     const handleDelete = (id: string) => {
         setSearchResults(prev => prev ? prev.filter(log => log.id !== id) : null);
@@ -104,6 +123,7 @@ const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelet
     }, [searchQuery]);
 
     return (
+        <HighlightContext.Provider value={highlight ?? null}>
         <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
             <Box sx={{ p: 2, borderBottom: '1px solid #222' }}>
                 <TextField 
@@ -180,6 +200,7 @@ const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelet
                 )}
             </Box>
         </Box>
+        </HighlightContext.Provider>
     );
 };
 
@@ -416,6 +437,18 @@ const ChannelNode = ({ year, month, day, channel, playingId, onPlay, onDelete, o
 
 const LogItem = ({ log, playingId, onPlay, onDelete, onFavoriteToggle }: { log: CallLog } & LogNodeProps) => {
     const [isFavorite, setIsFavorite] = useState(log.isFavorite ?? false);
+    const highlight = useContext(HighlightContext);
+    const itemRef = useRef<HTMLLIElement>(null);
+    const [flash, setFlash] = useState(false);
+
+    // Scroll into view and briefly flash when this log is the highlight target.
+    useEffect(() => {
+        if (!highlight || highlight.id !== log.id) return;
+        itemRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        setFlash(true);
+        const timer = setTimeout(() => setFlash(false), 2000);
+        return () => clearTimeout(timer);
+    }, [highlight, log.id]);
 
     const handleFavoriteClick = (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -435,15 +468,18 @@ const LogItem = ({ log, playingId, onPlay, onDelete, onFavoriteToggle }: { log: 
 
     return (
         <React.Fragment>
-            <ListItem 
-                sx={{ 
-                    pl: { xs: 4, sm: 10 }, 
+            <ListItem
+                ref={itemRef}
+                sx={{
+                    pl: { xs: 4, sm: 10 },
                     pr: 2,
                     py: 1,
                     '& .MuiListItemSecondaryAction-root': {
                         right: 8
                     },
-                    bgcolor: 'rgba(0,0,0,0.2)'
+                    bgcolor: flash ? 'rgba(255,183,77,0.18)' : 'rgba(0,0,0,0.2)',
+                    boxShadow: flash ? 'inset 3px 0 0 #ffb74d' : 'none',
+                    transition: 'background-color 0.6s ease, box-shadow 0.6s ease'
                 }}
                 secondaryAction={
                     <Box sx={{ display: 'flex', gap: 0.5 }}>

--- a/server/OpenScanner.Server/Controllers/SupportController.cs
+++ b/server/OpenScanner.Server/Controllers/SupportController.cs
@@ -32,6 +32,17 @@ public class SupportController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves storage usage statistics: recordings size/count, database size, and disk space.
+    /// </summary>
+    /// <returns>Storage usage snapshot.</returns>
+    [HttpGet("system/storage")]
+    [ProducesResponseType(typeof(OpenScanner.Server.Models.StorageInfo), StatusCodes.Status200OK)]
+    public IActionResult GetStorageInfo()
+    {
+        return Ok(_support.GetStorageInfo());
+    }
+
+    /// <summary>
     /// Generates and downloads a support package containing logs, configuration, and system info.
     /// </summary>
     /// <returns>A ZIP file containing diagnostic information.</returns>

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -253,6 +253,13 @@ public class Database : IDatabase
     }
 
     /// <inheritdoc />
+    public async Task<IEnumerable<string>> GetOldestTransmissionIdsAsync(int limit)
+    {
+        using var conn = GetConnection();
+        return await conn.QueryAsync<string>(SqlLoader.GetSql("Transmissions/GetOldest.sql"), new { Limit = limit });
+    }
+
+    /// <inheritdoc />
     public async Task DeleteTransmissionAsync(string id)
     {
         using var conn = GetConnection();

--- a/server/OpenScanner.Server/Devices/MockRadioSource.cs
+++ b/server/OpenScanner.Server/Devices/MockRadioSource.cs
@@ -104,6 +104,9 @@ public class MockRadioSource : BackgroundService, IRadioSource
         e.Timestamp = _timeProvider.GetUtcNow().UtcDateTime.ToString("o");
         e.Frequency = _state.CurrentChannel?.Frequency ?? _state.CurrentFrequency ?? 0;
         e.AlphaTag = _state.CurrentChannel?.AlphaTag;
+        // Link the event to the recording it coincides with (if any) so the UI can
+        // jump to it in the transmission history.
+        e.TransmissionId ??= _recordingService.CurrentRecordingId;
 
         _db.AddRadioEventAsync(e).ContinueWith(
             t => _logger.LogError(t.Exception, "Failed to persist radio event"),

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -410,6 +410,9 @@ public class RtlDevice : BackgroundService, IRadioSource
         e.Timestamp = DateTime.UtcNow.ToString("o");
         e.Frequency = _state.CurrentChannel?.Frequency ?? _state.CurrentFrequency ?? 0;
         e.AlphaTag = _state.CurrentChannel?.AlphaTag;
+        // Link the event to the recording it coincides with (if any) so the UI can
+        // jump to it in the transmission history.
+        e.TransmissionId ??= _recordingService.CurrentRecordingId;
 
         _db.AddRadioEventAsync(e).ContinueWith(
             t => _logger.LogError(t.Exception, "Failed to persist radio event"),

--- a/server/OpenScanner.Server/Interfaces/IDatabase.cs
+++ b/server/OpenScanner.Server/Interfaces/IDatabase.cs
@@ -68,6 +68,14 @@ public interface IDatabase
     Task<IEnumerable<CallLog>> GetHistoryAsync(int limit = 100);
 
     /// <summary>
+    /// Retrieves the IDs of the oldest non-favorite transmissions, oldest first.
+    /// Used by low-disk cleanup to purge recordings while preserving favorites.
+    /// </summary>
+    /// <param name="limit">Maximum number of IDs to return.</param>
+    /// <returns>A collection of transmission IDs, oldest first.</returns>
+    Task<IEnumerable<string>> GetOldestTransmissionIdsAsync(int limit);
+
+    /// <summary>
     /// Gets all years that have transmission data.
     /// </summary>
     /// <returns>A collection of years as strings.</returns>

--- a/server/OpenScanner.Server/Interfaces/IRecordingService.cs
+++ b/server/OpenScanner.Server/Interfaces/IRecordingService.cs
@@ -16,6 +16,14 @@ public interface IRecordingService
     /// </summary>
     bool IsChannelRecording(double frequency);
 
+    /// <summary>
+    /// The transmission log id (<c>log_{startTime}</c>) of the currently active
+    /// recording, or the most recently started one in parallel mode. Null when no
+    /// recording is active. Matches the id assigned to the finalized <see cref="CallLog"/>,
+    /// so callers can link concurrent events to the recording they coincide with.
+    /// </summary>
+    string? CurrentRecordingId { get; }
+
     void StartRecording(Channel channel, int? src, int? tgt, LinkedList<byte[]> preRollBuffer);
     void UpdateSourceTarget(int? src, int? tgt);
     void UpdateSourceTarget(double frequency, int? src, int? tgt);

--- a/server/OpenScanner.Server/Interfaces/ISupportService.cs
+++ b/server/OpenScanner.Server/Interfaces/ISupportService.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using OpenScanner.Server.Models;
 
 namespace OpenScanner.Server.Interfaces;
 
@@ -13,6 +14,12 @@ public interface ISupportService
     /// </summary>
     /// <returns>A dictionary containing version info.</returns>
     Dictionary<string, string> GetVersionInfo();
+
+    /// <summary>
+    /// Gets storage usage statistics: recordings size/count, database size, and disk space.
+    /// </summary>
+    /// <returns>A <see cref="StorageInfo"/> snapshot.</returns>
+    StorageInfo GetStorageInfo();
 
     /// <summary>
     /// Creates a ZIP archive containing diagnostic information.

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -386,6 +386,17 @@ public record ParallelChannelState(
 public record SpectrumPoint(double Frequency, double Db);
 
 /// <summary>
+/// Storage usage statistics surfaced in the settings UI.
+/// </summary>
+public record StorageInfo(
+    long RecordingsBytes,
+    int RecordingsCount,
+    long DatabaseBytes,
+    long DiskFreeBytes,
+    long DiskTotalBytes
+);
+
+/// <summary>
 /// Real-time status of the scanner hardware and software.
 /// </summary>
 public record ScannerState(

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddSingleton<IDecoderFactory, OpenScanner.Server.Decoders.Decod
 builder.Services.AddSingleton<ITranscriptionService, WhisperTranscriptionService>();
 builder.Services.AddSingleton<IRecordingService, RecordingService>();
 builder.Services.AddSingleton<IChannelService, ChannelService>();
+builder.Services.AddHostedService<RecordingCleanupService>();
 
 var radioProvider = builder.Configuration["Radio:Provider"] ?? "RTL-SDR";
 if (radioProvider == "Mock")

--- a/server/OpenScanner.Server/Services/RecordingCleanupService.cs
+++ b/server/OpenScanner.Server/Services/RecordingCleanupService.cs
@@ -1,0 +1,119 @@
+using OpenScanner.Server.Interfaces;
+
+namespace OpenScanner.Server.Services;
+
+/// <summary>
+/// Background service that guards against the host disk filling up with
+/// recordings. When free disk space on the recordings volume drops below a
+/// configurable threshold (default 2 GB), it deletes the oldest non-favorite
+/// recordings (file + database row) until free space recovers.
+/// </summary>
+public class RecordingCleanupService : BackgroundService
+{
+    private const long DefaultMinFreeBytes = 2L * 1024 * 1024 * 1024; // 2 GB
+    private const int DeleteBatchSize = 25;
+    private const int MaxBatchesPerTick = 40; // safety cap: up to 1000 deletions per tick
+
+    private static readonly TimeSpan CheckInterval = TimeSpan.FromSeconds(60);
+
+    private readonly IDatabase _db;
+    private readonly ILogger<RecordingCleanupService> _logger;
+    private readonly long _minFreeBytes;
+    private readonly string _recordingsPath;
+
+    public RecordingCleanupService(IDatabase db, ILogger<RecordingCleanupService> logger, IConfiguration config)
+    {
+        _db = db;
+        _logger = logger;
+
+        var configured = config.GetValue<long?>("Recording:MinFreeDiskBytes");
+        _minFreeBytes = configured is > 0 ? configured.Value : DefaultMinFreeBytes;
+
+        // Mirror the recordings location used by RecordingService.
+        _recordingsPath = Path.GetFullPath(
+            Path.Combine(Directory.GetCurrentDirectory(), "../../data/recordings"));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "RecordingCleanupService started. Threshold: {ThresholdMB} MB free at {Path}",
+            _minFreeBytes / 1024 / 1024, _recordingsPath);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await Task.Delay(CheckInterval, stoppingToken);
+                await EnforceFreeSpaceAsync(stoppingToken);
+            }
+            catch (OperationCanceledException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error during recording cleanup tick");
+            }
+        }
+    }
+
+    private async Task EnforceFreeSpaceAsync(CancellationToken stoppingToken)
+    {
+        var free = GetFreeBytes();
+        if (free < 0 || free >= _minFreeBytes) return;
+
+        _logger.LogWarning(
+            "Low disk space: {FreeMB} MB free, below {ThresholdMB} MB threshold. Purging oldest recordings.",
+            free / 1024 / 1024, _minFreeBytes / 1024 / 1024);
+
+        var totalDeleted = 0;
+
+        for (var batch = 0; batch < MaxBatchesPerTick; batch++)
+        {
+            if (stoppingToken.IsCancellationRequested) break;
+
+            var ids = (await _db.GetOldestTransmissionIdsAsync(DeleteBatchSize)).ToList();
+            if (ids.Count == 0)
+            {
+                _logger.LogWarning("No more non-favorite recordings to delete; free space still low.");
+                break;
+            }
+
+            foreach (var id in ids)
+            {
+                await _db.DeleteTransmissionAsync(id);
+                totalDeleted++;
+            }
+
+            free = GetFreeBytes();
+            if (free < 0 || free >= _minFreeBytes) break;
+        }
+
+        if (totalDeleted > 0)
+        {
+            _logger.LogInformation(
+                "Purged {Count} recording(s). Free space now {FreeMB} MB.",
+                totalDeleted, GetFreeBytes() / 1024 / 1024);
+        }
+    }
+
+    /// <summary>
+    /// Available free bytes on the recordings volume, or -1 if it cannot be read.
+    /// </summary>
+    private long GetFreeBytes()
+    {
+        try
+        {
+            var probe = Directory.Exists(_recordingsPath)
+                ? _recordingsPath
+                : Directory.GetCurrentDirectory();
+            return new DriveInfo(probe).AvailableFreeSpace;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to read free disk space for {Path}", _recordingsPath);
+            return -1;
+        }
+    }
+}

--- a/server/OpenScanner.Server/Services/RecordingService.cs
+++ b/server/OpenScanner.Server/Services/RecordingService.cs
@@ -38,6 +38,28 @@ public class RecordingService : IRecordingService
     /// <inheritdoc />
     public bool IsChannelRecording(double frequency) => _activeRecordings.ContainsKey(frequency);
 
+    /// <inheritdoc />
+    public string? CurrentRecordingId
+    {
+        get
+        {
+            lock (_audioLock)
+            {
+                if (_recordingStream != null) return $"log_{_recordingStartTime}";
+            }
+
+            if (!_activeRecordings.IsEmpty)
+            {
+                var latest = _activeRecordings.Values
+                    .OrderByDescending(r => r.StartTime)
+                    .FirstOrDefault();
+                if (latest != null) return $"log_{latest.StartTime}";
+            }
+
+            return null;
+        }
+    }
+
     public RecordingService(
         IDatabase db, 
         ILogger<RecordingService> logger, 
@@ -138,7 +160,9 @@ public class RecordingService : IRecordingService
         string? recordingPath;
         long startTime;
         string? speakerChain;
-        
+        int? sourceID;
+        int? targetID;
+
         lock (_audioLock)
         {
             if (_recordingStream == null) return;
@@ -146,119 +170,17 @@ public class RecordingService : IRecordingService
             _recordingStream = null;
             recordingPath = _currentRecordingPath;
             startTime = _recordingStartTime;
+            sourceID = _currentSourceID;
+            targetID = _currentTargetID;
             speakerChain = _speakerList.Count > 1
                 ? string.Join(" → ", _speakerList)
                 : null;
+            _currentRecordingPath = null;
         }
 
-        var duration = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTime) / 1000.0;
-        _logger.LogInformation($"Recording duration: {duration:F1}s. Raw file exists: {File.Exists(recordingPath)}");
-
-        if (duration >= 0.5 && recordingPath != null && File.Exists(recordingPath))
-        {
-             var fileInfo = new FileInfo(recordingPath);
-             if (fileInfo.Length < 4096) 
-             {
-                 try { File.Delete(recordingPath); } catch (Exception ex) { _logger.LogDebug(ex, "Failed to delete small recording file"); }
-                 _logger.LogInformation("Deleted small recording file (less than 4KB).");
-                 return;
-             }
-
-             if (channel != null)
-             {
-                 // Convert RAW to WAV (More robust than MP3)
-                 var wavPath = Path.ChangeExtension(recordingPath, ".wav");
-                 try 
-                 {
-                     var convertStart = new ProcessStartInfo(PlatformTools.Ffmpeg)
-                     {
-                         RedirectStandardOutput = true,
-                         RedirectStandardError = true,
-                         UseShellExecute = false,
-                         CreateNoWindow = true
-                     };
-                     // Input: Raw 48k
-                     convertStart.ArgumentList.Add("-f"); convertStart.ArgumentList.Add("s16le");
-                     convertStart.ArgumentList.Add("-ar"); convertStart.ArgumentList.Add("48000");
-                     convertStart.ArgumentList.Add("-ac"); convertStart.ArgumentList.Add("1");
-                     convertStart.ArgumentList.Add("-i"); convertStart.ArgumentList.Add(recordingPath);
-                     // Output: WAV PCM
-                     convertStart.ArgumentList.Add(wavPath);
-                     convertStart.ArgumentList.Add("-y");
-
-                     using (var proc = Process.Start(convertStart))
-                     {
-                         string output = proc?.StandardOutput.ReadToEnd() ?? string.Empty;
-                         string error = proc?.StandardError.ReadToEnd() ?? string.Empty;
-                         proc?.WaitForExit();
-
-                         if (!string.IsNullOrEmpty(output)) _logger.LogInformation($"FFmpeg Output: {output}");
-                         if (!string.IsNullOrEmpty(error)) _logger.LogError($"FFmpeg Error: {error}");
-                     }
-
-                     if (File.Exists(wavPath))
-                     {
-                         _logger.LogInformation($"WAV file created successfully: {wavPath}");
-                         try { File.Delete(recordingPath); } catch (Exception ex) { _logger.LogDebug(ex, "Failed to delete original RAW file after conversion"); }
-                         recordingPath = wavPath;
-                     }
-                     else
-                     {
-                         _logger.LogError($"WAV file was not created by FFmpeg at {wavPath}.");
-                     }
-                 }
-                 catch (Exception ex)
-                 {
-                     _logger.LogError(ex, "WAV conversion failed");
-                 }
-
-                 var gps = _gpsService.GetLastLocation();
-                 var lat = gps?.Lat ?? 0;
-                 var lon = gps?.Lon ?? 0;
-
-                 var log = new CallLog(
-                      $"log_{startTime}",
-                      DateTimeOffset.FromUnixTimeMilliseconds(startTime).UtcDateTime.ToString("o"),
-                      channel.Frequency,
-                      channel.AlphaTag,
-                      channel.Description,
-                      lat != 0 ? lat : null,
-                      lon != 0 ? lon : null,
-                      Path.GetFileName(recordingPath),
-                      duration,
-                      null, // transcription starts as null and is populated asynchronously
-                      _currentSourceID,
-                      _currentTargetID,
-                      lastDetectedTone,
-                      speakerChain
-                  );
-                 
-                  
-                  _logger.LogInformation($"Recording path before saving: {recordingPath}, exists: {File.Exists(recordingPath)}");
-                  _db.SaveTransmissionAsync(log).ContinueWith(t => {
-                      if (t.IsFaulted) _logger.LogError(t.Exception, "Failed to save transmission");
-                  });
-                 
-                  _logger.LogInformation($"Saved transmission: {duration:F1}s | RID: {_currentSourceID} | Tone: {lastDetectedTone} | Text: (queued)");
-                  _logger.LogInformation($"Recording saved to: {recordingPath}");
-                  OnNewLog?.Invoke(log);
-
-                  // Queue transcription in the background
-                  _transcriptionService.QueueTranscription(log, recordingPath);
-             }
-        }
-        else if (recordingPath != null)
-        {
-             try { File.Delete(recordingPath); } catch (Exception ex) { _logger.LogDebug(ex, "Failed to delete aborted recording file"); }
-        }
-        
-        lock (_audioLock)
-        {
-            if (_recordingStream == null && _currentRecordingPath == recordingPath)
-            {
-                _currentRecordingPath = null;
-            }
-        }
+        // Shared convert (RAW -> MP3), save, and transcribe logic.
+        FinalizeRecording(recordingPath, startTime, channel, sourceID, targetID,
+                          lastDetectedTone, speakerChain);
     }
 
     // --- Multi-channel (parallel mode) methods ---
@@ -404,7 +326,7 @@ public class RecordingService : IRecordingService
         var duration = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTime) / 1000.0;
         _logger.LogInformation($"Recording duration: {duration:F1}s. Raw file exists: {File.Exists(recordingPath)}");
 
-        if (duration >= 0.5 && recordingPath != null && File.Exists(recordingPath))
+        if (duration >= 0.5 && recordingPath != null && File.Exists(recordingPath) && channel != null)
         {
             var fileInfo = new FileInfo(recordingPath);
             if (fileInfo.Length < 4096)
@@ -414,8 +336,8 @@ public class RecordingService : IRecordingService
                 return;
             }
 
-            // Convert RAW to WAV
-            var wavPath = Path.ChangeExtension(recordingPath, ".wav");
+            // Convert RAW to compressed MP3 (mono, 32 kbps) to save disk space.
+            var mp3Path = Path.ChangeExtension(recordingPath, ".mp3");
             try
             {
                 var convertStart = new ProcessStartInfo(PlatformTools.Ffmpeg)
@@ -425,11 +347,16 @@ public class RecordingService : IRecordingService
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };
+                // Input: raw 48k mono s16le
                 convertStart.ArgumentList.Add("-f"); convertStart.ArgumentList.Add("s16le");
                 convertStart.ArgumentList.Add("-ar"); convertStart.ArgumentList.Add("48000");
                 convertStart.ArgumentList.Add("-ac"); convertStart.ArgumentList.Add("1");
                 convertStart.ArgumentList.Add("-i"); convertStart.ArgumentList.Add(recordingPath);
-                convertStart.ArgumentList.Add(wavPath);
+                // Output: MP3, mono, 32 kbps
+                convertStart.ArgumentList.Add("-codec:a"); convertStart.ArgumentList.Add("libmp3lame");
+                convertStart.ArgumentList.Add("-b:a"); convertStart.ArgumentList.Add("32k");
+                convertStart.ArgumentList.Add("-ac"); convertStart.ArgumentList.Add("1");
+                convertStart.ArgumentList.Add(mp3Path);
                 convertStart.ArgumentList.Add("-y");
 
                 using (var proc = Process.Start(convertStart))
@@ -442,20 +369,20 @@ public class RecordingService : IRecordingService
                     if (!string.IsNullOrEmpty(error)) _logger.LogError($"FFmpeg Error: {error}");
                 }
 
-                if (File.Exists(wavPath))
+                if (File.Exists(mp3Path))
                 {
-                    _logger.LogInformation($"WAV file created successfully: {wavPath}");
+                    _logger.LogInformation($"MP3 file created successfully: {mp3Path}");
                     try { File.Delete(recordingPath); } catch (Exception ex) { _logger.LogDebug(ex, "Failed to delete original RAW file after conversion"); }
-                    recordingPath = wavPath;
+                    recordingPath = mp3Path;
                 }
                 else
                 {
-                    _logger.LogError($"WAV file was not created by FFmpeg at {wavPath}.");
+                    _logger.LogError($"MP3 file was not created by FFmpeg at {mp3Path}.");
                 }
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "WAV conversion failed");
+                _logger.LogError(ex, "MP3 conversion failed");
             }
 
             var gps = _gpsService.GetLastLocation();

--- a/server/OpenScanner.Server/Services/SupportService.cs
+++ b/server/OpenScanner.Server/Services/SupportService.cs
@@ -238,6 +238,57 @@ public class SupportService : ISupportService
         return Path.Combine(dataDir, "openscanner.db");
     }
 
+    private static string GetRecordingsPath()
+    {
+        var root = Directory.GetCurrentDirectory();
+        return Path.GetFullPath(Path.Combine(root, "../../data/recordings"));
+    }
+
+    /// <inheritdoc />
+    public StorageInfo GetStorageInfo()
+    {
+        var logger = _loggerProvider.CreateLogger(nameof(SupportService));
+
+        long recordingsBytes = 0;
+        int recordingsCount = 0;
+        try
+        {
+            var dir = GetRecordingsPath();
+            if (Directory.Exists(dir))
+            {
+                foreach (var file in Directory.EnumerateFiles(dir))
+                {
+                    try
+                    {
+                        recordingsBytes += new FileInfo(file).Length;
+                        recordingsCount++;
+                    }
+                    catch (Exception ex) { logger.LogDebug(ex, "Failed to stat recording {File}", file); }
+                }
+            }
+        }
+        catch (Exception ex) { logger.LogDebug(ex, "Failed to size recordings directory"); }
+
+        long databaseBytes = 0;
+        try
+        {
+            var dbPath = GetDatabasePath();
+            if (File.Exists(dbPath)) databaseBytes = new FileInfo(dbPath).Length;
+        }
+        catch (Exception ex) { logger.LogDebug(ex, "Failed to size database"); }
+
+        long diskFree = 0, diskTotal = 0;
+        try
+        {
+            var drive = new DriveInfo(Directory.GetCurrentDirectory());
+            diskFree = drive.AvailableFreeSpace;
+            diskTotal = drive.TotalSize;
+        }
+        catch (Exception ex) { logger.LogDebug(ex, "Failed to read disk space"); }
+
+        return new StorageInfo(recordingsBytes, recordingsCount, databaseBytes, diskFree, diskTotal);
+    }
+
     private object GetDiskSpaceInfo()
     {
         try

--- a/server/OpenScanner.Server/Sql/Transmissions/GetOldest.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetOldest.sql
@@ -1,0 +1,1 @@
+SELECT id FROM transmissions WHERE isFavorite = 0 ORDER BY timestamp ASC LIMIT @Limit

--- a/server/OpenScanner.Server/appsettings.json
+++ b/server/OpenScanner.Server/appsettings.json
@@ -15,5 +15,8 @@
   "Radio": {
     "Provider": "RTL-SDR",
     "SkipDuration": 10
+  },
+  "Recording": {
+    "MinFreeDiskBytes": 2147483648
   }
 }

--- a/server/OpenScanner.Tests/Services/RecordingServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/RecordingServiceTests.cs
@@ -121,6 +121,56 @@ public class RecordingServiceTests
     }
 
     [Fact]
+    public void CurrentRecordingId_IsNullWhenIdle()
+    {
+        Assert.Null(_service.CurrentRecordingId);
+    }
+
+    [Fact]
+    public void CurrentRecordingId_LegacyRecording_MatchesFinalizedLogId()
+    {
+        CallLog? saved = null;
+        _db.Setup(d => d.SaveTransmissionAsync(It.IsAny<CallLog>()))
+           .Callback<CallLog>(l => saved = l)
+           .Returns(Task.CompletedTask);
+
+        _service.StartRecording(Chan(), 1, 2, new LinkedList<byte[]>());
+
+        // The id observed mid-recording (used to link coincident events) must equal
+        // the id of the finalized CallLog for a long-enough recording.
+        var liveId = _service.CurrentRecordingId;
+        Assert.NotNull(liveId);
+        Assert.StartsWith("log_", liveId);
+
+        // Feed enough audio to clear the 4KB minimum, then wait out the 0.5s floor.
+        _service.ProcessAudio(new byte[8192]);
+        Thread.Sleep(600);
+        _service.StopRecording(Chan(), "Station 1");
+
+        Assert.NotNull(saved);
+        Assert.Equal(liveId, saved!.Id);
+        Assert.Null(_service.CurrentRecordingId);
+    }
+
+    [Fact]
+    public void CurrentRecordingId_ParallelRecording_ReturnsMostRecentActive()
+    {
+        _service.StartParallelRecording(Chan(155.0), 1, 2, new LinkedList<byte[]>());
+        try
+        {
+            var id = _service.CurrentRecordingId;
+            Assert.NotNull(id);
+            Assert.StartsWith("log_", id);
+        }
+        finally
+        {
+            _service.StopParallelRecording(155.0, null); // short -> aborts
+        }
+
+        Assert.Null(_service.CurrentRecordingId);
+    }
+
+    [Fact]
     public void StartParallelRecording_SameFrequencyTwice_IsIgnored()
     {
         _service.StartParallelRecording(Chan(155.0), 1, 2, new LinkedList<byte[]>());


### PR DESCRIPTION
Targets `feature/macos-support` (this branch stacks on it) so the diff is only the new work — retarget to `main` if you'd rather land it there directly.

## What's in this PR

### 1. Compress recordings + low-disk auto-purge
- Finished recordings are now encoded as **mono 32 kbps MP3** instead of uncompressed WAV — ~24× smaller (verified: a 10 s clip went 960 KB → 40 KB). Browser playback (`decodeAudioData`) and Whisper transcription both handle MP3 unchanged.
- Collapsed the duplicated RAW→audio conversion in `StopRecording` into the shared `FinalizeRecording` path.
- New `RecordingCleanupService` background worker deletes the **oldest non-favorite** recordings when free disk drops below a configurable threshold (`Recording:MinFreeDiskBytes`, default 2 GB), reusing `DeleteTransmissionAsync` + a new `GetOldestTransmissionIdsAsync` query.

### 2. Link fire tone-outs to their recording in history
- Populate `RadioEvent.TransmissionId` (previously never set) via a new `IRecordingService.CurrentRecordingId` that matches the finalized `CallLog` id.
- Clicking a tone-out in the event log scrolls to and briefly flashes the matching transmission in the history panel below.

### 3. Storage stats + delete-all-recordings in settings
- New `GET /api/system/storage` (recordings size/count, DB size, disk free/total), rendered in the settings dialog with a disk-usage bar.
- "Delete All Recordings" button behind a confirmation, reusing the existing `DELETE /api/history` clear path.

## Verification
- Server **153/153** tests pass (incl. 3 new `CurrentRecordingId` tests); client `tsc` clean, **9/9** client tests pass.
- MP3 conversion + Whisper resample exercised directly with the real ffmpeg args.
- `/api/system/storage` verified live against real data (161 recordings / 69 MB, DB 72 KB — matched `du`).
- The destructive delete path was **not** run against real recordings; it reuses the already-covered `ClearHistory` logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)