### PR TITLE
Fix CMake 4 install, fire tone-out link resolution, and garbled parallel live audio

### DIFF
--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -29,7 +29,8 @@ import {
     Today,
     Radio,
     History as HistoryIcon,
-    Article
+    Article,
+    Link as LinkIcon
 } from '@mui/icons-material';
 import type { CallLog, Channel } from '../types';
 
@@ -65,21 +66,43 @@ const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelet
     const [recentOpen, setRecentOpen] = useState(true);
     const [favoritesRefreshKey, setFavoritesRefreshKey] = useState(0);
     const [powerDmsDept, setPowerDmsDept] = useState<string | null>(null);
+    const [linkedLog, setLinkedLog] = useState<CallLog | null>(null);
 
     const handleFavoriteToggle = () => setFavoritesRefreshKey(k => k + 1);
 
-    // When a new highlight targets a recent log, make sure the Recent Activity
-    // section is expanded and any active search is cleared so the item is rendered
-    // and can be scrolled into view. This adjusts state during render in response to
-    // a changed prop (React's recommended pattern) rather than in an effect.
+    // When a new highlight arrives, expand Recent Activity and clear any active
+    // search so the target item is rendered and can be scrolled into view. This
+    // adjusts state during render in response to a changed prop (React's
+    // recommended pattern) rather than in an effect.
     const [lastHighlightSeq, setLastHighlightSeq] = useState<number | undefined>(highlight?.seq);
     if (highlight && highlight.seq !== lastHighlightSeq) {
         setLastHighlightSeq(highlight.seq);
-        if (liveLogs.some(l => l.id === highlight.id)) {
-            setRecentOpen(true);
-            setSearchQuery('');
-        }
+        setRecentOpen(true);
+        setSearchQuery('');
     }
+
+    // The target recording may not be in the live "Recent Activity" list — e.g.
+    // an older tone-out whose recording has scrolled out of the recent window,
+    // or after a page reload. In that case fetch it directly so we can pin it at
+    // the top and scroll to it, making the tone-out link always work. setState
+    // only happens in the async callback (never synchronously in the effect).
+    useEffect(() => {
+        if (!highlight) return;
+        if (liveLogs.some(l => l.id === highlight.id)) return; // already rendered in Recent
+        if (linkedLog?.id === highlight.id) return;            // already pinned
+        const targetId = highlight.id;
+        let cancelled = false;
+        fetch(`/api/history/entry/${encodeURIComponent(targetId)}`)
+            .then(res => (res.ok ? res.json() : null))
+            .then((data: CallLog | null) => { if (!cancelled && data) setLinkedLog(data); })
+            .catch(err => console.error('Failed to fetch linked recording:', err));
+        return () => { cancelled = true; };
+    }, [highlight, liveLogs, linkedLog]);
+
+    // Only show the pinned recording while it is the active target and isn't
+    // already present in the live list (avoids showing it twice).
+    const showLinked = !!linkedLog && highlight?.id === linkedLog.id
+        && !liveLogs.some(l => l.id === linkedLog.id);
 
     const handleDelete = (id: string) => {
         setSearchResults(prev => prev ? prev.filter(log => log.id !== id) : null);
@@ -174,6 +197,19 @@ const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelet
                     </List>
                 ) : (
                     <List dense component="nav">
+                        {/* Linked Recording — a tone-out target that isn't in the recent list */}
+                        {showLinked && linkedLog && (
+                            <Box sx={{ borderBottom: '1px solid #1a1a1a' }}>
+                                <Box sx={{ display: 'flex', alignItems: 'center', px: 2, py: 1, bgcolor: 'rgba(255,183,77,0.06)' }}>
+                                    <LinkIcon sx={{ mr: 2, color: '#ffb74d', fontSize: 20 }} />
+                                    <Typography sx={{ fontWeight: 'bold', color: '#ffb74d', fontSize: '0.9rem' }}>
+                                        Linked Recording
+                                    </Typography>
+                                </Box>
+                                <LogItem log={linkedLog} playingId={playingId} onPlay={onPlay} onDelete={onDelete} onFavoriteToggle={handleFavoriteToggle} />
+                            </Box>
+                        )}
+
                         {/* Recent Activity Node */}
                         <ListItemButton onClick={() => setRecentOpen(!recentOpen)} sx={{ borderBottom: '1px solid #1a1a1a', bgcolor: 'rgba(0, 255, 0, 0.05)' }}>
                             <HistoryIcon sx={{ mr: 2, color: '#00ff00', fontSize: 20 }} />

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -254,7 +254,9 @@ if ! command -v dsd-fme &> /dev/null || ! ldconfig -p | grep -q libmbe; then
         cd mbelib
         rm -rf build
         mkdir -p build && cd build
-        cmake ..
+        # mbelib/dsd-fme ship an ancient cmake_minimum_required (<3.5), which
+        # CMake 4+ (Ubuntu 26.04) refuses to configure. Allow the old policy.
+        cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
         make -j$(nproc)
         sudo make install
         sudo ldconfig
@@ -271,7 +273,7 @@ if ! command -v dsd-fme &> /dev/null || ! ldconfig -p | grep -q libmbe; then
         git pull origin $(git branch --show-current) || true
         rm -rf build
         mkdir -p build && cd build
-        cmake ..
+        cmake -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ..
         make -j$(nproc)
         sudo make install
         sudo ldconfig

--- a/server/OpenScanner.Server/Controllers/HistoryController.cs
+++ b/server/OpenScanner.Server/Controllers/HistoryController.cs
@@ -31,6 +31,20 @@ public class HistoryController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves a single transmission log by its ID.
+    /// </summary>
+    /// <param name="id">The transmission ID.</param>
+    /// <returns>The matching call log, or 404 if it no longer exists.</returns>
+    [HttpGet("entry/{id}")]
+    [ProducesResponseType(typeof(CallLog), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<CallLog>> GetById(string id)
+    {
+        var log = await _db.GetTransmissionByIdAsync(id);
+        return log is null ? NotFound() : Ok(log);
+    }
+
+    /// <summary>
     /// Gets all years for which transmission data exists.
     /// </summary>
     /// <returns>List of years (e.g., ["2023", "2024"]).</returns>

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -209,6 +209,13 @@ public class Database : IDatabase
     }
     
     /// <inheritdoc />
+    public async Task<CallLog?> GetTransmissionByIdAsync(string id)
+    {
+        using var conn = GetConnection();
+        return await conn.QueryFirstOrDefaultAsync<CallLog>(SqlLoader.GetSql("Transmissions/GetById.sql"), new { Id = id });
+    }
+
+    /// <inheritdoc />
     public async Task<IEnumerable<string>> GetTransmissionYearsAsync()
     {
         using var conn = GetConnection();

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -67,6 +67,17 @@ public class RtlDevice : BackgroundService, IRadioSource
     // Stereo pan positions for parallel channels: maps frequency -> (leftGain, rightGain)
     private Dictionary<double, (double Left, double Right)> _parallelPanMap = new();
 
+    // Real-time stereo mixer for parallel mode. Each channel's mono audio is enqueued here,
+    // and a periodic timer sums all active channels sample-aligned into one panned stereo
+    // stream. Without this, simultaneous channels would broadcast independent stereo chunks
+    // that the browser scheduler serializes end-to-end (garbled overlapping audio).
+    private readonly Dictionary<double, Queue<short>> _mixQueues = new();
+    private readonly object _mixLock = new();
+    private System.Threading.Timer? _mixTimer;
+    private const int MixIntervalMs = 20;
+    private const int MixBlockSamples = 48000 * MixIntervalMs / 1000; // 960 samples @ 48kHz
+    private const int MixQueueMaxSamples = 48000 / 2; // ~500ms backlog cap to bound latency
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RtlDevice"/> class.
     /// </summary>
@@ -433,6 +444,14 @@ public class RtlDevice : BackgroundService, IRadioSource
 
     private void StopParallelPipelines()
     {
+        // Stop the mixer first so no tick fires after the pipelines are gone.
+        _mixTimer?.Dispose();
+        _mixTimer = null;
+        lock (_mixLock)
+        {
+            _mixQueues.Clear();
+        }
+
         if (_parallelPipelines != null)
         {
             foreach (var pipeline in _parallelPipelines)
@@ -597,6 +616,15 @@ public class RtlDevice : BackgroundService, IRadioSource
                 $"Parallel pan: {pipelines.First(p => p.Channel.Frequency == sortedFreqs[i]).Channel.AlphaTag} " +
                 $"({sortedFreqs[i]} MHz) -> L={leftGain:F2} R={rightGain:F2}");
         }
+
+        // Initialize the stereo mixer: one jitter queue per channel + periodic mix timer.
+        lock (_mixLock)
+        {
+            _mixQueues.Clear();
+            foreach (var freq in _parallelPanMap.Keys)
+                _mixQueues[freq] = new Queue<short>();
+        }
+        _mixTimer = new System.Threading.Timer(MixTick, null, MixIntervalMs, MixIntervalMs);
 
         // Build initial parallel channel states for the UI
         UpdateParallelState();
@@ -784,32 +812,29 @@ public class RtlDevice : BackgroundService, IRadioSource
     }
 
     /// <summary>
-    /// Handle audio from a parallel channel pipeline. Pan to stereo L/R and send to browser.
+    /// Handle audio from a parallel channel pipeline. Enqueue the channel's mono samples for
+    /// the stereo mixer (which sums all active channels into one panned stream) and route the
+    /// untouched mono audio to per-channel recording.
     /// </summary>
     private void HandleParallelAudio(Channel channel, byte[] audio)
     {
         _toneDetector.ProcessAudio(audio);
         _mdc.ProcessAudio(audio);
 
-        // Convert mono s16le to stereo s16le with per-channel panning
-        var (leftGain, rightGain) = _parallelPanMap.GetValueOrDefault(channel.Frequency, (0.5, 0.5));
+        // Enqueue mono samples for the mixer instead of broadcasting per-channel stereo.
         int monoSamples = audio.Length / 2;
-        var stereo = new byte[monoSamples * 4]; // 2 channels * 2 bytes per sample
-
-        for (int i = 0; i < monoSamples; i++)
+        lock (_mixLock)
         {
-            short mono = (short)(audio[i * 2] | (audio[i * 2 + 1] << 8));
-            short left = (short)(mono * leftGain);
-            short right = (short)(mono * rightGain);
+            if (_mixQueues.TryGetValue(channel.Frequency, out var queue))
+            {
+                for (int i = 0; i < monoSamples; i++)
+                    queue.Enqueue((short)(audio[i * 2] | (audio[i * 2 + 1] << 8)));
 
-            int outIdx = i * 4;
-            stereo[outIdx] = (byte)(left & 0xFF);
-            stereo[outIdx + 1] = (byte)((left >> 8) & 0xFF);
-            stereo[outIdx + 2] = (byte)(right & 0xFF);
-            stereo[outIdx + 3] = (byte)((right >> 8) & 0xFF);
+                // Bound latency: if this channel ran ahead, drop the oldest samples.
+                while (queue.Count > MixQueueMaxSamples)
+                    queue.Dequeue();
+            }
         }
-
-        OnAudio?.Invoke(stereo);
 
         // Route mono to multi-channel recording (recordings stay mono per channel)
         var rs = _recordingService as RecordingService;
@@ -819,6 +844,59 @@ public class RtlDevice : BackgroundService, IRadioSource
         }
 
         UpdateParallelState();
+    }
+
+    /// <summary>
+    /// Periodic mixer tick. Pulls an equal-length block from every parallel channel's queue,
+    /// applies each channel's pan gains, sums them sample-aligned into a single interleaved
+    /// stereo buffer, and broadcasts it. Channels with no buffered audio contribute silence.
+    /// Produces one continuous stereo stream so overlapping transmissions play concurrently.
+    /// </summary>
+    private void MixTick(object? _)
+    {
+        // No-op if the parallel scan has stopped (guards a late-firing timer tick).
+        if (_parallelPipelines == null) return;
+
+        var mixLeft = new int[MixBlockSamples];
+        var mixRight = new int[MixBlockSamples];
+        bool anyAudio = false;
+
+        lock (_mixLock)
+        {
+            foreach (var (freq, gains) in _parallelPanMap)
+            {
+                if (!_mixQueues.TryGetValue(freq, out var queue) || queue.Count == 0)
+                    continue;
+
+                int count = Math.Min(queue.Count, MixBlockSamples);
+                for (int i = 0; i < count; i++)
+                {
+                    short sample = queue.Dequeue();
+                    mixLeft[i] += (int)(sample * gains.Left);
+                    mixRight[i] += (int)(sample * gains.Right);
+                }
+                anyAudio = true;
+            }
+        }
+
+        // If every channel was silent this tick, skip the broadcast (preserves the
+        // "only stream when active" behavior; the client resumes cleanly on underrun).
+        if (!anyAudio) return;
+
+        var stereo = new byte[MixBlockSamples * 4];
+        for (int i = 0; i < MixBlockSamples; i++)
+        {
+            short left = (short)Math.Clamp(mixLeft[i], short.MinValue, short.MaxValue);
+            short right = (short)Math.Clamp(mixRight[i], short.MinValue, short.MaxValue);
+
+            int outIdx = i * 4;
+            stereo[outIdx] = (byte)(left & 0xFF);
+            stereo[outIdx + 1] = (byte)((left >> 8) & 0xFF);
+            stereo[outIdx + 2] = (byte)(right & 0xFF);
+            stereo[outIdx + 3] = (byte)((right >> 8) & 0xFF);
+        }
+
+        OnAudio?.Invoke(stereo);
     }
 
     /// <summary>

--- a/server/OpenScanner.Server/Interfaces/IDatabase.cs
+++ b/server/OpenScanner.Server/Interfaces/IDatabase.cs
@@ -68,6 +68,13 @@ public interface IDatabase
     Task<IEnumerable<CallLog>> GetHistoryAsync(int limit = 100);
 
     /// <summary>
+    /// Retrieves a single transmission log by its ID.
+    /// </summary>
+    /// <param name="id">The transmission ID.</param>
+    /// <returns>The matching call log, or null if not found.</returns>
+    Task<CallLog?> GetTransmissionByIdAsync(string id);
+
+    /// <summary>
     /// Retrieves the IDs of the oldest non-favorite transmissions, oldest first.
     /// Used by low-disk cleanup to purge recordings while preserving favorites.
     /// </summary>

--- a/server/OpenScanner.Server/Sql/Transmissions/GetById.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetById.sql
@@ -1,0 +1,1 @@
+SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, detectedTone, speakerChain, isFavorite FROM transmissions WHERE id = @Id LIMIT 1

--- a/server/OpenScanner.Tests/Controllers/HistoryControllerTests.cs
+++ b/server/OpenScanner.Tests/Controllers/HistoryControllerTests.cs
@@ -33,6 +33,34 @@ public class HistoryControllerTests
     }
 
     [Fact]
+    public async Task GetById_ReturnsLog_WhenFound()
+    {
+        // Arrange
+        var log = new CallLog { Id = "log_123" };
+        _dbMock.Setup(db => db.GetTransmissionByIdAsync("log_123")).ReturnsAsync(log);
+
+        // Act
+        var result = await _controller.GetById("log_123");
+
+        // Assert
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Same(log, ok.Value);
+    }
+
+    [Fact]
+    public async Task GetById_Returns404_WhenMissing()
+    {
+        // Arrange
+        _dbMock.Setup(db => db.GetTransmissionByIdAsync("nope")).ReturnsAsync((CallLog?)null);
+
+        // Act
+        var result = await _controller.GetById("nope");
+
+        // Assert
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    [Fact]
     public async Task GetYears_ReturnsYears()
     {
         // Arrange

--- a/server/OpenScanner.Tests/Database/DatabaseTests.cs
+++ b/server/OpenScanner.Tests/Database/DatabaseTests.cs
@@ -78,6 +78,21 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public async Task GetTransmissionById_ShouldReturnMatchingLog()
+    {
+        var log = new CallLog("target_id", DateTime.UtcNow.ToString("o"), 155.0, "Tag", "Desc", 45.0, -122.0, "audio.raw", 5.0, "Linked transcription", 1234, 5678);
+        await _db.SaveTransmissionAsync(log);
+
+        var found = await _db.GetTransmissionByIdAsync("target_id");
+        Assert.NotNull(found);
+        Assert.Equal("target_id", found!.Id);
+        Assert.Equal("Linked transcription", found.Transcription);
+
+        var missing = await _db.GetTransmissionByIdAsync("does_not_exist");
+        Assert.Null(missing);
+    }
+
+    [Fact]
     public async Task HierarchicalNavigation_ShouldReturnCorrectNodes()
     {
         var date1 = "2023-01-15T10:00:00";


### PR DESCRIPTION
Three independent fixes bundled on one branch.

## 1. CMake 4 install fix
The installer failed on a fresh Ubuntu 26.04 laptop while building `mbelib`:

> CMake Error: Compatibility with CMake < 3.5 has been removed from CMake.

Ubuntu 26.04 ships **CMake 4.x**, which dropped support for the ancient `cmake_minimum_required(<3.5)` that `mbelib` (and `dsd-fme`) declare. Added `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` to both cmake invocations in `scripts/install_service.sh` so the radio dependencies configure again. Everything else (.NET 10, Node, whisper.cpp) already installed cleanly.

## 2. Fire tone-out links always resolve to their recording
**Bug:** clicking a fire tone-out only scrolled to its recording when that recording was still in the live "Recent Activity" list. Older tone-outs — recording scrolled out of the 100-item window, or after a page reload — linked to nothing.

**Fix:**
- New `GET /api/history/entry/{id}` endpoint → `GetTransmissionByIdAsync` (`GetById.sql`).
- `TransmissionLog` fetches the target recording when it isn't in the live list and pins it in a "Linked Recording" section that scrolls + flashes like any other highlight. `setState` fires only in the async callback, staying clear of the strict no-setState-in-effect rule.

## 3. Garbled live audio when multiple parallel channels talk at once
**Bug:** in parallel scan mode each channel pipeline independently panned its own mono audio to stereo and broadcast it. When two channels talked simultaneously the server emitted two *separate* stereo streams, which the browser scheduler laid end-to-end (`nextStartTime += duration`) — serializing and time-stretching overlapping audio into a garble. Recordings were unaffected because they are written as independent mono per-channel files (never summed).

**Fix (`RtlDevice.cs`):** added a real-time mixer. Each channel enqueues its mono samples into a per-channel jitter queue; a 20ms timer pulls an equal-length block from every channel, applies the existing per-channel pan gains, and **sums** them sample-aligned into one interleaved stereo buffer (int accumulators clamped to s16). A ~500ms per-channel backlog cap bounds latency, all-silent ticks are skipped to preserve the "stream only when active" behavior, and the timer is torn down with the pipelines. The client needs no change — a single continuous stereo stream is exactly what its scheduler expects.

## Verification
- client `npm run lint` ✔, client `tsc` ✔
- server build ✔
- HistoryController tests (11, +2 new) ✔
- DatabaseTests (9, +1 new that runs the real `GetById.sql` against SQLite, confirming the embedded resource loads) ✔
- Audio mixer: server builds clean; end-to-end (≥2 simultaneously-active parallel channels) needs real SDR hardware or a replayed IQ dump to confirm in-browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)