### PR TITLE
Fix live-audio popping and fire tone-out recording split

### DIFF
--- a/client/src/hooks/useAudioPipeline.ts
+++ b/client/src/hooks/useAudioPipeline.ts
@@ -342,9 +342,15 @@ export function useAudioPipeline(volume: number) {
 
     const connectAudioWs = () => {
       wsAudio.current = new WebSocket(wsAudioUrl);
+      // Receive frames as ArrayBuffer, not Blob. Blob forces a per-frame
+      // `await event.data.arrayBuffer()` in the handler below, and that async
+      // yield lets concurrently-arriving frames resolve out of order — which
+      // reorders PCM and produces high-frequency popping. ArrayBuffer frames
+      // are available synchronously, so enqueue order matches arrival order.
+      wsAudio.current.binaryType = 'arraybuffer';
       wsAudio.current.onclose = () => { if (!closed) setTimeout(connectAudioWs, 3000); };
       wsAudio.current.onmessage = async (event) => {
-        if (!(event.data instanceof Blob)) return;
+        if (!(event.data instanceof ArrayBuffer)) return;
         if (isPageHiddenRef.current) return;
 
         try {
@@ -354,8 +360,7 @@ export function useAudioPipeline(volume: number) {
           const analyser = audioAnalyserRef.current;
           if (!analyser) return;
 
-          const arrayBuffer = await event.data.arrayBuffer();
-          const int16Array = new Int16Array(arrayBuffer);
+          const int16Array = new Int16Array(event.data);
           const isStereo = isParallelRef.current;
 
           // Deinterleave Int16 → Float32.
@@ -388,6 +393,9 @@ export function useAudioPipeline(volume: number) {
             // into the analyser with a jitter buffer.
             const frames = left.length;
             const stereo = left !== right;
+            // Buffer rate is the source PCM rate (48000), not ctx.sampleRate:
+            // this declares the samples' true rate so the engine resamples
+            // correctly if the device context runs at a different rate.
             const audioBuffer = ctx.createBuffer(stereo ? 2 : 1, frames, 48000);
             audioBuffer.copyToChannel(left, 0);
             if (stereo) audioBuffer.copyToChannel(right, 1);

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -39,11 +39,12 @@ public class RtlDevice : BackgroundService, IRadioSource
     private bool _manualOverride = false;
     
     private string? _lastDetectedTone;
-    // After a fire tone-out we keep the recording open this long so the pause
-    // before the dispatch voice doesn't split it into a separate transmission.
+    // Normally 2s of silence ends a transmission. After a fire tone-out we use a
+    // longer inactivity timeout so the pause between the tone ending and the
+    // dispatch voice keying up doesn't split it into a separate transmission —
+    // the tone and the voice that follows stay one recording.
     private const int ActivityTimeoutMs = 2000;
     private const int ToneHoldMs = 6000;
-    private DateTime _toneHoldUntil = DateTime.MinValue;
 
     private DateTime _recordingLockoutUntil = DateTime.MinValue;
     private CancellationTokenSource? _scanCts;
@@ -116,9 +117,9 @@ public class RtlDevice : BackgroundService, IRadioSource
 
         _toneDetector.OnToneDetected += (tone) => {
             _lastDetectedTone = tone.Name;
-            // Open the hold window and extend the current recording's stop timer so
-            // the tone and the dispatch voice that follows it stay one transmission.
-            _toneHoldUntil = DateTime.UtcNow.AddMilliseconds(ToneHoldMs);
+            // Extend the current recording's stop timer now so that if the tone is
+            // the last audio before the carrier drops, we still wait the full hold
+            // (measured from the tone ending) for the dispatch voice to follow.
             if (_recordingService.IsRecording) ScheduleStopTimeout();
             UpdateState(_state with { LastDetectedTone = tone.Name });
             RaiseRadioEvent(new RadioEvent
@@ -1543,9 +1544,12 @@ public class RtlDevice : BackgroundService, IRadioSource
     }
 
     // (Re)schedule the timer that finalizes the current transmission once audio
-    // stops. Normally 2s of silence ends a transmission; within the post-tone
-    // hold window we wait longer so the tone and the following dispatch voice are
-    // captured as a single transmission (with the speech available to transcribe).
+    // stops. Normally 2s of silence ends a transmission; once a fire tone-out has
+    // been detected for this transmission we wait ToneHoldMs of silence instead,
+    // so the tone and the following dispatch voice are captured as a single
+    // transmission (with the speech available to transcribe). Because this timer
+    // is re-armed on every audio chunk, the hold is measured from the last audio
+    // — i.e. from when the tone actually ends — not from when it was detected.
     private void ScheduleStopTimeout()
     {
         _activityTimeoutCts?.Cancel();
@@ -1557,7 +1561,7 @@ public class RtlDevice : BackgroundService, IRadioSource
             RestartSessionTimeout(5000); // 5s hang time
         }
 
-        bool withinToneHold = _lastDetectedTone != null && DateTime.UtcNow < _toneHoldUntil;
+        bool withinToneHold = _lastDetectedTone != null;
         int stopDelayMs = withinToneHold ? ToneHoldMs : ActivityTimeoutMs;
 
         Task.Delay(stopDelayMs, token).ContinueWith(t =>


### PR DESCRIPTION
Two live-audio/recording fixes on this branch.

## 1. High-frequency popping in the live audio stream

**Problem:** The live stream had rapid popping (on both HTTP and HTTPS, single-channel included) while recordings were clean.

**Cause:** In `client/src/hooks/useAudioPipeline.ts`, the `/ws/audio` `onmessage` handler received each PCM frame as a `Blob` and did `await event.data.arrayBuffer()` before enqueuing. That per-frame await yields, so continuations for back-to-back frames could resolve **out of order**, reordering ~40 ms PCM frames. It sits upstream of the playback split, so it hit both the AudioWorklet path (HTTPS/localhost) and the buffer-source fallback (http); recordings (one contiguous decode) were immune.

**Fix:** Set `binaryType = 'arraybuffer'` and read `new Int16Array(event.data)` directly, dropping the reorder-inducing await. Enqueue order now matches arrival order.

## 2. Fire tone-out recording split from the dispatch voice

**Problem:** The tone recorded as its own transmission and the dispatcher's voice as a separate one, so the tone-out event linked to a recording with no dispatch audio.

**Cause:** The 6 s post-tone hold anchored its window to the tone-*detection* instant (`_toneHoldUntil = detection + 6s`). Detection fires *during* the tone (1 s into a single/long tone; end of tone B for two-tone). For the long tones fire depts use, the remaining tone duration consumes most of the window, so by the time the tone ends the hold has expired and the recording finalizes at the normal 2 s tail — the voice keys up as a separate transmission.

**Fix:** Gate the hold on "a tone was detected for this (not-yet-finalized) transmission" (`_lastDetectedTone != null`) instead of the fixed wall-clock. The stop timer is re-armed on every audio chunk, so the hold is now measured from the last audio — i.e. from when the tone actually ends — bridging up to `ToneHoldMs` (6 s) of pause into the same recording. `_lastDetectedTone` is already cleared on finalize and on `StopDecoding`, so the hold ends normally.

## Verification
- Client: `npm run lint` + `tsc --noEmit` pass; popping gone on localhost.
- Server: `dotnet build` clean; ToneDetector/Events tests pass (8/8).
- Tone-out merge needs a real over-the-air (or mock) tone-then-voice check on hardware to confirm end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)