### PR TITLE
Transcription accuracy, System Debug page, and backfill

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import ChannelManager from './components/ChannelManager';
 import FireToneManager from './components/FireToneManager';
 import SettingsManager from './components/SettingsManager';
 import RfDebugDialog from './components/RfDebugDialog';
+import SystemDebugDialog from './components/SystemDebugDialog';
 import NowPlayingBar from './components/NowPlayingBar';
 import CommandPalette from './components/CommandPalette';
 import { useAudioPipeline } from './hooks/useAudioPipeline';
@@ -28,6 +29,7 @@ function App() {
   const [isToneManagerOpen, setIsToneManagerOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isDebugModalOpen, setIsDebugModalOpen] = useState(false);
+  const [isSystemDebugOpen, setIsSystemDebugOpen] = useState(false);
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const [debugFreq, setDebugFreq] = useState<string>('155.500');
   const [debugGain, setDebugGain] = useState<number>(40);
@@ -191,7 +193,7 @@ function App() {
           onOpenFireTones={() => setIsToneManagerOpen(true)}
           onOpenSettings={() => setIsSettingsOpen(true)}
           onOpenDebug={openDebug}
-          onDownloadSupport={downloadSupportPackage}
+          onOpenSystemDebug={() => setIsSystemDebugOpen(true)}
         />
 
         <Box sx={{ flexGrow: 1, p: { xs: 1, sm: 2 }, height: '100%', overflowY: { xs: 'auto', md: 'hidden' } }}>
@@ -300,6 +302,12 @@ function App() {
           debugGain={debugGain}
           onDebugGainChange={setDebugGain}
           onTune={() => scanner.sendCommand('debug_spectrum', Number(debugFreq), debugGain)}
+        />
+
+        <SystemDebugDialog
+          open={isSystemDebugOpen}
+          onClose={() => setIsSystemDebugOpen(false)}
+          onDownloadSupport={downloadSupportPackage}
         />
 
         <Snackbar open={showAudioPrompt} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -156,6 +156,15 @@ function App() {
     [scanner.radioEvents],
   );
 
+  // Recording id → transcription for the fire tone-out event log. Value is null
+  // while the recording is present but its transcription hasn't streamed in yet,
+  // so EventLog can show a "Transcribing…" placeholder until it arrives.
+  const eventTranscriptions = useMemo(() => {
+    const map = new Map<string, string | null>();
+    for (const log of scanner.callLog) map.set(log.id, log.transcription ?? null);
+    return map;
+  }, [scanner.callLog]);
+
   return (
       <Box sx={{
         display: 'flex', flexDirection: 'column', height: '100vh', width: '100vw',
@@ -224,6 +233,7 @@ function App() {
                 {scanner.fireTones.length > 0 && (
                   <EventLog
                     events={scanner.radioEvents}
+                    transcriptions={eventTranscriptions}
                     onClear={scanner.clearEvents}
                     onEventClick={(e) => {
                       if (e.transmissionId) {

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -13,7 +13,7 @@ import UsbOffIcon from '@mui/icons-material/UsbOff';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
-import SupportAgentIcon from '@mui/icons-material/SupportAgent';
+import BugReportIcon from '@mui/icons-material/BugReport';
 import SettingsIcon from '@mui/icons-material/Settings';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import MonitorIcon from '@mui/icons-material/Monitor';
@@ -33,7 +33,7 @@ interface Props {
   onOpenFireTones: () => void;
   onOpenSettings: () => void;
   onOpenDebug: () => void;
-  onDownloadSupport: () => void;
+  onOpenSystemDebug: () => void;
 }
 
 const MONO = '"Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -41,7 +41,7 @@ const gpsMono = { fontFamily: MONO, color: 'text.primary' } as const;
 
 const AppHeader: React.FC<Props> = ({
   scannerState, currentTime, volume, onVolumeChange, manualHold, onResume,
-  isFullscreen, onToggleFullscreen, onOpenFireTones, onOpenSettings, onOpenDebug, onDownloadSupport,
+  isFullscreen, onToggleFullscreen, onOpenFireTones, onOpenSettings, onOpenDebug, onOpenSystemDebug,
 }) => {
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const gps = scannerState.gps;
@@ -53,7 +53,7 @@ const AppHeader: React.FC<Props> = ({
     { label: 'Settings', icon: <SettingsIcon />, onClick: onOpenSettings },
     { label: isFullscreen ? 'Exit Fullscreen' : 'Fullscreen', icon: isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />, onClick: onToggleFullscreen },
     { label: 'RF Spectrum Debug', icon: <MonitorIcon />, onClick: onOpenDebug },
-    { label: 'Download Support Package', icon: <SupportAgentIcon />, onClick: onDownloadSupport },
+    { label: 'System Debug', icon: <BugReportIcon />, onClick: onOpenSystemDebug },
   ];
 
   return (

--- a/client/src/components/EventLog.tsx
+++ b/client/src/components/EventLog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Box, Typography, IconButton, Collapse, List, ListItemButton, Tooltip, ButtonBase } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
@@ -6,7 +6,7 @@ import DeleteSweepIcon from '@mui/icons-material/DeleteSweep';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import LaunchIcon from '@mui/icons-material/Launch';
-import type { RadioEvent } from '../types';
+import type { CallLog, RadioEvent } from '../types';
 import { status } from '../theme/tokens';
 import EmptyState from './common/EmptyState';
 
@@ -31,6 +31,36 @@ const formatDetail = (e: RadioEvent): string => {
 
 export default function EventLog({ events, onClear, onEventClick, transcriptions }: EventLogProps) {
     const [open, setOpen] = useState(true);
+
+    // Transcriptions for older tone-outs whose recording has scrolled out of the
+    // live window: fetched on demand by recording id (null = fetched, no text).
+    // Mirrors TransmissionLog's linked-recording fetch — setState happens only in
+    // the async callback, never synchronously in the effect.
+    const [fetched, setFetched] = useState<Map<string, string | null>>(new Map());
+    const attempted = useRef<Set<string>>(new Set());
+
+    useEffect(() => {
+        const missing = events
+            .map(e => e.transmissionId)
+            .filter((id): id is string => !!id && !transcriptions?.has(id) && !attempted.current.has(id));
+        if (missing.length === 0) return;
+        let cancelled = false;
+        for (const id of missing) {
+            attempted.current.add(id);
+            fetch(`/api/history/entry/${encodeURIComponent(id)}`)
+                .then(res => (res.ok ? res.json() : null))
+                .then((data: CallLog | null) => {
+                    if (cancelled) return;
+                    setFetched(prev => {
+                        const next = new Map(prev);
+                        next.set(id, data?.transcription ?? null);
+                        return next;
+                    });
+                })
+                .catch(() => { /* leave unfetched; row simply shows no transcription */ });
+        }
+        return () => { cancelled = true; };
+    }, [events, transcriptions]);
 
     return (
         <Box sx={{ borderBottom: '1px solid', borderColor: 'surface.border', flexShrink: 0 }}>
@@ -68,8 +98,13 @@ export default function EventLog({ events, onClear, onEventClick, transcriptions
                     <List dense disablePadding sx={{ maxHeight: 200, overflowY: 'auto' }}>
                         {events.map(e => {
                             const clickable = !!e.transmissionId && !!onEventClick;
-                            const transcription = e.transmissionId ? transcriptions?.get(e.transmissionId) : undefined;
-                            const pending = !transcription && !!e.transmissionId && !!transcriptions?.has(e.transmissionId);
+                            const inLiveWindow = !!e.transmissionId && !!transcriptions?.has(e.transmissionId);
+                            const transcription = e.transmissionId
+                                ? (transcriptions?.get(e.transmissionId) ?? fetched.get(e.transmissionId) ?? undefined)
+                                : undefined;
+                            // Only recent (live-window) recordings show a "Transcribing…" state;
+                            // an older fetched recording with no text just renders nothing.
+                            const pending = !transcription && inLiveWindow;
                             return (
                                 <ListItemButton
                                     key={e.id}

--- a/client/src/components/EventLog.tsx
+++ b/client/src/components/EventLog.tsx
@@ -14,6 +14,13 @@ interface EventLogProps {
     events: RadioEvent[];
     onClear: () => void;
     onEventClick?: (event: RadioEvent) => void;
+    /**
+     * Lookup of a tone-out's recording id → its transcription. A present key with a
+     * null value means the recording exists but isn't transcribed yet (shows a
+     * "Transcribing…" placeholder); a missing key means the recording isn't in the
+     * recent window so no transcription is shown.
+     */
+    transcriptions?: Map<string, string | null>;
 }
 
 const formatDetail = (e: RadioEvent): string => {
@@ -22,7 +29,7 @@ const formatDetail = (e: RadioEvent): string => {
     return '';
 };
 
-export default function EventLog({ events, onClear, onEventClick }: EventLogProps) {
+export default function EventLog({ events, onClear, onEventClick, transcriptions }: EventLogProps) {
     const [open, setOpen] = useState(true);
 
     return (
@@ -61,6 +68,8 @@ export default function EventLog({ events, onClear, onEventClick }: EventLogProp
                     <List dense disablePadding sx={{ maxHeight: 200, overflowY: 'auto' }}>
                         {events.map(e => {
                             const clickable = !!e.transmissionId && !!onEventClick;
+                            const transcription = e.transmissionId ? transcriptions?.get(e.transmissionId) : undefined;
+                            const pending = !transcription && !!e.transmissionId && !!transcriptions?.has(e.transmissionId);
                             return (
                                 <ListItemButton
                                     key={e.id}
@@ -92,6 +101,19 @@ export default function EventLog({ events, onClear, onEventClick }: EventLogProp
                                                 {formatDetail(e)}
                                                 {e.alphaTag ? ` · ${e.alphaTag}` : e.frequency ? ` · ${e.frequency.toFixed(4)} MHz` : ''}
                                             </Typography>
+                                            {transcription ? (
+                                                <Typography
+                                                    sx={{ color: 'text.secondary', fontStyle: 'italic', fontSize: '0.7rem', lineHeight: 1.25, mt: 0.25 }}
+                                                    noWrap
+                                                    title={transcription}
+                                                >
+                                                    “{transcription}”
+                                                </Typography>
+                                            ) : pending ? (
+                                                <Typography sx={{ color: 'text.disabled', fontStyle: 'italic', fontSize: '0.7rem', lineHeight: 1.25, mt: 0.25 }}>
+                                                    Transcribing…
+                                                </Typography>
+                                            ) : null}
                                         </Box>
                                         {clickable && <LaunchIcon sx={{ color: alpha(status.warn, 0.6), fontSize: 14, flexShrink: 0 }} />}
                                         <Typography sx={{ color: 'text.disabled', fontSize: '0.7rem', flexShrink: 0 }}>

--- a/client/src/components/SettingsManager.tsx
+++ b/client/src/components/SettingsManager.tsx
@@ -232,6 +232,7 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
             onClose={onClose}
             title="System Settings"
             icon={<SettingsIcon />}
+            maxWidth="md"
             actions={<Button onClick={onClose} color="inherit">Close</Button>}
         >
                 {updateAvailable && (

--- a/client/src/components/SettingsManager.tsx
+++ b/client/src/components/SettingsManager.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import {
     Button, Switch,
     Box, CircularProgress, Alert, AlertTitle, Link, TextField,
-    Typography, LinearProgress,
+    Typography, LinearProgress, Select, MenuItem,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
@@ -29,6 +29,29 @@ const formatBytes = (bytes: number): string => {
     const units = ['B', 'KB', 'MB', 'GB', 'TB'];
     const i = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
     return `${(bytes / Math.pow(1024, i)).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+
+// Whisper models offered in the UI. Larger = more accurate but slower on a Pi.
+const TRANSCRIPTION_MODELS: { value: string; label: string }[] = [
+    { value: 'large-v3-turbo-q5_0', label: 'Large v3 Turbo (q5) — most accurate, recommended' },
+    { value: 'large-v3-turbo', label: 'Large v3 Turbo — most accurate, larger' },
+    { value: 'medium.en', label: 'Medium (English) — accurate' },
+    { value: 'small.en', label: 'Small (English) — balanced' },
+    { value: 'base.en', label: 'Base (English) — fast' },
+    { value: 'tiny.en', label: 'Tiny (English) — fastest' },
+];
+
+// Format the raw TranscriptionModelStatus setting (e.g. "downloading:small.en",
+// "ready:small.en", "error: ...") into { text, downloading }.
+const parseModelStatus = (raw?: string): { text: string; downloading: boolean } => {
+    if (!raw) return { text: '', downloading: false };
+    if (raw.startsWith('downloading')) {
+        const m = raw.split(':')[1];
+        return { text: `Downloading${m ? ` ${m}` : ''}…`, downloading: true };
+    }
+    if (raw.startsWith('ready')) return { text: 'Ready', downloading: false };
+    if (raw.startsWith('error')) return { text: raw, downloading: false };
+    return { text: raw, downloading: false };
 };
 
 // A titled, bordered settings section (card).
@@ -69,6 +92,14 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
             fetchStorage();
         }
     }, [open]);
+
+    // While a model download is in progress, poll settings so the status updates.
+    const modelDownloading = parseModelStatus(settings['TranscriptionModelStatus']).downloading;
+    useEffect(() => {
+        if (!open || !modelDownloading) return;
+        const id = setInterval(fetchSettings, 3000);
+        return () => clearInterval(id);
+    }, [open, modelDownloading]);
 
     const fetchStorage = async () => {
         try {
@@ -246,22 +277,63 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
                                 />
                             ))}
                             {settings['EnableTranscription'] === 'true' && (
-                                <Row
-                                    label="Transcription Threads"
-                                    description={`Number of recordings transcribed at once. With a large model, 1 is recommended (each run already uses all cores). CPU cores: ${systemInfo.CpuCores || 'Unknown'}`}
-                                    control={
-                                        <TextField
-                                            type="number"
-                                            size="small"
-                                            variant="outlined"
-                                            style={{ width: '80px', minWidth: '80px' }}
-                                            value={settings['TranscriptionThreads'] || ''}
-                                            inputProps={{ min: 1, max: 32 }}
-                                            onChange={(e) => handleValueChange('TranscriptionThreads', e.target.value)}
-                                        />
-                                    }
-                                />
+                                <>
+                                    <Row
+                                        label="Model"
+                                        description={(() => {
+                                            const s = parseModelStatus(settings['TranscriptionModelStatus']);
+                                            return s.text
+                                                ? `Larger models are more accurate but slower on a Pi. Status: ${s.text}`
+                                                : 'Larger models are more accurate but slower on a Pi. Downloaded automatically when changed.';
+                                        })()}
+                                        control={
+                                            <Select
+                                                size="small"
+                                                variant="outlined"
+                                                style={{ minWidth: 260 }}
+                                                value={settings['TranscriptionModel'] || 'large-v3-turbo-q5_0'}
+                                                onChange={(e) => handleValueChange('TranscriptionModel', e.target.value)}
+                                            >
+                                                {TRANSCRIPTION_MODELS.map((m) => (
+                                                    <MenuItem key={m.value} value={m.value}>{m.label}</MenuItem>
+                                                ))}
+                                            </Select>
+                                        }
+                                    />
+                                    <Row
+                                        label="Transcription Threads"
+                                        description={`Number of recordings transcribed at once. With a large model, 1 is recommended (each run already uses all cores). CPU cores: ${systemInfo.CpuCores || 'Unknown'}`}
+                                        control={
+                                            <TextField
+                                                type="number"
+                                                size="small"
+                                                variant="outlined"
+                                                style={{ width: '80px', minWidth: '80px' }}
+                                                value={settings['TranscriptionThreads'] || ''}
+                                                inputProps={{ min: 1, max: 32 }}
+                                                onChange={(e) => handleValueChange('TranscriptionThreads', e.target.value)}
+                                            />
+                                        }
+                                    />
+                                </>
                             )}
+                        </Section>
+
+                        <Section title="Integrations">
+                            <Row
+                                label="PowerDMS Department"
+                                description="Public PowerDMS department slug for daily-log links. Leave blank to disable."
+                                control={
+                                    <TextField
+                                        size="small"
+                                        variant="outlined"
+                                        placeholder="e.g. mytown-pd"
+                                        style={{ width: '180px' }}
+                                        value={settings['PowerDmsDepartment'] || ''}
+                                        onChange={(e) => handleValueChange('PowerDmsDepartment', e.target.value)}
+                                    />
+                                }
+                            />
                         </Section>
 
                         <Section title="Storage">

--- a/client/src/components/SettingsManager.tsx
+++ b/client/src/components/SettingsManager.tsx
@@ -248,7 +248,7 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
                             {settings['EnableTranscription'] === 'true' && (
                                 <Row
                                     label="Transcription Threads"
-                                    description={`Parallel threads for AI transcription. CPU cores: ${systemInfo.CpuCores || 'Unknown'}`}
+                                    description={`Number of recordings transcribed at once. With a large model, 1 is recommended (each run already uses all cores). CPU cores: ${systemInfo.CpuCores || 'Unknown'}`}
                                     control={
                                         <TextField
                                             type="number"

--- a/client/src/components/SystemDebugDialog.tsx
+++ b/client/src/components/SystemDebugDialog.tsx
@@ -1,0 +1,596 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box, Typography, Button, Paper, Grid, CircularProgress, Tooltip,
+} from '@mui/material';
+import { useTheme } from '@mui/material/styles';
+import BugReportIcon from '@mui/icons-material/BugReport';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import SupportAgentIcon from '@mui/icons-material/SupportAgent';
+import FormDialog from './common/FormDialog';
+import StatusChip from './common/StatusChip';
+import type { StatusTone } from './common/StatusChip';
+import { apiFetch, apiJson } from './common/apiBase';
+
+interface TranscriptionQueueStatus { queued: number; workers: number; }
+interface SystemStats {
+  cpuPercent: number;
+  memPercent: number;
+  memUsedMb: number;
+  memTotalMb: number;
+  transcription: TranscriptionQueueStatus;
+}
+interface ServiceStatus { name: string; state: string; detail: string; }
+interface ListeningPort { protocol: string; port: number; process: string; }
+interface ServicesSnapshot { services: ServiceStatus[]; ports: ListeningPort[]; }
+
+interface GpsLocation {
+  lat: number; lon: number; alt: number; speed: number;
+  time: string; fix: number; sats: number; satsVisible: number; hdop?: number | null;
+}
+interface DiagnosticsSnapshot {
+  uptime: string;
+  scanner: {
+    status: string; hardwareConnected: boolean; frequency?: number | null;
+    signalDb?: number | null; signalStrength: number; gain?: number | null;
+    squelch?: number | null; audioStreaming: boolean;
+  };
+  gps: { gpsdConnected: boolean; secondsSinceFix?: number | null; location: GpsLocation | null };
+  database: { totalRecordings: number; transcribed: number; pending: number; oldestUtc?: string | null; newestUtc?: string | null };
+  connections: { controlClients: number; audioClients: number };
+  recording: { activeCount: number; activeIds: string[] };
+  radio: { restartCount: number; throughputKbps: number };
+  cleanup: { lastRunUtc?: string | null; lastFreeBytes?: number | null; totalPurged: number };
+  transcriptionModelStatus?: string | null;
+}
+interface StorageInfo {
+  recordingsBytes: number; recordingsCount: number; databaseBytes: number;
+  diskFreeBytes: number; diskTotalBytes: number;
+}
+type SystemInfo = Record<string, string>;
+
+// Byte / time formatting helpers.
+const fmtBytes = (n: number): string => {
+  if (!n || n < 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.min(units.length - 1, Math.floor(Math.log(n) / Math.log(1024)));
+  return `${(n / 1024 ** i).toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+};
+const fmtAge = (sec?: number | null): string => {
+  if (sec == null) return '—';
+  if (sec < 90) return `${Math.round(sec)}s ago`;
+  if (sec < 5400) return `${Math.round(sec / 60)}m ago`;
+  return `${Math.round(sec / 3600)}h ago`;
+};
+const fmtTs = (iso?: string | null): string => {
+  if (!iso) return '—';
+  const d = new Date(iso.includes('T') || iso.includes('Z') ? iso : iso.replace(' ', 'T') + 'Z');
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString([], { hour12: false });
+};
+const FIX_LABEL = ['No fix', 'No fix', '2D fix', '3D fix'];
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onDownloadSupport: () => void;
+}
+
+const MONO = '"Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
+
+// How many one-second samples to retain — the graphs cover the last 120 seconds.
+const WINDOW = 120;
+
+interface Sample { t: number; cpu: number; mem: number; }
+
+/**
+ * Single-series area+line chart over the last WINDOW seconds with a fixed 0-100%
+ * y-domain and a hover crosshair. Text uses ink tokens; only the mark is colored.
+ */
+const ResourceGraph: React.FC<{
+  label: string;
+  color: string;
+  samples: Sample[];
+  value: (s: Sample) => number;
+  currentText: string;
+}> = ({ label, color, samples, value, currentText }) => {
+  const theme = useTheme();
+  const W = 520;
+  const H = 140;
+  const padL = 34;
+  const padR = 8;
+  const padT = 10;
+  const padB = 16;
+  const plotW = W - padL - padR;
+  const plotH = H - padT - padB;
+
+  const [hover, setHover] = useState<number | null>(null);
+
+  // Map a sample index to an x coordinate. The window is right-aligned so the
+  // newest sample sits at the right edge even before the buffer is full.
+  const x = (i: number) => padL + plotW * (i - (samples.length - WINDOW)) / (WINDOW - 1);
+  const y = (v: number) => padT + plotH * (1 - Math.max(0, Math.min(100, v)) / 100);
+
+  const linePath = samples.map((s, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${y(value(s)).toFixed(1)}`).join(' ');
+  const areaPath = samples.length
+    ? `${linePath} L${x(samples.length - 1).toFixed(1)},${(padT + plotH).toFixed(1)} L${x(0).toFixed(1)},${(padT + plotH).toFixed(1)} Z`
+    : '';
+
+  const gridColor = theme.palette.surface.border;
+  const inkMuted = theme.palette.text.secondary;
+
+  const onMove = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const px = (e.clientX - rect.left) / rect.width * W;
+    if (px < padL || px > W - padR || samples.length === 0) { setHover(null); return; }
+    const frac = (px - padL) / plotW;
+    const idx = Math.round((samples.length - WINDOW) + frac * (WINDOW - 1));
+    setHover(Math.max(0, Math.min(samples.length - 1, idx)));
+  }, [samples.length, plotW]);
+
+  const hoverSample = hover != null ? samples[hover] : undefined;
+
+  return (
+    <Box>
+      <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', mb: 0.5 }}>
+        <Typography variant="caption" sx={{ color: inkMuted, fontWeight: 700, letterSpacing: 0.5, textTransform: 'uppercase' }}>
+          {label}
+        </Typography>
+        <Typography variant="body2" sx={{ fontFamily: MONO, color: 'text.primary', fontWeight: 700 }}>
+          {currentText}
+        </Typography>
+      </Box>
+      <Box
+        component="svg"
+        viewBox={`0 0 ${W} ${H}`}
+        onMouseMove={onMove}
+        onMouseLeave={() => setHover(null)}
+        sx={{ width: '100%', height: 'auto', display: 'block' }}
+      >
+        {[0, 25, 50, 75, 100].map((g) => (
+          <g key={g}>
+            <line x1={padL} x2={W - padR} y1={y(g)} y2={y(g)} stroke={gridColor} strokeWidth={1} opacity={0.5} />
+            <text x={padL - 6} y={y(g) + 3} textAnchor="end" fontSize={9} fill={inkMuted} fontFamily={MONO}>{g}</text>
+          </g>
+        ))}
+        {areaPath && <path d={areaPath} fill={color} opacity={0.14} />}
+        {linePath && <path d={linePath} fill="none" stroke={color} strokeWidth={2} strokeLinejoin="round" strokeLinecap="round" />}
+        {hoverSample && (
+          <g>
+            <line x1={x(hover!)} x2={x(hover!)} y1={padT} y2={padT + plotH} stroke={inkMuted} strokeWidth={1} opacity={0.6} />
+            <circle cx={x(hover!)} cy={y(value(hoverSample))} r={3.5} fill={color} stroke={theme.palette.background.paper} strokeWidth={1.5} />
+            <text
+              x={Math.min(x(hover!) + 6, W - padR - 40)}
+              y={padT + 10}
+              fontSize={10}
+              fontFamily={MONO}
+              fill={theme.palette.text.primary}
+            >
+              {value(hoverSample).toFixed(0)}%
+            </text>
+          </g>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+const serviceTone = (state: string): StatusTone => {
+  const s = state.toLowerCase();
+  if (s.startsWith('active') || s.includes('running')) return 'success';
+  if (s.startsWith('activating') || s.includes('reload')) return 'warn';
+  if (s.startsWith('failed')) return 'error';
+  return 'muted';
+};
+
+const modelStatusTone = (status?: string | null): StatusTone => {
+  if (!status) return 'muted';
+  if (status.startsWith('ready')) return 'success';
+  if (status.startsWith('downloading')) return 'warn';
+  if (status.startsWith('error')) return 'error';
+  return 'muted';
+};
+
+// A label + mono value row used across the diagnostic panels.
+const StatRow: React.FC<{ label: string; value: React.ReactNode; title?: string }> = ({ label, value, title }) => (
+  <Box sx={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', gap: 2, minWidth: 0 }}>
+    <Typography variant="caption" color="text.secondary" sx={{ flexShrink: 0 }}>{label}</Typography>
+    <Tooltip title={title ?? ''} disableHoverListener={!title}>
+      <Typography variant="body2" sx={{ fontFamily: MONO, fontWeight: 600, textAlign: 'right', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+        {value}
+      </Typography>
+    </Tooltip>
+  </Box>
+);
+
+// Horizontal usage bar (0-1 fraction). Turns amber/red as it fills.
+const UsageBar: React.FC<{ fraction: number }> = ({ fraction }) => {
+  const theme = useTheme();
+  const f = Math.max(0, Math.min(1, fraction));
+  const color = f > 0.9 ? theme.palette.statusColors.error
+    : f > 0.75 ? theme.palette.statusColors.warn
+    : theme.palette.primary.main;
+  return (
+    <Box sx={{ height: 8, borderRadius: 999, bgcolor: 'surface.border', overflow: 'hidden' }}>
+      <Box sx={{ height: '100%', width: `${f * 100}%`, bgcolor: color, transition: 'width 0.4s' }} />
+    </Box>
+  );
+};
+
+const PanelTitle: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 700 }}>{children}</Typography>
+);
+
+const SystemDebugDialog: React.FC<Props> = ({ open, onClose, onDownloadSupport }) => {
+  const [samples, setSamples] = useState<Sample[]>([]);
+  const [stats, setStats] = useState<SystemStats | null>(null);
+  const [services, setServices] = useState<ServicesSnapshot | null>(null);
+  const [diag, setDiag] = useState<DiagnosticsSnapshot | null>(null);
+  const [storage, setStorage] = useState<StorageInfo | null>(null);
+  const [info, setInfo] = useState<SystemInfo | null>(null);
+  const [logs, setLogs] = useState<string>('');
+  const [logsLoading, setLogsLoading] = useState(false);
+  const theme = useTheme();
+
+  const logBoxRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchLogs = useCallback(async () => {
+    setLogsLoading(true);
+    try {
+      const res = await apiFetch('/api/system/logs?lines=500');
+      const text = res.ok ? await res.text() : 'Failed to load logs.';
+      setLogs(text || '(no log output)');
+    } catch {
+      setLogs('Failed to load logs.');
+    } finally {
+      setLogsLoading(false);
+    }
+  }, []);
+
+  // Poll resource stats once per second while the dialog is open, keeping a
+  // rolling WINDOW-second buffer that drives the graphs and the queue readout.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const poll = async () => {
+      const s = await apiJson<SystemStats>('/api/system/stats');
+      if (cancelled || !s) return;
+      setStats(s);
+      setSamples((prev) => {
+        const next = [...prev, { t: Date.now(), cpu: s.cpuPercent, mem: s.memPercent }];
+        return next.length > WINDOW ? next.slice(next.length - WINDOW) : next;
+      });
+    };
+    poll();
+    const id = setInterval(poll, 1000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [open]);
+
+  // Services/ports refresh less often; they change rarely.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const poll = async () => {
+      const s = await apiJson<ServicesSnapshot>('/api/system/services');
+      if (!cancelled && s) setServices(s);
+    };
+    poll();
+    const id = setInterval(poll, 5000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [open]);
+
+  // Composite diagnostics (scanner/GPS/DB/connections/recording/reliability) — ~2s.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const poll = async () => {
+      const d = await apiJson<DiagnosticsSnapshot>('/api/system/diagnostics');
+      if (!cancelled && d) setDiag(d);
+    };
+    poll();
+    const id = setInterval(poll, 2000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [open]);
+
+  // Storage refreshes slowly; it's disk-bound to compute.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const poll = async () => {
+      const s = await apiJson<StorageInfo>('/api/system/storage');
+      if (!cancelled && s) setStorage(s);
+    };
+    poll();
+    const id = setInterval(poll, 15000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [open]);
+
+  // Reset the graph buffer, load one-shot build info, and (re)load logs on open.
+  useEffect(() => {
+    if (!open) return;
+    setSamples([]);
+    setStats(null);
+    apiJson<SystemInfo>('/api/system/info').then((i) => { if (i) setInfo(i); });
+    fetchLogs();
+  }, [open, fetchLogs]);
+
+  // Keep the log view pinned to the newest lines when they update.
+  useEffect(() => {
+    const el = logBoxRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [logs]);
+
+  const queue = stats?.transcription;
+  const cpuText = stats ? `${stats.cpuPercent.toFixed(0)}%` : '—';
+  const memText = stats
+    ? `${stats.memPercent.toFixed(0)}%  (${stats.memUsedMb}/${stats.memTotalMb} MB)`
+    : '—';
+
+  const cpuColor = theme.palette.primary.main;
+  const memColor = theme.palette.statusColors.info;
+
+  const sortedPorts = useMemo(() => services?.ports ?? [], [services]);
+
+  return (
+    <FormDialog
+      open={open}
+      onClose={onClose}
+      title="System Debug"
+      icon={<BugReportIcon />}
+      maxWidth="lg"
+      actions={(
+        <>
+          <Button
+            onClick={onDownloadSupport}
+            variant="contained"
+            color="primary"
+            startIcon={<SupportAgentIcon />}
+          >
+            Download Support Package
+          </Button>
+          <Button onClick={onClose} color="inherit">Close</Button>
+        </>
+      )}
+    >
+      <Grid container spacing={2}>
+        {/* Resource graphs */}
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base', height: '100%' }}>
+            <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 700 }}>Resources · last {WINDOW}s</Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <ResourceGraph label="CPU" color={cpuColor} samples={samples} value={(s) => s.cpu} currentText={cpuText} />
+              <ResourceGraph label="Memory" color={memColor} samples={samples} value={(s) => s.mem} currentText={memText} />
+            </Box>
+          </Paper>
+        </Grid>
+
+        {/* Services + transcription queue */}
+        <Grid size={{ xs: 12, md: 6 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
+            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base' }}>
+              <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 700 }}>Transcription Queue</Typography>
+              {queue ? (
+                <Box sx={{ display: 'flex', gap: 3 }}>
+                  <Box>
+                    <Typography variant="h4" sx={{ fontFamily: MONO, fontWeight: 700, lineHeight: 1 }}>{queue.queued}</Typography>
+                    <Typography variant="caption" color="text.secondary">queued clips</Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="h4" sx={{ fontFamily: MONO, fontWeight: 700, lineHeight: 1 }}>{queue.workers}</Typography>
+                    <Typography variant="caption" color="text.secondary">active workers</Typography>
+                  </Box>
+                </Box>
+              ) : (
+                <CircularProgress size={18} />
+              )}
+            </Paper>
+
+            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base' }}>
+              <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 700 }}>Services</Typography>
+              {services ? (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+                  {services.services.map((svc) => (
+                    <Box key={svc.name} sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+                      <StatusChip label={svc.state} tone={serviceTone(svc.state)} variant="filled" sx={{ fontSize: 10, minWidth: 96 }} />
+                      <Tooltip title={svc.detail}>
+                        <Typography variant="body2" sx={{ fontFamily: MONO, fontWeight: 700 }}>{svc.name}</Typography>
+                      </Tooltip>
+                    </Box>
+                  ))}
+                </Box>
+              ) : (
+                <CircularProgress size={18} />
+              )}
+            </Paper>
+
+            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base', flexGrow: 1 }}>
+              <Typography variant="subtitle2" sx={{ mb: 1.5, fontWeight: 700 }}>Listening Ports</Typography>
+              {services ? (
+                sortedPorts.length ? (
+                  <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                    {sortedPorts.map((p) => (
+                      <Tooltip key={`${p.protocol}-${p.port}`} title={p.process || 'unknown process'}>
+                        <Box sx={{
+                          px: 1.25, py: 0.5, borderRadius: 1, border: '1px solid', borderColor: 'surface.border',
+                          fontFamily: MONO, fontSize: 12, display: 'flex', gap: 0.75, alignItems: 'baseline',
+                        }}>
+                          <Box component="span" sx={{ color: 'primary.main', fontWeight: 700 }}>{p.port}</Box>
+                          <Box component="span" sx={{ color: 'text.secondary' }}>{p.process || p.protocol}</Box>
+                        </Box>
+                      </Tooltip>
+                    ))}
+                  </Box>
+                ) : (
+                  <Typography variant="caption" color="text.secondary">No listening ports detected.</Typography>
+                )
+              ) : (
+                <CircularProgress size={18} />
+              )}
+            </Paper>
+          </Box>
+        </Grid>
+
+        {/* SDR / Scanner */}
+        <Grid size={{ xs: 12, md: 4 }}>
+          <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base', height: '100%' }}>
+            <PanelTitle>SDR / Scanner</PanelTitle>
+            {diag ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                  <StatusChip
+                    label={diag.scanner.hardwareConnected ? 'SDR READY' : 'DISCONNECTED'}
+                    tone={diag.scanner.hardwareConnected ? 'success' : 'error'}
+                    variant="filled"
+                    sx={{ fontSize: 10 }}
+                  />
+                  <StatusChip label={diag.scanner.status} tone="info" sx={{ fontSize: 10 }} />
+                </Box>
+                <StatRow label="Frequency" value={diag.scanner.frequency != null ? `${diag.scanner.frequency.toFixed(4)} MHz` : '—'} />
+                <StatRow label="Signal" value={diag.scanner.signalDb != null ? `${diag.scanner.signalDb.toFixed(1)} dB` : '—'} />
+                <Box sx={{ my: 0.5 }}><UsageBar fraction={diag.scanner.signalStrength / 100} /></Box>
+                <StatRow label="Gain" value={diag.scanner.gain != null ? (diag.scanner.gain === 0 ? 'AUTO' : `${diag.scanner.gain} dB`) : '—'} />
+                <StatRow label="Squelch" value={diag.scanner.squelch != null ? `${diag.scanner.squelch.toFixed(1)} dB` : '—'} />
+                <StatRow label="Audio" value={diag.scanner.audioStreaming ? 'streaming' : 'idle'} />
+                <StatRow label="Throughput" value={`${diag.radio.throughputKbps.toFixed(1)} KB/s`} />
+                <StatRow label="SDR restarts" value={diag.radio.restartCount} title="Capture watchdog restarts since startup" />
+              </Box>
+            ) : <CircularProgress size={18} />}
+          </Paper>
+        </Grid>
+
+        {/* GPS */}
+        <Grid size={{ xs: 12, md: 4 }}>
+          <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base', height: '100%' }}>
+            <PanelTitle>GPS</PanelTitle>
+            {diag ? (
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 0.5 }}>
+                  <StatusChip
+                    label={diag.gps.gpsdConnected ? 'GPSD UP' : 'GPSD DOWN'}
+                    tone={diag.gps.gpsdConnected ? 'success' : 'muted'}
+                    variant="filled"
+                    sx={{ fontSize: 10 }}
+                  />
+                  <StatusChip
+                    label={FIX_LABEL[diag.gps.location?.fix ?? 0] ?? 'No fix'}
+                    tone={(diag.gps.location?.fix ?? 0) >= 2 ? 'success' : 'warn'}
+                    sx={{ fontSize: 10 }}
+                  />
+                </Box>
+                <StatRow label="Satellites" value={diag.gps.location ? `${diag.gps.location.sats}${diag.gps.location.satsVisible ? ` / ${diag.gps.location.satsVisible}` : ''}` : '—'} />
+                <StatRow label="HDOP" value={diag.gps.location?.hdop != null ? diag.gps.location.hdop.toFixed(1) : '—'} />
+                <StatRow label="Lat / Lon" value={diag.gps.location && diag.gps.location.fix >= 2 ? `${diag.gps.location.lat.toFixed(4)}, ${diag.gps.location.lon.toFixed(4)}` : '—'} />
+                <StatRow label="Altitude" value={diag.gps.location && diag.gps.location.fix >= 3 ? `${Math.round(diag.gps.location.alt * 3.28084)} ft` : '—'} />
+                <StatRow label="Speed" value={diag.gps.location && diag.gps.location.fix >= 2 ? `${Math.round(diag.gps.location.speed * 2.23694)} mph` : '—'} />
+                <StatRow label="Last fix" value={fmtAge(diag.gps.secondsSinceFix)} />
+              </Box>
+            ) : <CircularProgress size={18} />}
+          </Paper>
+        </Grid>
+
+        {/* Recordings / DB + Connections */}
+        <Grid size={{ xs: 12, md: 4 }}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, height: '100%' }}>
+            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base' }}>
+              <PanelTitle>Recordings &amp; DB</PanelTitle>
+              {diag ? (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                  <StatRow label="Total recordings" value={diag.database.totalRecordings.toLocaleString()} />
+                  <StatRow label="Transcribed" value={diag.database.transcribed.toLocaleString()} />
+                  <StatRow label="Pending" value={diag.database.pending.toLocaleString()} />
+                  <StatRow label="In-flight" value={diag.recording.activeCount} title={diag.recording.activeIds.join('\n') || undefined} />
+                  <StatRow label="Oldest" value={fmtTs(diag.database.oldestUtc)} />
+                  <StatRow label="Newest" value={fmtTs(diag.database.newestUtc)} />
+                </Box>
+              ) : <CircularProgress size={18} />}
+            </Paper>
+
+            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base' }}>
+              <PanelTitle>Live Connections</PanelTitle>
+              {diag ? (
+                <Box sx={{ display: 'flex', gap: 3 }}>
+                  <Box>
+                    <Typography variant="h4" sx={{ fontFamily: MONO, fontWeight: 700, lineHeight: 1 }}>{diag.connections.controlClients}</Typography>
+                    <Typography variant="caption" color="text.secondary">control</Typography>
+                  </Box>
+                  <Box>
+                    <Typography variant="h4" sx={{ fontFamily: MONO, fontWeight: 700, lineHeight: 1 }}>{diag.connections.audioClients}</Typography>
+                    <Typography variant="caption" color="text.secondary">audio</Typography>
+                  </Box>
+                </Box>
+              ) : <CircularProgress size={18} />}
+            </Paper>
+
+            <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base', flexGrow: 1 }}>
+              <PanelTitle>Storage</PanelTitle>
+              {storage ? (
+                <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.75 }}>
+                  <UsageBar fraction={storage.diskTotalBytes ? (storage.diskTotalBytes - storage.diskFreeBytes) / storage.diskTotalBytes : 0} />
+                  <StatRow label="Disk free" value={`${fmtBytes(storage.diskFreeBytes)} / ${fmtBytes(storage.diskTotalBytes)}`} />
+                  <StatRow label="Recordings" value={`${fmtBytes(storage.recordingsBytes)} · ${storage.recordingsCount.toLocaleString()}`} />
+                  <StatRow label="Database" value={fmtBytes(storage.databaseBytes)} />
+                </Box>
+              ) : <CircularProgress size={18} />}
+            </Paper>
+          </Box>
+        </Grid>
+
+        {/* Health footer: uptime, version, model status, cleanup */}
+        <Grid size={12}>
+          <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base' }}>
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 2, md: 4 }, alignItems: 'center' }}>
+              <StatRow label="Uptime" value={diag?.uptime ?? '—'} />
+              <StatRow label="Version" value={info?.Version ?? '—'} />
+              <StatRow label="Commit" value={info?.Commit ? info.Commit.slice(0, 8) : '—'} title={info?.Commit ?? undefined} />
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <Typography variant="caption" color="text.secondary">Model</Typography>
+                <StatusChip label={diag?.transcriptionModelStatus ?? 'unknown'} tone={modelStatusTone(diag?.transcriptionModelStatus)} sx={{ fontSize: 10 }} />
+              </Box>
+              <StatRow
+                label="Cleanup"
+                value={diag?.cleanup.lastRunUtc
+                  ? `${fmtBytes(diag.cleanup.lastFreeBytes ?? 0)} free · ${diag.cleanup.totalPurged} purged`
+                  : 'not run yet'}
+                title={diag?.cleanup.lastRunUtc ? `Last run ${fmtTs(diag.cleanup.lastRunUtc)}` : undefined}
+              />
+            </Box>
+          </Paper>
+        </Grid>
+
+        {/* Logs */}
+        <Grid size={12}>
+          <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1.5 }}>
+              <Typography variant="subtitle2" sx={{ flexGrow: 1, fontWeight: 700 }}>
+                OpenScanner Logs <Box component="span" sx={{ color: 'text.secondary', fontWeight: 400 }}>(systemd · journalctl -u openscanner)</Box>
+              </Typography>
+              <Button size="small" startIcon={<RefreshIcon />} onClick={fetchLogs} disabled={logsLoading}>
+                Refresh
+              </Button>
+            </Box>
+            <Box
+              ref={logBoxRef}
+              sx={{
+                height: 260,
+                overflow: 'auto',
+                bgcolor: 'background.default',
+                border: '1px solid',
+                borderColor: 'surface.border',
+                borderRadius: 1,
+                p: 1.5,
+                fontFamily: MONO,
+                fontSize: 11.5,
+                lineHeight: 1.5,
+                whiteSpace: 'pre-wrap',
+                wordBreak: 'break-word',
+                color: 'text.secondary',
+              }}
+            >
+              {logsLoading && !logs ? <CircularProgress size={18} /> : logs}
+            </Box>
+          </Paper>
+        </Grid>
+      </Grid>
+    </FormDialog>
+  );
+};
+
+export default SystemDebugDialog;

--- a/client/src/components/SystemDebugDialog.tsx
+++ b/client/src/components/SystemDebugDialog.tsx
@@ -6,6 +6,9 @@ import { useTheme } from '@mui/material/styles';
 import BugReportIcon from '@mui/icons-material/BugReport';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import SupportAgentIcon from '@mui/icons-material/SupportAgent';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import StopIcon from '@mui/icons-material/Stop';
+import HistoryIcon from '@mui/icons-material/History';
 import FormDialog from './common/FormDialog';
 import StatusChip from './common/StatusChip';
 import type { StatusTone } from './common/StatusChip';
@@ -45,6 +48,17 @@ interface DiagnosticsSnapshot {
 interface StorageInfo {
   recordingsBytes: number; recordingsCount: number; databaseBytes: number;
   diskFreeBytes: number; diskTotalBytes: number;
+}
+interface BackfillStatus {
+  running: boolean;
+  total: number;
+  processed: number;
+  succeeded: number;
+  failed: number;
+  current?: string | null;
+  startedUtc?: string | null;
+  finishedUtc?: string | null;
+  message?: string | null;
 }
 type SystemInfo = Record<string, string>;
 
@@ -226,6 +240,8 @@ const SystemDebugDialog: React.FC<Props> = ({ open, onClose, onDownloadSupport }
   const [diag, setDiag] = useState<DiagnosticsSnapshot | null>(null);
   const [storage, setStorage] = useState<StorageInfo | null>(null);
   const [info, setInfo] = useState<SystemInfo | null>(null);
+  const [backfill, setBackfill] = useState<BackfillStatus | null>(null);
+  const [backfillBusy, setBackfillBusy] = useState(false);
   const [logs, setLogs] = useState<string>('');
   const [logsLoading, setLogsLoading] = useState(false);
   const theme = useTheme();
@@ -302,6 +318,29 @@ const SystemDebugDialog: React.FC<Props> = ({ open, onClose, onDownloadSupport }
     const id = setInterval(poll, 15000);
     return () => { cancelled = true; clearInterval(id); };
   }, [open]);
+
+  // Transcription backfill job status.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const poll = async () => {
+      const b = await apiJson<BackfillStatus>('/api/transcription/backfill');
+      if (!cancelled && b) setBackfill(b);
+    };
+    poll();
+    const id = setInterval(poll, 2000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [open]);
+
+  const controlBackfill = useCallback(async (action: 'start' | 'stop') => {
+    setBackfillBusy(true);
+    try {
+      const b = await apiJson<BackfillStatus>(`/api/transcription/backfill/${action}`, { method: 'POST' });
+      if (b) setBackfill(b);
+    } finally {
+      setBackfillBusy(false);
+    }
+  }, []);
 
   // Reset the graph buffer, load one-shot build info, and (re)load logs on open.
   useEffect(() => {
@@ -426,6 +465,61 @@ const SystemDebugDialog: React.FC<Props> = ({ open, onClose, onDownloadSupport }
               )}
             </Paper>
           </Box>
+        </Grid>
+
+        {/* Transcription backfill */}
+        <Grid size={12}>
+          <Paper variant="outlined" sx={{ p: 2, bgcolor: 'surface.base' }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1.5, flexWrap: 'wrap' }}>
+              <HistoryIcon fontSize="small" sx={{ color: 'primary.main' }} />
+              <Typography variant="subtitle2" sx={{ fontWeight: 700 }}>
+                Transcription Backfill <Box component="span" sx={{ color: 'text.secondary', fontWeight: 400 }}>· missing transcriptions, last 24h</Box>
+              </Typography>
+              <Box sx={{ flexGrow: 1 }} />
+              {backfill?.running ? (
+                <StatusChip label="RUNNING" tone="live" variant="filled" sx={{ fontSize: 10 }} />
+              ) : (
+                <StatusChip label="IDLE" tone="muted" sx={{ fontSize: 10 }} />
+              )}
+              <Button
+                size="small"
+                variant="contained"
+                color="primary"
+                startIcon={<PlayArrowIcon />}
+                disabled={backfillBusy || backfill?.running}
+                onClick={() => controlBackfill('start')}
+              >
+                Start
+              </Button>
+              <Button
+                size="small"
+                color="inherit"
+                startIcon={<StopIcon />}
+                disabled={backfillBusy || !backfill?.running}
+                onClick={() => controlBackfill('stop')}
+              >
+                Stop
+              </Button>
+            </Box>
+
+            {backfill && (backfill.running || backfill.total > 0) && (
+              <Box sx={{ mb: 1 }}>
+                <UsageBar fraction={backfill.total > 0 ? backfill.processed / backfill.total : 0} />
+              </Box>
+            )}
+
+            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: { xs: 2, md: 4 }, alignItems: 'baseline' }}>
+              <StatRow label="Progress" value={backfill ? `${backfill.processed} / ${backfill.total}` : '—'} />
+              <StatRow label="Transcribed" value={backfill?.succeeded ?? '—'} />
+              <StatRow label="Failed" value={backfill?.failed ?? '—'} />
+              {backfill?.current && <StatRow label="Current" value={backfill.current} title={backfill.current} />}
+            </Box>
+            {backfill?.message && (
+              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 1 }}>
+                {backfill.message}
+              </Typography>
+            )}
+          </Paper>
         </Grid>
 
         {/* SDR / Scanner */}

--- a/scripts/compress_recordings.sh
+++ b/scripts/compress_recordings.sh
@@ -9,15 +9,20 @@ set -euo pipefail
 # transcodes any leftover *.wav recordings to the same MP3 format, updates the
 # database so playback keeps working, and deletes the original WAV.
 #
+# It converts in parallel (default: one job per CPU core) and applies all
+# database changes in a single transaction, so it scales to tens of thousands
+# of files. While updating the DB it also corrects each row's stored duration
+# (derived from the audio bytes: 48kHz mono 16-bit = 96000 bytes/sec), which
+# fixes older recordings whose duration was recorded as wall-clock time.
+#
 # It is safe to re-run: files already converted are skipped, and a WAV is only
-# deleted after its MP3 exists and (when a matching DB row is present) the
-# database has been updated.
+# deleted after its MP3 exists and the database transaction has committed.
 #
 # Recommended: stop the service first so the database isn't locked:
 #   systemctl --user stop openscanner   # or: sudo systemctl stop openscanner
 #
 # Usage:
-#   scripts/compress_recordings.sh [--dry-run] [--bitrate 32k] [--data-dir PATH]
+#   scripts/compress_recordings.sh [--dry-run] [--jobs N] [--bitrate 32k] [--data-dir PATH]
 # ============================================================================
 
 # Colors
@@ -30,14 +35,18 @@ log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
+cpu_count() { nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4; }
+
 # Defaults
 DRY_RUN=false
 BITRATE="32k"
 DATA_DIR="$PROJECT_ROOT/data"
+JOBS="$(cpu_count)"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=true; shift ;;
+    --jobs) JOBS="$2"; shift 2 ;;
     --bitrate) BITRATE="$2"; shift 2 ;;
     --data-dir) DATA_DIR="$2"; shift 2 ;;
     -h|--help)
@@ -50,129 +59,143 @@ done
 RECORDINGS_DIR="$DATA_DIR/recordings"
 DB_PATH="$DATA_DIR/openscanner.db"
 
+# Raw audio is 48 kHz mono 16-bit PCM.
+RAW_BYTES_PER_SEC=96000
+
 # --- Preconditions ---------------------------------------------------------
-command -v ffmpeg >/dev/null 2>&1 || { log_error "ffmpeg not found on PATH. Install it (e.g. sudo apt install ffmpeg)."; exit 1; }
+command -v ffmpeg  >/dev/null 2>&1 || { log_error "ffmpeg not found on PATH. Install it (e.g. sudo apt install ffmpeg)."; exit 1; }
+command -v sqlite3 >/dev/null 2>&1 || { log_error "sqlite3 not found on PATH. Install it (e.g. sudo apt install sqlite3)."; exit 1; }
 
-HAVE_SQLITE=true
-if ! command -v sqlite3 >/dev/null 2>&1; then
-  HAVE_SQLITE=false
-  log_warn "sqlite3 not found — files will be converted but the database will NOT be updated."
-  log_warn "Install it (sudo apt install sqlite3) and re-run to fix playback links, or the app will 404 on old rows."
-fi
-
-if [ ! -d "$RECORDINGS_DIR" ]; then
-  log_error "Recordings directory not found: $RECORDINGS_DIR"
-  log_error "Pass --data-dir if your data lives elsewhere."
-  exit 1
-fi
-
-if [ "$HAVE_SQLITE" = true ] && [ ! -f "$DB_PATH" ]; then
-  log_warn "Database not found at $DB_PATH — converting files without DB updates."
-  HAVE_SQLITE=false
-fi
+[ -d "$RECORDINGS_DIR" ] || { log_error "Recordings directory not found: $RECORDINGS_DIR (pass --data-dir)"; exit 1; }
+[ -f "$DB_PATH" ]        || { log_error "Database not found: $DB_PATH (pass --data-dir)"; exit 1; }
+[[ "$JOBS" =~ ^[0-9]+$ ]] && [ "$JOBS" -ge 1 ] || { log_error "--jobs must be a positive integer"; exit 1; }
 
 $DRY_RUN && log_warn "DRY RUN — no files will be changed."
 log_info "Recordings: $RECORDINGS_DIR"
 log_info "Database:   $DB_PATH"
-log_info "Target:     MP3 mono @ $BITRATE"
+log_info "Target:     MP3 mono @ $BITRATE   Jobs: $JOBS"
 
-# Portable file size in bytes.
 filesize() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || echo 0; }
-
 human() {
   local b=$1 u=(B KB MB GB TB) i=0
   while [ "$b" -ge 1024 ] && [ "$i" -lt 4 ]; do b=$((b / 1024)); i=$((i + 1)); done
   echo "${b} ${u[$i]}"
 }
 
-# Update transmissions.audio_path from the WAV basename to the MP3 basename.
-# Returns non-zero on failure so the caller can keep the WAV for a later retry.
-db_update() {
-  local wav_base="$1" mp3_base="$2"
-  # Escape single quotes for SQL string literals.
-  local w="${wav_base//\'/\'\'}" m="${mp3_base//\'/\'\'}"
-  # Redirect stdout so PRAGMA's returned value isn't printed; keep stderr for errors.
-  sqlite3 "$DB_PATH" >/dev/null <<SQL
-PRAGMA busy_timeout=15000;
-UPDATE transmissions SET audio_path='$m' WHERE audio_path='$w';
-SQL
-}
-
-# --- Main loop -------------------------------------------------------------
+# --- Gather WAVs -----------------------------------------------------------
 log_step "Scanning for WAV recordings..."
-
 shopt -s nullglob
 wavs=("$RECORDINGS_DIR"/*.wav "$RECORDINGS_DIR"/*.WAV)
 shopt -u nullglob
 
-if [ "${#wavs[@]}" -eq 0 ]; then
+total=${#wavs[@]}
+if [ "$total" -eq 0 ]; then
   log_success "No WAV recordings found — nothing to do."
   exit 0
 fi
+log_info "Found $total WAV file(s)."
 
-log_info "Found ${#wavs[@]} WAV file(s)."
+if $DRY_RUN; then
+  bytes=0
+  for w in "${wavs[@]}"; do bytes=$((bytes + $(filesize "$w"))); done
+  log_step "Summary (dry run)"
+  log_info "Would convert $total file(s), reclaiming up to ~$(human "$bytes") (minus new MP3s)."
+  log_info "Re-run without --dry-run to apply."
+  exit 0
+fi
 
-converted=0; skipped=0; failed=0
-bytes_before=0; bytes_after=0
+# --- Phase 1: convert in parallel -----------------------------------------
+# Each worker converts one WAV -> MP3 and, on success, appends a tab-separated
+# record (wav_path, wav_size, mp3_size) to the manifest. No DB writes or deletes
+# happen here, so there is zero database contention across jobs.
+MANIFEST=$(mktemp)
+FAILLOG=$(mktemp)
+trap 'rm -f "$MANIFEST" "$FAILLOG"' EXIT
 
-for wav in "${wavs[@]}"; do
-  base=$(basename "$wav")
-  mp3="${wav%.*}.mp3"
-  mp3_base=$(basename "$mp3")
-  wav_size=$(filesize "$wav")
+export BITRATE MANIFEST FAILLOG
 
-  if $DRY_RUN; then
-    log_info "Would convert: $base ($(human "$wav_size")) -> $mp3_base"
-    bytes_before=$((bytes_before + wav_size))
-    converted=$((converted + 1))
-    continue
-  fi
+convert_one() {
+  local wav="$1"
+  local mp3="${wav%.*}.mp3"
+  size() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || echo 0; }
 
-  # Reuse an existing MP3 if a previous run already produced one; otherwise encode.
-  if [ -f "$mp3" ] && [ "$(filesize "$mp3")" -gt 0 ]; then
-    log_info "MP3 already exists for $base — reconciling DB/cleanup only."
-  else
+  if [ ! -f "$mp3" ] || [ "$(size "$mp3")" -eq 0 ]; then
     if ! ffmpeg -nostdin -y -loglevel error -i "$wav" -codec:a libmp3lame -b:a "$BITRATE" -ac 1 "$mp3" </dev/null; then
-      log_error "ffmpeg failed on $base — leaving original in place."
       rm -f "$mp3" 2>/dev/null || true
-      failed=$((failed + 1))
-      continue
+      printf '%s\n' "$wav" >> "$FAILLOG"
+      return 0
     fi
   fi
-
-  if [ ! -f "$mp3" ] || [ "$(filesize "$mp3")" -eq 0 ]; then
-    log_error "Conversion produced no MP3 for $base — leaving original in place."
+  if [ ! -f "$mp3" ] || [ "$(size "$mp3")" -eq 0 ]; then
     rm -f "$mp3" 2>/dev/null || true
-    failed=$((failed + 1))
-    continue
+    printf '%s\n' "$wav" >> "$FAILLOG"
+    return 0
   fi
+  # Short line; append is atomic (< PIPE_BUF).
+  printf '%s\t%s\t%s\n' "$wav" "$(size "$wav")" "$(size "$mp3")" >> "$MANIFEST"
+}
+export -f convert_one
 
-  # Point the DB row at the new file before deleting the old one.
-  if [ "$HAVE_SQLITE" = true ]; then
-    if ! db_update "$base" "$mp3_base"; then
-      log_warn "DB update failed for $base (locked?) — keeping WAV so you can re-run. MP3 was created."
-      failed=$((failed + 1))
-      continue
-    fi
-  fi
+log_step "Converting $total file(s) with $JOBS parallel job(s)..."
+# Progress watcher.
+( while :; do
+    done=$(wc -l < "$MANIFEST" 2>/dev/null | tr -d ' ' || echo 0)
+    fail=$(wc -l < "$FAILLOG" 2>/dev/null | tr -d ' ' || echo 0)
+    printf "\r${BLUE}[INFO]${NC} Converted %s/%s (failed %s)   " "$done" "$total" "$fail"
+    sleep 3
+  done ) &
+WATCHER=$!
 
-  mp3_size=$(filesize "$mp3")
-  rm -f "$wav"
-  bytes_before=$((bytes_before + wav_size))
-  bytes_after=$((bytes_after + mp3_size))
-  converted=$((converted + 1))
-  log_success "$base ($(human "$wav_size")) -> $mp3_base ($(human "$mp3_size"))"
-done
+printf '%s\0' "${wavs[@]}" | xargs -0 -P "$JOBS" -I{} bash -c 'convert_one "$@"' _ {}
+
+kill "$WATCHER" 2>/dev/null || true
+wait "$WATCHER" 2>/dev/null || true
+printf "\n"
+
+converted=$(wc -l < "$MANIFEST" | tr -d ' ')
+failed=$(wc -l < "$FAILLOG" | tr -d ' ')
+log_info "Converted $converted file(s); $failed failed."
+
+if [ "$converted" -eq 0 ]; then
+  log_warn "Nothing converted. Failed files left untouched."
+  exit 1
+fi
+
+# --- Phase 2: one DB transaction, then delete originals --------------------
+log_step "Updating database (single transaction)..."
+# Build SQL: for each converted file, point audio_path at the MP3 and correct
+# the duration from the audio byte count.
+build_sql() {
+  echo "PRAGMA busy_timeout=30000;"
+  echo "BEGIN;"
+  while IFS=$'\t' read -r wav wsz _msz; do
+    local base mp3base dur w m
+    base=$(basename "$wav")
+    mp3base="${base%.*}.mp3"
+    dur=$(awk "BEGIN{printf \"%.3f\", $wsz/$RAW_BYTES_PER_SEC}")
+    w="${base//\'/\'\'}"; m="${mp3base//\'/\'\'}"
+    echo "UPDATE transmissions SET audio_path='$m', duration=$dur WHERE audio_path='$w';"
+  done < "$MANIFEST"
+  echo "COMMIT;"
+}
+
+if build_sql | sqlite3 "$DB_PATH" >/dev/null; then
+  log_success "Database updated for $converted file(s)."
+else
+  log_error "Database transaction failed — WAV files kept so you can re-run. MP3s were created."
+  exit 1
+fi
+
+log_step "Deleting original WAV files..."
+bytes_before=0; bytes_after=0
+while IFS=$'\t' read -r wav wsz msz; do
+  rm -f "$wav" && bytes_before=$((bytes_before + wsz)) && bytes_after=$((bytes_after + msz))
+done < "$MANIFEST"
 
 # --- Summary ---------------------------------------------------------------
+freed=$((bytes_before - bytes_after)); [ "$freed" -lt 0 ] && freed=0
 log_step "Summary"
-if $DRY_RUN; then
-  log_info "Would convert $converted file(s), reclaiming up to ~$(human "$bytes_before") (minus new MP3s)."
-  log_info "Re-run without --dry-run to apply."
-else
-  freed=$((bytes_before - bytes_after))
-  [ "$freed" -lt 0 ] && freed=0
-  log_success "Converted: $converted   Failed/kept: $failed"
-  log_success "Disk reclaimed: $(human "$freed")  ($(human "$bytes_before") WAV -> $(human "$bytes_after") MP3)"
-  [ "$failed" -gt 0 ] && log_warn "Some files were kept; fix the cause (e.g. stop the service, install sqlite3) and re-run."
-fi
+log_success "Converted: $converted   Failed/kept: $failed"
+log_success "Disk reclaimed: $(human "$freed")   ($(human "$bytes_before") WAV -> $(human "$bytes_after") MP3)"
+[ "$failed" -gt 0 ] && log_warn "Some files failed to convert and were left in place; re-run to retry them."
+exit 0

--- a/scripts/compress_recordings.sh
+++ b/scripts/compress_recordings.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# OpenScanner — Compress old WAV recordings to MP3
+# ============================================================================
+# Recordings used to be stored as 48kHz mono WAV (~96 KB/s). They are now saved
+# as 32 kbps mono MP3 (~4 KB/s) to save disk. This one-off maintenance script
+# transcodes any leftover *.wav recordings to the same MP3 format, updates the
+# database so playback keeps working, and deletes the original WAV.
+#
+# It is safe to re-run: files already converted are skipped, and a WAV is only
+# deleted after its MP3 exists and (when a matching DB row is present) the
+# database has been updated.
+#
+# Recommended: stop the service first so the database isn't locked:
+#   systemctl --user stop openscanner   # or: sudo systemctl stop openscanner
+#
+# Usage:
+#   scripts/compress_recordings.sh [--dry-run] [--bitrate 32k] [--data-dir PATH]
+# ============================================================================
+
+# Colors
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; BLUE='\033[0;34m'; NC='\033[0m'; BOLD='\033[1m'
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_step() { echo -e "\n${BLUE}${BOLD}==> $1${NC}"; }
+log_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+# Defaults
+DRY_RUN=false
+BITRATE="32k"
+DATA_DIR="$PROJECT_ROOT/data"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=true; shift ;;
+    --bitrate) BITRATE="$2"; shift 2 ;;
+    --data-dir) DATA_DIR="$2"; shift 2 ;;
+    -h|--help)
+      grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) log_error "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+RECORDINGS_DIR="$DATA_DIR/recordings"
+DB_PATH="$DATA_DIR/openscanner.db"
+
+# --- Preconditions ---------------------------------------------------------
+command -v ffmpeg >/dev/null 2>&1 || { log_error "ffmpeg not found on PATH. Install it (e.g. sudo apt install ffmpeg)."; exit 1; }
+
+HAVE_SQLITE=true
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  HAVE_SQLITE=false
+  log_warn "sqlite3 not found — files will be converted but the database will NOT be updated."
+  log_warn "Install it (sudo apt install sqlite3) and re-run to fix playback links, or the app will 404 on old rows."
+fi
+
+if [ ! -d "$RECORDINGS_DIR" ]; then
+  log_error "Recordings directory not found: $RECORDINGS_DIR"
+  log_error "Pass --data-dir if your data lives elsewhere."
+  exit 1
+fi
+
+if [ "$HAVE_SQLITE" = true ] && [ ! -f "$DB_PATH" ]; then
+  log_warn "Database not found at $DB_PATH — converting files without DB updates."
+  HAVE_SQLITE=false
+fi
+
+$DRY_RUN && log_warn "DRY RUN — no files will be changed."
+log_info "Recordings: $RECORDINGS_DIR"
+log_info "Database:   $DB_PATH"
+log_info "Target:     MP3 mono @ $BITRATE"
+
+# Portable file size in bytes.
+filesize() { stat -c%s "$1" 2>/dev/null || stat -f%z "$1" 2>/dev/null || echo 0; }
+
+human() {
+  local b=$1 u=(B KB MB GB TB) i=0
+  while [ "$b" -ge 1024 ] && [ "$i" -lt 4 ]; do b=$((b / 1024)); i=$((i + 1)); done
+  echo "${b} ${u[$i]}"
+}
+
+# Update transmissions.audio_path from the WAV basename to the MP3 basename.
+# Returns non-zero on failure so the caller can keep the WAV for a later retry.
+db_update() {
+  local wav_base="$1" mp3_base="$2"
+  # Escape single quotes for SQL string literals.
+  local w="${wav_base//\'/\'\'}" m="${mp3_base//\'/\'\'}"
+  # Redirect stdout so PRAGMA's returned value isn't printed; keep stderr for errors.
+  sqlite3 "$DB_PATH" >/dev/null <<SQL
+PRAGMA busy_timeout=15000;
+UPDATE transmissions SET audio_path='$m' WHERE audio_path='$w';
+SQL
+}
+
+# --- Main loop -------------------------------------------------------------
+log_step "Scanning for WAV recordings..."
+
+shopt -s nullglob
+wavs=("$RECORDINGS_DIR"/*.wav "$RECORDINGS_DIR"/*.WAV)
+shopt -u nullglob
+
+if [ "${#wavs[@]}" -eq 0 ]; then
+  log_success "No WAV recordings found — nothing to do."
+  exit 0
+fi
+
+log_info "Found ${#wavs[@]} WAV file(s)."
+
+converted=0; skipped=0; failed=0
+bytes_before=0; bytes_after=0
+
+for wav in "${wavs[@]}"; do
+  base=$(basename "$wav")
+  mp3="${wav%.*}.mp3"
+  mp3_base=$(basename "$mp3")
+  wav_size=$(filesize "$wav")
+
+  if $DRY_RUN; then
+    log_info "Would convert: $base ($(human "$wav_size")) -> $mp3_base"
+    bytes_before=$((bytes_before + wav_size))
+    converted=$((converted + 1))
+    continue
+  fi
+
+  # Reuse an existing MP3 if a previous run already produced one; otherwise encode.
+  if [ -f "$mp3" ] && [ "$(filesize "$mp3")" -gt 0 ]; then
+    log_info "MP3 already exists for $base — reconciling DB/cleanup only."
+  else
+    if ! ffmpeg -nostdin -y -loglevel error -i "$wav" -codec:a libmp3lame -b:a "$BITRATE" -ac 1 "$mp3" </dev/null; then
+      log_error "ffmpeg failed on $base — leaving original in place."
+      rm -f "$mp3" 2>/dev/null || true
+      failed=$((failed + 1))
+      continue
+    fi
+  fi
+
+  if [ ! -f "$mp3" ] || [ "$(filesize "$mp3")" -eq 0 ]; then
+    log_error "Conversion produced no MP3 for $base — leaving original in place."
+    rm -f "$mp3" 2>/dev/null || true
+    failed=$((failed + 1))
+    continue
+  fi
+
+  # Point the DB row at the new file before deleting the old one.
+  if [ "$HAVE_SQLITE" = true ]; then
+    if ! db_update "$base" "$mp3_base"; then
+      log_warn "DB update failed for $base (locked?) — keeping WAV so you can re-run. MP3 was created."
+      failed=$((failed + 1))
+      continue
+    fi
+  fi
+
+  mp3_size=$(filesize "$mp3")
+  rm -f "$wav"
+  bytes_before=$((bytes_before + wav_size))
+  bytes_after=$((bytes_after + mp3_size))
+  converted=$((converted + 1))
+  log_success "$base ($(human "$wav_size")) -> $mp3_base ($(human "$mp3_size"))"
+done
+
+# --- Summary ---------------------------------------------------------------
+log_step "Summary"
+if $DRY_RUN; then
+  log_info "Would convert $converted file(s), reclaiming up to ~$(human "$bytes_before") (minus new MP3s)."
+  log_info "Re-run without --dry-run to apply."
+else
+  freed=$((bytes_before - bytes_after))
+  [ "$freed" -lt 0 ] && freed=0
+  log_success "Converted: $converted   Failed/kept: $failed"
+  log_success "Disk reclaimed: $(human "$freed")  ($(human "$bytes_before") WAV -> $(human "$bytes_after") MP3)"
+  [ "$failed" -gt 0 ] && log_warn "Some files were kept; fix the cause (e.g. stop the service, install sqlite3) and re-run."
+fi

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -120,6 +120,8 @@ if [ ! -f "$PROJECT_ROOT/whisper.cpp/build/bin/whisper-cli" ]; then
     log_success "Whisper.cpp built."
 fi
 
+# Model comes from appsettings.json (e.g. large-v3-turbo-q5_0). Turbo models
+# require a reasonably recent whisper.cpp; the clone above tracks master.
 WHISPER_MODEL=$(grep '"Model":' "$PROJECT_ROOT/server/OpenScanner.Server/appsettings.json" | head -n 1 | cut -d'"' -f4 || echo "small.en")
 log_info "Transcription Model: $WHISPER_MODEL"
 if [ ! -f "$PROJECT_ROOT/whisper.cpp/models/ggml-$WHISPER_MODEL.bin" ]; then

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -229,7 +229,8 @@ if [ ! -f "$PROJECT_ROOT/whisper.cpp/build/bin/whisper-cli" ]; then
     log_success "Whisper.cpp built."
 fi
 
-# Get model from appsettings.json
+# Get model from appsettings.json (e.g. large-v3-turbo-q5_0). Turbo models
+# require a reasonably recent whisper.cpp; the clone above tracks master.
 WHISPER_MODEL=$(grep '"Model":' "$PROJECT_ROOT/server/OpenScanner.Server/appsettings.json" | head -n 1 | cut -d'"' -f4 || echo "small.en")
 log_info "Transcription Model: $WHISPER_MODEL"
 

--- a/server/OpenScanner.Server/Controllers/PowerDmsController.cs
+++ b/server/OpenScanner.Server/Controllers/PowerDmsController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using OpenScanner.Server.Interfaces;
 
 namespace OpenScanner.Server.Controllers;
 
@@ -19,15 +20,26 @@ public class PowerDmsController : ControllerBase
     private static readonly SemaphoreSlim _cacheLock = new(1, 1);
 
     private readonly IConfiguration _config;
+    private readonly IDatabase _db;
     private readonly ILogger<PowerDmsController> _logger;
 
-    public PowerDmsController(IConfiguration config, ILogger<PowerDmsController> logger)
+    public PowerDmsController(IConfiguration config, IDatabase db, ILogger<PowerDmsController> logger)
     {
         _config = config;
+        _db = db;
         _logger = logger;
     }
 
-    private string? Department => _config["PowerDMS:Department"] is { Length: > 0 } d ? d : null;
+    /// <summary>
+    /// The PowerDMS department slug, managed from the web-app settings (DB),
+    /// falling back to appsettings. Returns null when not configured.
+    /// </summary>
+    private async Task<string?> GetDepartmentAsync()
+    {
+        var fromDb = await _db.GetSettingAsync("PowerDmsDepartment");
+        if (!string.IsNullOrWhiteSpace(fromDb)) return fromDb.Trim();
+        return _config["PowerDMS:Department"] is { Length: > 0 } d ? d : null;
+    }
 
     /// <summary>
     /// Returns the configured PowerDMS department slug, or null if not configured.
@@ -35,9 +47,9 @@ public class PowerDmsController : ControllerBase
     /// </summary>
     [HttpGet("config")]
     [ProducesResponseType(typeof(PowerDmsConfigResponse), StatusCodes.Status200OK)]
-    public IActionResult GetConfig()
+    public async Task<IActionResult> GetConfig()
     {
-        return Ok(new PowerDmsConfigResponse(Department));
+        return Ok(new PowerDmsConfigResponse(await GetDepartmentAsync()));
     }
 
     /// <summary>
@@ -49,7 +61,7 @@ public class PowerDmsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> CheckDailyLog(int year, int month, int day)
     {
-        var dept = Department;
+        var dept = await GetDepartmentAsync();
         if (dept is null)
             return Ok(new PowerDmsCheckResponse(false));
 
@@ -85,7 +97,7 @@ public class PowerDmsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status503ServiceUnavailable)]
     public async Task<IActionResult> GetDailyLog(int year, int month, int day)
     {
-        var dept = Department;
+        var dept = await GetDepartmentAsync();
         if (dept is null)
             return StatusCode(503, "PowerDMS integration is not configured.");
 

--- a/server/OpenScanner.Server/Controllers/SettingsController.cs
+++ b/server/OpenScanner.Server/Controllers/SettingsController.cs
@@ -12,10 +12,12 @@ namespace OpenScanner.Server.Controllers;
 public class SettingsController : ControllerBase
 {
     private readonly IDatabase _db;
+    private readonly ITranscriptionService _transcription;
 
-    public SettingsController(IDatabase db)
+    public SettingsController(IDatabase db, ITranscriptionService transcription)
     {
         _db = db;
+        _transcription = transcription;
     }
 
     /// <summary>
@@ -39,6 +41,14 @@ public class SettingsController : ControllerBase
     public async Task<IActionResult> UpdateSetting(string key, [FromBody] string value)
     {
         await _db.SetSettingAsync(key, value);
+
+        // Changing the transcription model kicks off a background download of
+        // the ggml weights if they aren't present yet.
+        if (key == "TranscriptionModel" && !string.IsNullOrWhiteSpace(value))
+        {
+            _transcription.PrepareModel(value);
+        }
+
         return Ok();
     }
 }

--- a/server/OpenScanner.Server/Controllers/SupportController.cs
+++ b/server/OpenScanner.Server/Controllers/SupportController.cs
@@ -43,6 +43,55 @@ public class SupportController : ControllerBase
     }
 
     /// <summary>
+    /// Retrieves an instantaneous CPU/memory/transcription-queue sample. The debug
+    /// page polls this once per second to build rolling resource graphs.
+    /// </summary>
+    /// <returns>A <see cref="OpenScanner.Server.Models.SystemStats"/> sample.</returns>
+    [HttpGet("system/stats")]
+    [ProducesResponseType(typeof(OpenScanner.Server.Models.SystemStats), StatusCodes.Status200OK)]
+    public IActionResult GetSystemStats()
+    {
+        return Ok(_support.GetSystemStats());
+    }
+
+    /// <summary>
+    /// Retrieves the running services and the TCP ports the host is listening on.
+    /// </summary>
+    /// <returns>A <see cref="OpenScanner.Server.Models.ServicesSnapshot"/>.</returns>
+    [HttpGet("system/services")]
+    [ProducesResponseType(typeof(OpenScanner.Server.Models.ServicesSnapshot), StatusCodes.Status200OK)]
+    public IActionResult GetServices()
+    {
+        return Ok(_support.GetServices());
+    }
+
+    /// <summary>
+    /// Retrieves a composite diagnostics snapshot (scanner, GPS, database, connections,
+    /// recording activity, and reliability counters) for the debug page.
+    /// </summary>
+    /// <returns>A <see cref="OpenScanner.Server.Models.DiagnosticsSnapshot"/>.</returns>
+    [HttpGet("system/diagnostics")]
+    [ProducesResponseType(typeof(OpenScanner.Server.Models.DiagnosticsSnapshot), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetDiagnostics()
+    {
+        return Ok(await _support.GetDiagnosticsAsync());
+    }
+
+    /// <summary>
+    /// Retrieves the most recent OpenScanner systemd journal lines.
+    /// </summary>
+    /// <param name="lines">Number of trailing lines to return (default 500).</param>
+    /// <returns>Plain-text log content.</returns>
+    [HttpGet("system/logs")]
+    [Produces("text/plain")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetLogs([FromQuery] int lines = 500)
+    {
+        var logs = await _support.GetSystemdLogsAsync(lines);
+        return Content(logs, "text/plain");
+    }
+
+    /// <summary>
     /// Generates and downloads a support package containing logs, configuration, and system info.
     /// </summary>
     /// <returns>A ZIP file containing diagnostic information.</returns>

--- a/server/OpenScanner.Server/Controllers/TranscriptionController.cs
+++ b/server/OpenScanner.Server/Controllers/TranscriptionController.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenScanner.Server.Interfaces;
+
+namespace OpenScanner.Server.Controllers;
+
+/// <summary>
+/// Controls the on-demand transcription backfill job.
+/// </summary>
+[ApiController]
+[Route("api/transcription")]
+[Produces("application/json")]
+public class TranscriptionController : ControllerBase
+{
+    private readonly IBackfillService _backfill;
+
+    public TranscriptionController(IBackfillService backfill)
+    {
+        _backfill = backfill;
+    }
+
+    /// <summary>
+    /// Gets the current status/progress of the transcription backfill job.
+    /// </summary>
+    [HttpGet("backfill")]
+    [ProducesResponseType(typeof(OpenScanner.Server.Models.BackfillStatus), StatusCodes.Status200OK)]
+    public IActionResult GetBackfillStatus()
+    {
+        return Ok(_backfill.GetStatus());
+    }
+
+    /// <summary>
+    /// Starts the backfill job. No-op if it is already running.
+    /// </summary>
+    [HttpPost("backfill/start")]
+    [ProducesResponseType(typeof(OpenScanner.Server.Models.BackfillStatus), StatusCodes.Status200OK)]
+    public IActionResult StartBackfill()
+    {
+        _backfill.Start();
+        return Ok(_backfill.GetStatus());
+    }
+
+    /// <summary>
+    /// Requests the running backfill job to stop after the current clip.
+    /// </summary>
+    [HttpPost("backfill/stop")]
+    [ProducesResponseType(typeof(OpenScanner.Server.Models.BackfillStatus), StatusCodes.Status200OK)]
+    public IActionResult StopBackfill()
+    {
+        _backfill.Stop();
+        return Ok(_backfill.GetStatus());
+    }
+}

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -238,6 +238,17 @@ public class Database : IDatabase
     }
 
     /// <inheritdoc />
+    public async Task<IEnumerable<CallLog>> GetUntranscribedSinceAsync(DateTime sinceUtc)
+    {
+        using var conn = GetConnection();
+        // Timestamps are stored as round-trip ("o") UTC strings, so a lexicographic
+        // compare against the same format is chronological.
+        return await conn.QueryAsync<CallLog>(
+            SqlLoader.GetSql("Transmissions/GetUntranscribedSince.sql"),
+            new { Since = sinceUtc.ToUniversalTime().ToString("o") });
+    }
+
+    /// <inheritdoc />
     public async Task<CallLog?> GetTransmissionByIdAsync(string id)
     {
         using var conn = GetConnection();

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -226,6 +226,18 @@ public class Database : IDatabase
     }
     
     /// <inheritdoc />
+    public async Task<DbStats> GetDbStatsAsync()
+    {
+        using var conn = GetConnection();
+        var total = await conn.ExecuteScalarAsync<int>("SELECT COUNT(*) FROM transmissions");
+        var transcribed = await conn.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM transmissions WHERE transcription IS NOT NULL AND transcription != ''");
+        var oldest = await conn.ExecuteScalarAsync<string?>("SELECT MIN(timestamp) FROM transmissions");
+        var newest = await conn.ExecuteScalarAsync<string?>("SELECT MAX(timestamp) FROM transmissions");
+        return new DbStats(total, transcribed, Math.Max(0, total - transcribed), oldest, newest);
+    }
+
+    /// <inheritdoc />
     public async Task<CallLog?> GetTransmissionByIdAsync(string id)
     {
         using var conn = GetConnection();

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -127,6 +127,21 @@ public class Database : IDatabase
             // (whisper -t), so running several at once just makes each slower.
             conn.Execute("INSERT INTO settings (key, value) VALUES ('TranscriptionThreads', '1')");
         }
+
+        // Whisper model, managed from the web-app settings. The server downloads
+        // the ggml weights on demand when this changes.
+        var modelCount = conn.ExecuteScalar<int>("SELECT count(*) FROM settings WHERE key = 'TranscriptionModel'");
+        if (modelCount == 0)
+        {
+            conn.Execute("INSERT INTO settings (key, value) VALUES ('TranscriptionModel', 'large-v3-turbo-q5_0')");
+        }
+
+        // PowerDMS department slug, managed from the web-app settings.
+        var powerDmsCount = conn.ExecuteScalar<int>("SELECT count(*) FROM settings WHERE key = 'PowerDmsDepartment'");
+        if (powerDmsCount == 0)
+        {
+            conn.Execute("INSERT INTO settings (key, value) VALUES ('PowerDmsDepartment', '')");
+        }
     }
 
     /// <inheritdoc />

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -122,8 +122,10 @@ public class Database : IDatabase
         var threadsCount = conn.ExecuteScalar<int>("SELECT count(*) FROM settings WHERE key = 'TranscriptionThreads'");
         if (threadsCount == 0)
         {
-            var defaultThreads = Math.Max(1, Environment.ProcessorCount / 2);
-            conn.Execute("INSERT INTO settings (key, value) VALUES ('TranscriptionThreads', @DefaultThreads)", new { DefaultThreads = defaultThreads.ToString() });
+            // Number of concurrent transcription processes. Default to 1: with a
+            // large accuracy-first model each run already uses all CPU cores
+            // (whisper -t), so running several at once just makes each slower.
+            conn.Execute("INSERT INTO settings (key, value) VALUES ('TranscriptionThreads', '1')");
         }
     }
 

--- a/server/OpenScanner.Server/Devices/MockRadioSource.cs
+++ b/server/OpenScanner.Server/Devices/MockRadioSource.cs
@@ -122,6 +122,9 @@ public class MockRadioSource : BackgroundService, IRadioSource
 
     public ScannerState GetState() => _state;
 
+    /// <inheritdoc />
+    public RadioDiagnostics GetDiagnostics() => new RadioDiagnostics(0, 0);
+
     public void ReloadChannels() => _channelService.ReloadChannels();
 
     public void SetSquelch(double db) => UpdateState(_state with { Squelch = db });

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -37,6 +37,11 @@ public class RtlDevice : BackgroundService, IRadioSource
 
     private ScannerState _state = new ScannerState("IDLE", 0);
     private bool _manualOverride = false;
+
+    // Capture-watchdog diagnostics surfaced on the debug page.
+    private int _restartCount;
+    private long _totalBytesRead;
+    private (DateTime When, long Bytes)? _lastThroughputSample;
     
     private string? _lastDetectedTone;
     // Normally 2s of silence ends a transmission. After a fire tone-out we use a
@@ -151,6 +156,22 @@ public class RtlDevice : BackgroundService, IRadioSource
 
     /// <inheritdoc />
     public ScannerState GetState() => _state;
+
+    /// <inheritdoc />
+    public RadioDiagnostics GetDiagnostics()
+    {
+        // Throughput = bytes read since the previous call, over elapsed wall time.
+        var now = DateTime.UtcNow;
+        var bytes = System.Threading.Interlocked.Read(ref _totalBytesRead);
+        double kbPerSec = 0;
+        if (_lastThroughputSample is { } prev)
+        {
+            var elapsed = (now - prev.When).TotalSeconds;
+            if (elapsed > 0) kbPerSec = (bytes - prev.Bytes) / 1024.0 / elapsed;
+        }
+        _lastThroughputSample = (now, bytes);
+        return new RadioDiagnostics(_restartCount, Math.Round(Math.Max(0, kbPerSec), 1));
+    }
 
     /// <inheritdoc />
     public void ReloadChannels()
@@ -722,6 +743,7 @@ public class RtlDevice : BackgroundService, IRadioSource
                 {
                     bool isAlive = _scannerProcess != null && !_scannerProcess.HasExited;
                     _logger.LogWarning($"Parallel scanner stalled. Process alive: {isAlive}. Restarting...");
+                    System.Threading.Interlocked.Increment(ref _restartCount);
                     break;
                 }
 
@@ -730,6 +752,7 @@ public class RtlDevice : BackgroundService, IRadioSource
                 if (bytesRead <= 0) break;
 
                 totalBytesRead += bytesRead;
+                System.Threading.Interlocked.Add(ref _totalBytesRead, bytesRead);
 
                 // Warm-up: skip first 50ms
                 if ((DateTime.UtcNow - segmentStartTime).TotalMilliseconds < 50) continue;
@@ -1106,7 +1129,8 @@ public class RtlDevice : BackgroundService, IRadioSource
                 {
                     bool isAlive = _scannerProcess != null && !_scannerProcess.HasExited;
                     _logger.LogWarning($"Scanner hardware stalled (No data for 5s). Process Alive: {isAlive}, Total Bytes: {totalBytesRead}. Restarting...");
-                    break; 
+                    System.Threading.Interlocked.Increment(ref _restartCount);
+                    break;
                 }
 
                 // Data received, cancel the watchdog task
@@ -1119,6 +1143,7 @@ public class RtlDevice : BackgroundService, IRadioSource
                 }
 
                 totalBytesRead += bytesRead;
+                System.Threading.Interlocked.Add(ref _totalBytesRead, bytesRead);
 
 
                 // Rate limit FFT updates (approx 50Hz)

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -69,6 +69,9 @@ public class RtlDevice : BackgroundService, IRadioSource
     // Parallel FastScan mode
     private List<ChannelPipeline>? _parallelPipelines;
     private readonly ConcurrentDictionary<double, CancellationTokenSource> _parallelActivityTimeouts = new();
+    // Per-channel throttle for the audio-driven activity-timeout reset (mirrors
+    // the single-channel _lastActivityReset throttle) to avoid task churn.
+    private readonly ConcurrentDictionary<double, DateTime> _parallelLastAudioReset = new();
     private readonly ConcurrentDictionary<double, string?> _parallelLastTones = new();
     // Stereo pan positions for parallel channels: maps frequency -> (leftGain, rightGain)
     private Dictionary<double, (double Left, double Right)> _parallelPanMap = new();
@@ -477,6 +480,7 @@ public class RtlDevice : BackgroundService, IRadioSource
             kvp.Value.Cancel();
         }
         _parallelActivityTimeouts.Clear();
+        _parallelLastAudioReset.Clear();
         _parallelLastTones.Clear();
     }
 
@@ -851,6 +855,19 @@ public class RtlDevice : BackgroundService, IRadioSource
         if (rs != null && rs.IsChannelRecording(channel.Frequency))
         {
             _recordingService.ProcessAudio(channel.Frequency, audio);
+
+            // Keep the recording alive while audio is still flowing, not only on
+            // decoder metadata/activity events. Otherwise a gap in metadata longer
+            // than the 2s activity timeout finalizes the clip mid-transmission and
+            // the next event starts a new one, splitting one over into ~2s chunks.
+            // Throttled per channel to avoid re-arming the timer on every chunk.
+            var now = DateTime.UtcNow;
+            var last = _parallelLastAudioReset.TryGetValue(channel.Frequency, out var l) ? l : DateTime.MinValue;
+            if ((now - last).TotalMilliseconds >= 500)
+            {
+                _parallelLastAudioReset[channel.Frequency] = now;
+                ResetParallelActivityTimeout(channel);
+            }
         }
 
         UpdateParallelState();

--- a/server/OpenScanner.Server/Interfaces/IBackfillService.cs
+++ b/server/OpenScanner.Server/Interfaces/IBackfillService.cs
@@ -1,0 +1,19 @@
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Interfaces;
+
+/// <summary>
+/// On-demand, low-priority job that re-transcribes recordings from the last 24
+/// hours that are missing a transcription. It yields to live transcription work.
+/// </summary>
+public interface IBackfillService
+{
+    /// <summary>Gets the current progress/status of the backfill job.</summary>
+    BackfillStatus GetStatus();
+
+    /// <summary>Starts the job. Returns false if it is already running.</summary>
+    bool Start();
+
+    /// <summary>Requests the running job to stop after the current clip.</summary>
+    void Stop();
+}

--- a/server/OpenScanner.Server/Interfaces/IDatabase.cs
+++ b/server/OpenScanner.Server/Interfaces/IDatabase.cs
@@ -154,6 +154,12 @@ public interface IDatabase
     /// </summary>
     Task ClearHistoryAsync();
 
+    /// <summary>
+    /// Gets aggregate recording/transcription statistics for diagnostics:
+    /// total recordings, how many are transcribed, and the oldest/newest timestamps.
+    /// </summary>
+    Task<DbStats> GetDbStatsAsync();
+
     // Fire Tones
     
     /// <summary>

--- a/server/OpenScanner.Server/Interfaces/IDatabase.cs
+++ b/server/OpenScanner.Server/Interfaces/IDatabase.cs
@@ -160,6 +160,12 @@ public interface IDatabase
     /// </summary>
     Task<DbStats> GetDbStatsAsync();
 
+    /// <summary>
+    /// Gets recordings with a missing (null/empty) transcription whose timestamp is
+    /// at or after <paramref name="sinceUtc"/>. Used by the transcription backfill job.
+    /// </summary>
+    Task<IEnumerable<CallLog>> GetUntranscribedSinceAsync(DateTime sinceUtc);
+
     // Fire Tones
     
     /// <summary>

--- a/server/OpenScanner.Server/Interfaces/IRadioSource.cs
+++ b/server/OpenScanner.Server/Interfaces/IRadioSource.cs
@@ -34,6 +34,11 @@ public interface IRadioSource
     ScannerState GetState();
 
     /// <summary>
+    /// Gets SDR reliability diagnostics (capture restart count and throughput).
+    /// </summary>
+    RadioDiagnostics GetDiagnostics();
+
+    /// <summary>
     /// Reloads the channel list from the database.
     /// </summary>
     void ReloadChannels();

--- a/server/OpenScanner.Server/Interfaces/IRecordingService.cs
+++ b/server/OpenScanner.Server/Interfaces/IRecordingService.cs
@@ -24,6 +24,12 @@ public interface IRecordingService
     /// </summary>
     string? CurrentRecordingId { get; }
 
+    /// <summary>Number of recordings currently in flight (parallel channels + legacy single).</summary>
+    int ActiveRecordingCount { get; }
+
+    /// <summary>Ids of the recordings currently in flight, newest first.</summary>
+    IReadOnlyCollection<string> ActiveRecordingIds { get; }
+
     void StartRecording(Channel channel, int? src, int? tgt, LinkedList<byte[]> preRollBuffer);
     void UpdateSourceTarget(int? src, int? tgt);
     void UpdateSourceTarget(double frequency, int? src, int? tgt);

--- a/server/OpenScanner.Server/Interfaces/ISupportService.cs
+++ b/server/OpenScanner.Server/Interfaces/ISupportService.cs
@@ -22,6 +22,29 @@ public interface ISupportService
     StorageInfo GetStorageInfo();
 
     /// <summary>
+    /// Gets an instantaneous CPU/memory/transcription-queue sample for the debug page.
+    /// </summary>
+    SystemStats GetSystemStats();
+
+    /// <summary>
+    /// Gets the running services and listening TCP ports on the host.
+    /// </summary>
+    ServicesSnapshot GetServices();
+
+    /// <summary>
+    /// Gets a composite, slower-changing diagnostics snapshot (scanner, GPS, DB,
+    /// connections, recording activity, reliability counters) for the debug page.
+    /// </summary>
+    Task<DiagnosticsSnapshot> GetDiagnosticsAsync();
+
+    /// <summary>
+    /// Gets the most recent OpenScanner systemd journal lines (falls back to the
+    /// in-memory log buffer when journalctl is unavailable).
+    /// </summary>
+    /// <param name="lines">Maximum number of trailing lines to return.</param>
+    Task<string> GetSystemdLogsAsync(int lines);
+
+    /// <summary>
     /// Creates a ZIP archive containing diagnostic information.
     /// </summary>
     /// <returns>Byte array of the ZIP file.</returns>

--- a/server/OpenScanner.Server/Interfaces/ITranscriptionService.cs
+++ b/server/OpenScanner.Server/Interfaces/ITranscriptionService.cs
@@ -7,5 +7,13 @@ public interface ITranscriptionService
 {
     string? TranscribeAudio(string audioPath);
     void QueueTranscription(CallLog log, string audioPath);
+
+    /// <summary>
+    /// Ensure the given whisper model is downloaded, in the background. Safe to
+    /// call when it already exists. Progress is surfaced via the
+    /// TranscriptionModelStatus setting.
+    /// </summary>
+    void PrepareModel(string modelName);
+
     event Action<CallLog>? OnTranscriptionCompleted;
 }

--- a/server/OpenScanner.Server/Interfaces/ITranscriptionService.cs
+++ b/server/OpenScanner.Server/Interfaces/ITranscriptionService.cs
@@ -9,6 +9,11 @@ public interface ITranscriptionService
     void QueueTranscription(CallLog log, string audioPath);
 
     /// <summary>
+    /// Current depth of the transcription queue and the number of active workers.
+    /// </summary>
+    TranscriptionQueueStatus GetQueueStatus();
+
+    /// <summary>
     /// Ensure the given whisper model is downloaded, in the background. Safe to
     /// call when it already exists. Progress is surfaced via the
     /// TranscriptionModelStatus setting.

--- a/server/OpenScanner.Server/Interfaces/ITranscriptionService.cs
+++ b/server/OpenScanner.Server/Interfaces/ITranscriptionService.cs
@@ -14,6 +14,13 @@ public interface ITranscriptionService
     TranscriptionQueueStatus GetQueueStatus();
 
     /// <summary>
+    /// Transcribes an existing recording synchronously (not via the live queue),
+    /// persists the result, and raises <see cref="OnTranscriptionCompleted"/> so the
+    /// UI updates. Used by the backfill job. Returns true if text was produced.
+    /// </summary>
+    Task<bool> RetranscribeAsync(CallLog log, string audioPath);
+
+    /// <summary>
     /// Ensure the given whisper model is downloaded, in the background. Safe to
     /// call when it already exists. Progress is surfaced via the
     /// TranscriptionModelStatus setting.

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -412,6 +412,22 @@ public record ListeningPort(string Protocol, int Port, string Process);
 /// <summary>Running services and open ports surfaced on the debug page.</summary>
 public record ServicesSnapshot(List<ServiceStatus> Services, List<ListeningPort> Ports);
 
+/// <summary>
+/// Progress/status of the on-demand transcription backfill job, which re-transcribes
+/// recordings from the last 24 hours that are missing a transcription.
+/// </summary>
+public record BackfillStatus(
+    bool Running,
+    int Total,
+    int Processed,
+    int Succeeded,
+    int Failed,
+    string? Current,
+    string? StartedUtc,
+    string? FinishedUtc,
+    string? Message
+);
+
 /// <summary>Compact SDR/scanner state for the debug page.</summary>
 public record ScannerSummary(
     string Status,

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -386,6 +386,79 @@ public record ParallelChannelState(
 public record SpectrumPoint(double Frequency, double Db);
 
 /// <summary>
+/// Snapshot of the transcription worker pool: how many clips are waiting and
+/// how many workers are draining the queue.
+/// </summary>
+public record TranscriptionQueueStatus(int Queued, int Workers);
+
+/// <summary>
+/// Instantaneous system resource sample surfaced on the debug page. The client
+/// polls this once per second to build the rolling CPU/memory graphs.
+/// </summary>
+public record SystemStats(
+    double CpuPercent,
+    double MemPercent,
+    long MemUsedMb,
+    long MemTotalMb,
+    TranscriptionQueueStatus Transcription
+);
+
+/// <summary>State of a systemd unit (or the process itself when systemd is absent).</summary>
+public record ServiceStatus(string Name, string State, string Detail);
+
+/// <summary>A TCP socket the host is listening on.</summary>
+public record ListeningPort(string Protocol, int Port, string Process);
+
+/// <summary>Running services and open ports surfaced on the debug page.</summary>
+public record ServicesSnapshot(List<ServiceStatus> Services, List<ListeningPort> Ports);
+
+/// <summary>Compact SDR/scanner state for the debug page.</summary>
+public record ScannerSummary(
+    string Status,
+    bool HardwareConnected,
+    double? Frequency,
+    double? SignalDb,
+    double SignalStrength,
+    double? Gain,
+    double? Squelch,
+    bool AudioStreaming
+);
+
+/// <summary>GPS link health: gpsd connectivity, fix age, and the last location.</summary>
+public record GpsDiagnostics(bool GpsdConnected, double? SecondsSinceFix, GpsData? Location);
+
+/// <summary>Aggregate recording/transcription counts from the database.</summary>
+public record DbStats(int TotalRecordings, int Transcribed, int Pending, string? OldestUtc, string? NewestUtc);
+
+/// <summary>Connected real-time WebSocket client counts.</summary>
+public record ConnectionStats(int ControlClients, int AudioClients);
+
+/// <summary>In-flight recording activity.</summary>
+public record RecordingActivity(int ActiveCount, List<string> ActiveIds);
+
+/// <summary>SDR reliability counters surfaced from the capture watchdog.</summary>
+public record RadioDiagnostics(int RestartCount, double ThroughputKbps);
+
+/// <summary>Status of the low-disk recording cleanup service.</summary>
+public record CleanupStatus(string? LastRunUtc, long? LastFreeBytes, int TotalPurged);
+
+/// <summary>
+/// Composite, slower-changing diagnostics surfaced on the System Debug page
+/// (polled less frequently than the per-second CPU/memory <see cref="SystemStats"/>).
+/// </summary>
+public record DiagnosticsSnapshot(
+    string Uptime,
+    ScannerSummary Scanner,
+    GpsDiagnostics Gps,
+    DbStats Database,
+    ConnectionStats Connections,
+    RecordingActivity Recording,
+    RadioDiagnostics Radio,
+    CleanupStatus Cleanup,
+    string? TranscriptionModelStatus
+);
+
+/// <summary>
 /// Storage usage statistics surfaced in the settings UI.
 /// </summary>
 public record StorageInfo(

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -45,7 +45,8 @@ builder.Services.AddSingleton<IDecoderFactory, OpenScanner.Server.Decoders.Decod
 builder.Services.AddSingleton<ITranscriptionService, WhisperTranscriptionService>();
 builder.Services.AddSingleton<IRecordingService, RecordingService>();
 builder.Services.AddSingleton<IChannelService, ChannelService>();
-builder.Services.AddHostedService<RecordingCleanupService>();
+builder.Services.AddSingleton<RecordingCleanupService>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<RecordingCleanupService>());
 
 var radioProvider = builder.Configuration["Radio:Provider"] ?? "RTL-SDR";
 if (radioProvider == "Mock")

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -61,6 +61,7 @@ else
     builder.Services.AddHostedService(sp => (RtlDevice)sp.GetRequiredService<IRadioSource>());
 }
 
+builder.Services.AddSingleton<IBackfillService, BackfillTranscriptionService>();
 builder.Services.AddSingleton<ISupportService, SupportService>();
 builder.Services.AddSingleton<WebSocketBroadcaster>();
 builder.Services.AddCors();

--- a/server/OpenScanner.Server/Services/BackfillTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/BackfillTranscriptionService.cs
@@ -1,0 +1,171 @@
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Services;
+
+/// <summary>
+/// Low-priority, on-demand job that scans the last 24 hours of recordings for
+/// missing transcriptions and re-transcribes them. It pauses whenever the live
+/// transcription queue has work so real-time transmissions keep priority.
+/// </summary>
+public class BackfillTranscriptionService : IBackfillService
+{
+    private readonly IDatabase _db;
+    private readonly ITranscriptionService _transcription;
+    private readonly ILogger<BackfillTranscriptionService> _logger;
+
+    // How far back to look for missing transcriptions.
+    private static readonly TimeSpan Window = TimeSpan.FromHours(24);
+
+    private readonly object _lock = new();
+    private CancellationTokenSource? _cts;
+    private Task? _runTask;
+
+    // Status fields, guarded by _lock.
+    private bool _running;
+    private int _total, _processed, _succeeded, _failed;
+    private string? _current, _startedUtc, _finishedUtc, _message;
+
+    public BackfillTranscriptionService(IDatabase db, ITranscriptionService transcription, ILogger<BackfillTranscriptionService> logger)
+    {
+        _db = db;
+        _transcription = transcription;
+        _logger = logger;
+    }
+
+    public BackfillStatus GetStatus()
+    {
+        lock (_lock)
+        {
+            return new BackfillStatus(_running, _total, _processed, _succeeded, _failed, _current, _startedUtc, _finishedUtc, _message);
+        }
+    }
+
+    public bool Start()
+    {
+        lock (_lock)
+        {
+            if (_running) return false;
+            _running = true;
+            _total = _processed = _succeeded = _failed = 0;
+            _current = null;
+            _finishedUtc = null;
+            _startedUtc = DateTime.UtcNow.ToString("o");
+            _message = "Starting…";
+            _cts = new CancellationTokenSource();
+            _runTask = Task.Run(() => RunAsync(_cts.Token));
+        }
+        _logger.LogInformation("Transcription backfill started.");
+        return true;
+    }
+
+    public void Stop()
+    {
+        lock (_lock)
+        {
+            if (!_running) return;
+            _cts?.Cancel();
+            _message = "Stopping…";
+        }
+        _logger.LogInformation("Transcription backfill stop requested.");
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            var since = DateTime.UtcNow - Window;
+            var pending = (await _db.GetUntranscribedSinceAsync(since)).ToList();
+
+            lock (_lock)
+            {
+                _total = pending.Count;
+                _message = pending.Count == 0
+                    ? "Nothing to backfill in the last 24 hours."
+                    : $"Found {pending.Count} clip(s) to re-transcribe.";
+            }
+
+            var recordingsDir = Path.GetFullPath(
+                Path.Combine(Directory.GetCurrentDirectory(), "../../data/recordings"));
+
+            foreach (var log in pending)
+            {
+                if (ct.IsCancellationRequested) break;
+
+                // Low priority: while live transcription has queued work, wait.
+                while (!ct.IsCancellationRequested && _transcription.GetQueueStatus().Queued > 0)
+                {
+                    lock (_lock) _message = "Paused: yielding to live transcription queue…";
+                    await Task.Delay(2000, ct);
+                }
+                if (ct.IsCancellationRequested) break;
+
+                var name = log.AudioPath;
+                lock (_lock) { _current = name; _message = "Re-transcribing…"; }
+
+                try
+                {
+                    if (string.IsNullOrWhiteSpace(name))
+                    {
+                        lock (_lock) { _processed++; _failed++; }
+                        continue;
+                    }
+
+                    var audioPath = Path.Combine(recordingsDir, name);
+                    if (!File.Exists(audioPath))
+                    {
+                        _logger.LogDebug("Backfill: audio file missing for {Id} at {Path}", log.Id, audioPath);
+                        lock (_lock) { _processed++; _failed++; }
+                        continue;
+                    }
+
+                    var ok = await _transcription.RetranscribeAsync(log, audioPath);
+                    lock (_lock)
+                    {
+                        _processed++;
+                        if (ok) _succeeded++; else _failed++;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Backfill failed for {Id}", log.Id);
+                    lock (_lock) { _processed++; _failed++; }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Stopped — handled in finally.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Transcription backfill run failed");
+            lock (_lock) _message = "Error: " + ex.Message;
+        }
+        finally
+        {
+            lock (_lock)
+            {
+                var cancelled = _cts?.IsCancellationRequested == true;
+                _running = false;
+                _current = null;
+                _finishedUtc = DateTime.UtcNow.ToString("o");
+                if (cancelled)
+                {
+                    _message = $"Stopped. {_processed}/{_total} processed ({_succeeded} transcribed).";
+                }
+                else if (_total > 0)
+                {
+                    _message = $"Done. {_succeeded} transcribed, {_failed} failed of {_total}.";
+                }
+                _cts?.Dispose();
+                _cts = null;
+            }
+            _logger.LogInformation("Transcription backfill finished.");
+        }
+    }
+}

--- a/server/OpenScanner.Server/Services/GpsService.cs
+++ b/server/OpenScanner.Server/Services/GpsService.cs
@@ -13,6 +13,14 @@ public class GpsService : BackgroundService
     private readonly ILogger<GpsService> _logger;
     public GpsData? LastKnownLocation { get; private set; }
     private DateTime _lastUpdate = DateTime.MinValue;
+    private volatile bool _gpsdConnected;
+
+    /// <summary>Whether the service currently has a live TCP connection to gpsd.</summary>
+    public bool IsGpsdConnected => _gpsdConnected;
+
+    /// <summary>Seconds since the last GPS fix update, or null if none received yet.</summary>
+    public double? SecondsSinceLastFix =>
+        _lastUpdate == DateTime.MinValue ? null : (DateTime.UtcNow - _lastUpdate).TotalSeconds;
 
     /// <summary>
     /// Event triggered when a new GPS location update is received.
@@ -52,6 +60,7 @@ public class GpsService : BackgroundService
                 using var client = new TcpClient();
                 // gpsd default port is 2947
                 await client.ConnectAsync("localhost", 2947, stoppingToken);
+                _gpsdConnected = true;
                 _logger.LogInformation("Connected to gpsd");
 
                 using var stream = client.GetStream();
@@ -102,6 +111,10 @@ public class GpsService : BackgroundService
                     _logger.LogWarning("GPSD Connection failed (retrying in 5s): " + ex.Message);
                 }
                 await Task.Delay(5000, stoppingToken);
+            }
+            finally
+            {
+                _gpsdConnected = false;
             }
         }
     }

--- a/server/OpenScanner.Server/Services/RecordingCleanupService.cs
+++ b/server/OpenScanner.Server/Services/RecordingCleanupService.cs
@@ -21,6 +21,15 @@ public class RecordingCleanupService : BackgroundService
     private readonly long _minFreeBytes;
     private readonly string _recordingsPath;
 
+    /// <summary>UTC time of the last cleanup tick, or null before the first run.</summary>
+    public DateTime? LastRunUtc { get; private set; }
+
+    /// <summary>Free bytes on the recordings volume observed at the last tick.</summary>
+    public long? LastFreeBytes { get; private set; }
+
+    /// <summary>Total recordings purged since startup.</summary>
+    public int TotalPurged { get; private set; }
+
     public RecordingCleanupService(IDatabase db, ILogger<RecordingCleanupService> logger, IConfiguration config)
     {
         _db = db;
@@ -45,6 +54,8 @@ public class RecordingCleanupService : BackgroundService
             try
             {
                 await Task.Delay(CheckInterval, stoppingToken);
+                LastRunUtc = DateTime.UtcNow;
+                LastFreeBytes = GetFreeBytes();
                 await EnforceFreeSpaceAsync(stoppingToken);
             }
             catch (OperationCanceledException)
@@ -84,6 +95,7 @@ public class RecordingCleanupService : BackgroundService
             {
                 await _db.DeleteTransmissionAsync(id);
                 totalDeleted++;
+                TotalPurged++;
             }
 
             free = GetFreeBytes();

--- a/server/OpenScanner.Server/Services/RecordingService.cs
+++ b/server/OpenScanner.Server/Services/RecordingService.cs
@@ -323,10 +323,15 @@ public class RecordingService : IRecordingService
                                     int? sourceID, int? targetID,
                                     string? lastDetectedTone, string? speakerChain)
     {
-        var duration = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTime) / 1000.0;
-        _logger.LogInformation($"Recording duration: {duration:F1}s. Raw file exists: {File.Exists(recordingPath)}");
+        // Wall-clock elapsed is used only as a coarse liveness gate. The stored
+        // duration is derived from the audio actually written (below) so it
+        // matches the playable clip, since wall-clock over-counts the silent
+        // finalize hang time (2s, or up to 6s after a tone-out) and under-counts
+        // the pre-roll buffer prepended at the start.
+        var elapsed = (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() - startTime) / 1000.0;
+        _logger.LogInformation($"Recording elapsed: {elapsed:F1}s. Raw file exists: {File.Exists(recordingPath)}");
 
-        if (duration >= 0.5 && recordingPath != null && File.Exists(recordingPath) && channel != null)
+        if (elapsed >= 0.5 && recordingPath != null && File.Exists(recordingPath) && channel != null)
         {
             var fileInfo = new FileInfo(recordingPath);
             if (fileInfo.Length < 4096)
@@ -335,6 +340,11 @@ public class RecordingService : IRecordingService
                 _logger.LogInformation("Deleted small recording file (less than 4KB).");
                 return;
             }
+
+            // Raw audio is 48 kHz mono 16-bit PCM = 96000 bytes/sec. Deriving the
+            // duration from the byte count matches the actual MP3 length.
+            const double RawBytesPerSecond = 48000.0 * 2.0;
+            var duration = fileInfo.Length / RawBytesPerSecond;
 
             // Convert RAW to compressed MP3 (mono, 32 kbps) to save disk space.
             var mp3Path = Path.ChangeExtension(recordingPath, ".mp3");

--- a/server/OpenScanner.Server/Services/RecordingService.cs
+++ b/server/OpenScanner.Server/Services/RecordingService.cs
@@ -39,6 +39,37 @@ public class RecordingService : IRecordingService
     public bool IsChannelRecording(double frequency) => _activeRecordings.ContainsKey(frequency);
 
     /// <inheritdoc />
+    public int ActiveRecordingCount
+    {
+        get
+        {
+            var count = _activeRecordings.Count;
+            lock (_audioLock)
+            {
+                if (_recordingStream != null) count++;
+            }
+            return count;
+        }
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> ActiveRecordingIds
+    {
+        get
+        {
+            var ids = _activeRecordings.Values
+                .OrderByDescending(r => r.StartTime)
+                .Select(r => $"log_{r.StartTime}")
+                .ToList();
+            lock (_audioLock)
+            {
+                if (_recordingStream != null) ids.Insert(0, $"log_{_recordingStartTime}");
+            }
+            return ids;
+        }
+    }
+
+    /// <inheritdoc />
     public string? CurrentRecordingId
     {
         get

--- a/server/OpenScanner.Server/Services/SupportService.cs
+++ b/server/OpenScanner.Server/Services/SupportService.cs
@@ -75,17 +75,34 @@ public class SupportService : ISupportService
     private readonly IDatabase _db;
     private readonly IRadioSource _radio;
     private readonly GpsService _gps;
+    private readonly ITranscriptionService _transcription;
+    private readonly WebSocketBroadcaster _broadcaster;
+    private readonly IRecordingService _recording;
+    private readonly RecordingCleanupService _cleanup;
+
+    // Previous CPU samples, retained so a percentage can be computed from the
+    // delta between successive polls (this service is a singleton).
+    private readonly object _cpuLock = new();
+    private (long Idle, long Total)? _lastProcStat;
+    private (DateTime When, TimeSpan Cpu)? _lastProcessCpu;
+
+    // systemd units the debug page reports on, in display order.
+    private static readonly string[] MonitoredUnits = { "openscanner", "gpsd" };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SupportService"/> class.
     /// </summary>
-    public SupportService(IConfiguration configuration, ILoggerProvider loggerProvider, IDatabase db, IRadioSource radio, GpsService gps)
+    public SupportService(IConfiguration configuration, ILoggerProvider loggerProvider, IDatabase db, IRadioSource radio, GpsService gps, ITranscriptionService transcription, WebSocketBroadcaster broadcaster, IRecordingService recording, RecordingCleanupService cleanup)
     {
         _configuration = configuration;
         _loggerProvider = (MemoryLoggerProvider)loggerProvider;
         _db = db;
         _radio = radio;
         _gps = gps;
+        _transcription = transcription;
+        _broadcaster = broadcaster;
+        _recording = recording;
+        _cleanup = cleanup;
     }
 
     /// <inheritdoc />
@@ -145,6 +162,365 @@ public class SupportService : ISupportService
 
         info["CpuCores"] = Environment.ProcessorCount.ToString();
         return info;
+    }
+
+    /// <inheritdoc />
+    public SystemStats GetSystemStats()
+    {
+        var cpu = GetCpuPercent();
+        var (usedBytes, totalBytes) = GetMemoryBytes();
+        var memPct = totalBytes > 0 ? (double)usedBytes / totalBytes * 100.0 : 0;
+
+        return new SystemStats(
+            Math.Round(cpu, 1),
+            Math.Round(memPct, 1),
+            usedBytes / 1024 / 1024,
+            totalBytes / 1024 / 1024,
+            _transcription.GetQueueStatus());
+    }
+
+    /// <inheritdoc />
+    public async Task<DiagnosticsSnapshot> GetDiagnosticsAsync()
+    {
+        var state = _radio.GetState();
+        var scanner = new ScannerSummary(
+            state.Status,
+            state.IsHardwareConnected,
+            state.CurrentFrequency,
+            state.CurrentSignalDb,
+            state.SignalStrength,
+            state.Gain,
+            state.Squelch,
+            state.IsAudioStreaming);
+
+        var gps = new GpsDiagnostics(
+            _gps.IsGpsdConnected,
+            _gps.SecondsSinceLastFix.HasValue ? Math.Round(_gps.SecondsSinceLastFix.Value, 1) : null,
+            _gps.LastKnownLocation);
+
+        DbStats dbStats;
+        try
+        {
+            dbStats = await _db.GetDbStatsAsync();
+        }
+        catch (Exception ex)
+        {
+            _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to read DB stats");
+            dbStats = new DbStats(0, 0, 0, null, null);
+        }
+
+        var connections = new ConnectionStats(_broadcaster.ControlClientCount, _broadcaster.AudioClientCount);
+        var recording = new RecordingActivity(_recording.ActiveRecordingCount, _recording.ActiveRecordingIds.ToList());
+        var cleanup = new CleanupStatus(
+            _cleanup.LastRunUtc?.ToString("o"),
+            _cleanup.LastFreeBytes,
+            _cleanup.TotalPurged);
+
+        string? modelStatus = null;
+        try { modelStatus = await _db.GetSettingAsync("TranscriptionModelStatus"); }
+        catch (Exception ex) { _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to read model status"); }
+
+        return new DiagnosticsSnapshot(
+            GetUptime(),
+            scanner,
+            gps,
+            dbStats,
+            connections,
+            recording,
+            _radio.GetDiagnostics(),
+            cleanup,
+            modelStatus);
+    }
+
+    // System-wide CPU utilisation (0-100). Uses /proc/stat deltas on Linux and
+    // falls back to this process's CPU time on other platforms (dev/macOS).
+    private double GetCpuPercent()
+    {
+        lock (_cpuLock)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/proc/stat"))
+            {
+                try
+                {
+                    var first = File.ReadLines("/proc/stat").FirstOrDefault();
+                    if (first != null && first.StartsWith("cpu "))
+                    {
+                        var parts = first.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                        // parts[0]="cpu"; then user nice system idle iowait irq softirq steal ...
+                        var values = parts.Skip(1).Select(p => long.TryParse(p, out var v) ? v : 0).ToArray();
+                        long idle = values.Length > 3 ? values[3] + (values.Length > 4 ? values[4] : 0) : 0; // idle + iowait
+                        long total = values.Sum();
+
+                        double pct = 0;
+                        if (_lastProcStat is { } prev && total > prev.Total)
+                        {
+                            var dTotal = total - prev.Total;
+                            var dIdle = idle - prev.Idle;
+                            pct = (1.0 - (double)dIdle / dTotal) * 100.0;
+                        }
+                        _lastProcStat = (idle, total);
+                        return Math.Clamp(pct, 0, 100);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to read /proc/stat");
+                }
+            }
+
+            // Cross-platform fallback: this process's CPU usage across all cores.
+            try
+            {
+                using var proc = Process.GetCurrentProcess();
+                var now = DateTime.UtcNow;
+                var cpu = proc.TotalProcessorTime;
+                double pct = 0;
+                if (_lastProcessCpu is { } prev)
+                {
+                    var wallMs = (now - prev.When).TotalMilliseconds;
+                    var cpuMs = (cpu - prev.Cpu).TotalMilliseconds;
+                    if (wallMs > 0)
+                        pct = cpuMs / (wallMs * Environment.ProcessorCount) * 100.0;
+                }
+                _lastProcessCpu = (now, cpu);
+                return Math.Clamp(pct, 0, 100);
+            }
+            catch (Exception ex)
+            {
+                _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to compute process CPU");
+                return 0;
+            }
+        }
+    }
+
+    // Returns (usedBytes, totalBytes) of physical memory. Uses /proc/meminfo on
+    // Linux; elsewhere reports the managed heap against total available memory.
+    private (long Used, long Total) GetMemoryBytes()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/proc/meminfo"))
+        {
+            try
+            {
+                long total = 0, available = 0;
+                foreach (var line in File.ReadLines("/proc/meminfo"))
+                {
+                    if (line.StartsWith("MemTotal:")) total = ParseMeminfoKb(line);
+                    else if (line.StartsWith("MemAvailable:")) available = ParseMeminfoKb(line);
+                    if (total > 0 && available > 0) break;
+                }
+                if (total > 0)
+                    return ((total - available) * 1024, total * 1024);
+            }
+            catch (Exception ex)
+            {
+                _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to read /proc/meminfo");
+            }
+        }
+
+        try
+        {
+            var totalAvail = GC.GetGCMemoryInfo().TotalAvailableMemoryBytes;
+            using var proc = Process.GetCurrentProcess();
+            var used = proc.WorkingSet64;
+            if (totalAvail <= 0) totalAvail = used;
+            return (used, totalAvail);
+        }
+        catch (Exception ex)
+        {
+            _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to read process memory");
+            return (0, 0);
+        }
+    }
+
+    // "MemTotal:       8123456 kB" -> 8123456
+    private static long ParseMeminfoKb(string line)
+    {
+        var parts = line.Split(new[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length >= 2 && long.TryParse(parts[1], out var kb) ? kb : 0;
+    }
+
+    /// <inheritdoc />
+    public ServicesSnapshot GetServices()
+    {
+        return new ServicesSnapshot(GetServiceStatuses(), GetListeningPorts());
+    }
+
+    private List<ServiceStatus> GetServiceStatuses()
+    {
+        var result = new List<ServiceStatus>();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            foreach (var unit in MonitoredUnits)
+            {
+                var output = RunCommand("systemctl", new[] { "show", unit, "-p", "ActiveState", "-p", "SubState", "-p", "MainPID", "-p", "Description" }, 4000);
+                if (output == null)
+                {
+                    // systemctl missing entirely: stop probing further units.
+                    break;
+                }
+
+                var props = ParseKeyValues(output);
+                var active = props.GetValueOrDefault("ActiveState", "unknown");
+                var sub = props.GetValueOrDefault("SubState", "");
+                var pid = props.GetValueOrDefault("MainPID", "0");
+                var desc = props.GetValueOrDefault("Description", unit);
+
+                // A never-installed unit shows LoadState=not-found / ActiveState=inactive.
+                var detail = pid != "0" && !string.IsNullOrEmpty(pid)
+                    ? $"{desc} (pid {pid})"
+                    : desc;
+                result.Add(new ServiceStatus(unit, string.IsNullOrEmpty(sub) ? active : $"{active} ({sub})", detail));
+            }
+        }
+
+        if (result.Count == 0)
+        {
+            // No systemd (e.g. macOS dev): report the app itself as the running service.
+            using var self = Process.GetCurrentProcess();
+            result.Add(new ServiceStatus("openscanner", "active (running)", $"OpenScanner Server (pid {self.Id})"));
+        }
+
+        return result;
+    }
+
+    private List<ListeningPort> GetListeningPorts()
+    {
+        var ports = new List<ListeningPort>();
+
+        // Prefer `ss` on Linux; fall back to `lsof` (available on macOS/dev).
+        var ss = RuntimeInformation.IsOSPlatform(OSPlatform.Linux)
+            ? RunCommand("ss", new[] { "-H", "-ltnp" }, 4000)
+            : null;
+
+        if (ss != null)
+        {
+            foreach (var line in ss.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                var cols = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                // State Recv-Q Send-Q Local:Port Peer:Port [users:(("proc",pid=..))]
+                if (cols.Length < 4) continue;
+                var port = ExtractPort(cols[3]);
+                if (port <= 0) continue;
+                var proc = cols.Length >= 6 ? ExtractSsProcess(cols[5]) : "";
+                ports.Add(new ListeningPort("tcp", port, proc));
+            }
+        }
+        else
+        {
+            var lsof = RunCommand("lsof", new[] { "-nP", "-iTCP", "-sTCP:LISTEN" }, 4000);
+            if (lsof != null)
+            {
+                foreach (var line in lsof.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1))
+                {
+                    var cols = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    if (cols.Length < 9) continue;
+                    var port = ExtractPort(cols[8]); // NAME column, e.g. *:8080
+                    if (port <= 0) continue;
+                    ports.Add(new ListeningPort("tcp", port, cols[0]));
+                }
+            }
+        }
+
+        // Distinct by port, sorted for a stable display.
+        return ports
+            .GroupBy(p => p.Port)
+            .Select(g => g.First())
+            .OrderBy(p => p.Port)
+            .ToList();
+    }
+
+    // Pull the trailing port out of an address token like "0.0.0.0:80", "[::]:443", "*:8080".
+    private static int ExtractPort(string addr)
+    {
+        var idx = addr.LastIndexOf(':');
+        if (idx < 0 || idx == addr.Length - 1) return -1;
+        return int.TryParse(addr[(idx + 1)..], out var port) ? port : -1;
+    }
+
+    // users:(("dotnet",pid=1234,fd=200)) -> "dotnet"
+    private static string ExtractSsProcess(string users)
+    {
+        var start = users.IndexOf("((\"", StringComparison.Ordinal);
+        if (start < 0) return "";
+        start += 3;
+        var end = users.IndexOf('"', start);
+        return end > start ? users[start..end] : "";
+    }
+
+    private static Dictionary<string, string> ParseKeyValues(string output)
+    {
+        var dict = new Dictionary<string, string>();
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = line.IndexOf('=');
+            if (eq > 0) dict[line[..eq]] = line[(eq + 1)..].Trim();
+        }
+        return dict;
+    }
+
+    /// <inheritdoc />
+    public async Task<string> GetSystemdLogsAsync(int lines)
+    {
+        lines = Math.Clamp(lines, 1, 5000);
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var output = await RunCommandAsync("journalctl", new[] { "-u", "openscanner", "-n", lines.ToString(), "--no-pager", "-o", "short-iso" }, 8000);
+            if (!string.IsNullOrWhiteSpace(output))
+                return output;
+        }
+
+        // Fallback (macOS dev, or journalctl unavailable): in-memory log buffer.
+        var buffered = _loggerProvider.GetLogs().ToArray();
+        var tail = buffered.Length > lines ? buffered[^lines..] : buffered;
+        return string.Join(Environment.NewLine, tail);
+    }
+
+    // Runs a command and returns stdout, or null if the executable is missing /
+    // fails to start. Non-zero exit codes still return whatever stdout was produced.
+    private string? RunCommand(string fileName, string[] args, int timeoutMs)
+    {
+        return RunCommandAsync(fileName, args, timeoutMs).GetAwaiter().GetResult();
+    }
+
+    private async Task<string?> RunCommandAsync(string fileName, string[] args, int timeoutMs)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(fileName)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            foreach (var a in args) psi.ArgumentList.Add(a);
+
+            using var proc = Process.Start(psi);
+            if (proc == null) return null;
+
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+            _ = proc.StandardError.ReadToEndAsync();
+
+            using var cts = new CancellationTokenSource(timeoutMs);
+            try
+            {
+                await proc.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { proc.Kill(true); } catch { }
+                return null;
+            }
+
+            return await stdoutTask;
+        }
+        catch (Exception ex)
+        {
+            _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Command '{Cmd}' failed", fileName);
+            return null;
+        }
     }
 
     /// <summary>

--- a/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
+++ b/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
@@ -19,6 +19,12 @@ public class WebSocketBroadcaster
     private readonly ConcurrentDictionary<string, SocketSession> _audioSessions = new();
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
 
+    /// <summary>Number of connected control (state/log) WebSocket clients.</summary>
+    public int ControlClientCount => _controlSessions.Count;
+
+    /// <summary>Number of connected audio-streaming WebSocket clients.</summary>
+    public int AudioClientCount => _audioSessions.Count;
+
     private class SocketSession
     {
         public WebSocket Socket { get; }

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -53,6 +53,39 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
 
         // Start background setting monitor
         _ = StartSettingsMonitor(_cts.Token);
+
+        // Proactively ensure the configured model is present (and reflect its
+        // status) so the first transmission isn't blocked on a large download.
+        PrepareModel(GetConfiguredModel());
+    }
+
+    private string GetConfiguredModel()
+    {
+        string? model = null;
+        try { model = _db.GetSettingAsync("TranscriptionModel").GetAwaiter().GetResult(); }
+        catch { /* fall through to config/default */ }
+        if (string.IsNullOrWhiteSpace(model)) model = _config["Transcription:Model"];
+        if (string.IsNullOrWhiteSpace(model)) model = "small.en";
+        return model;
+    }
+
+    public void PrepareModel(string modelName)
+    {
+        if (!IsValidModelName(modelName)) return;
+        Task.Run(() =>
+        {
+            try
+            {
+                var whisperRoot = FindWhisperRoot();
+                var modelPath = Path.Combine(whisperRoot, $"models/ggml-{modelName}.bin");
+                if (File.Exists(modelPath)) { SetModelStatus($"ready:{modelName}"); return; }
+                EnsureModelAvailable(whisperRoot, modelName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "PrepareModel failed for '{Model}'", modelName);
+            }
+        });
     }
 
     private int GetTargetThreadCount()
@@ -219,54 +252,154 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         return args;
     }
 
+    // Serializes model downloads so concurrent workers don't fetch the same
+    // (or different) models at once.
+    private static readonly SemaphoreSlim _modelDownloadLock = new(1, 1);
+
+    // ggml model names are simple tokens (e.g. "large-v3-turbo-q5_0", "small.en").
+    // Validate before using in a path or passing to the download script.
+    internal static bool IsValidModelName(string name) =>
+        !string.IsNullOrWhiteSpace(name) &&
+        System.Text.RegularExpressions.Regex.IsMatch(name, "^[A-Za-z0-9._-]+$");
+
+    // Walk up from the working directory to locate the cloned whisper.cpp folder.
+    private static string FindWhisperRoot()
+    {
+        var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        for (int i = 0; i < 6 && currentDir != null; i++)
+        {
+            var probe = Path.Combine(currentDir.FullName, "whisper.cpp");
+            if (Directory.Exists(probe)) return probe;
+
+            probe = Path.Combine(currentDir.FullName, "../whisper.cpp");
+            if (Directory.Exists(probe)) return Path.GetFullPath(probe);
+
+            currentDir = currentDir.Parent;
+        }
+        return Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "../../whisper.cpp"));
+    }
+
+    private void SetModelStatus(string status)
+    {
+        try { _db.SetSettingAsync("TranscriptionModelStatus", status).GetAwaiter().GetResult(); }
+        catch (Exception ex) { _logger.LogWarning(ex, "Failed to write TranscriptionModelStatus"); }
+    }
+
+    // Ensure the ggml model file for `modelName` exists under whisperRoot/models,
+    // downloading it via whisper.cpp's download-ggml-model.sh if missing. Returns
+    // true when the model is present. Surfaces progress via the
+    // TranscriptionModelStatus setting so the web UI can show it.
+    private bool EnsureModelAvailable(string whisperRoot, string modelName)
+    {
+        var modelPath = Path.Combine(whisperRoot, $"models/ggml-{modelName}.bin");
+        if (File.Exists(modelPath)) return true;
+
+        _modelDownloadLock.Wait();
+        try
+        {
+            // Re-check now that we hold the lock (another worker may have fetched it).
+            if (File.Exists(modelPath)) return true;
+
+            var script = Path.Combine(whisperRoot, "models/download-ggml-model.sh");
+            if (!File.Exists(script))
+            {
+                _logger.LogError("Model download script not found at {Script}", script);
+                SetModelStatus($"error: download script missing");
+                return false;
+            }
+
+            _logger.LogInformation("Downloading Whisper model '{Model}'...", modelName);
+            SetModelStatus($"downloading:{modelName}");
+
+            var psi = new ProcessStartInfo("bash")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = whisperRoot
+            };
+            psi.ArgumentList.Add(script);
+            psi.ArgumentList.Add(modelName);
+
+            try
+            {
+                using var proc = Process.Start(psi);
+                if (proc == null)
+                {
+                    SetModelStatus("error: failed to start download");
+                    return false;
+                }
+                var stderr = proc.StandardError.ReadToEndAsync();
+                _ = proc.StandardOutput.ReadToEndAsync(); // drain stdout so the pipe can't fill
+                // Large models over a slow link can take a while; cap at 30 min.
+                if (!proc.WaitForExit(30 * 60 * 1000))
+                {
+                    proc.Kill(true);
+                    _logger.LogError("Model download for '{Model}' timed out.", modelName);
+                    SetModelStatus("error: download timed out");
+                    return false;
+                }
+
+                if (proc.ExitCode != 0 || !File.Exists(modelPath))
+                {
+                    _logger.LogError("Model download for '{Model}' failed (exit {Code}).\n{Err}", modelName, proc.ExitCode, stderr.Result);
+                    SetModelStatus($"error: download failed");
+                    return false;
+                }
+
+                _logger.LogInformation("Whisper model '{Model}' downloaded.", modelName);
+                SetModelStatus($"ready:{modelName}");
+                return true;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error downloading Whisper model '{Model}'", modelName);
+                SetModelStatus($"error: {ex.Message}");
+                return false;
+            }
+        }
+        finally
+        {
+            _modelDownloadLock.Release();
+        }
+    }
+
     public string? TranscribeAudio(string audioPath)
     {
         // Check setting
         var enabled = _db.GetSettingAsync("EnableTranscription").GetAwaiter().GetResult();
         if (enabled != "true") return null;
 
-        // Get model name from config (e.g. "large-v3-turbo-q5_0")
-        var modelName = _config["Transcription:Model"] ?? "small.en";
+        // Model is managed from the web-app settings (DB), falling back to
+        // appsettings then a safe default.
+        var modelName = _db.GetSettingAsync("TranscriptionModel").GetAwaiter().GetResult();
+        if (string.IsNullOrWhiteSpace(modelName)) modelName = _config["Transcription:Model"];
+        if (string.IsNullOrWhiteSpace(modelName)) modelName = "small.en";
+        if (!IsValidModelName(modelName))
+        {
+            _logger.LogError("Invalid transcription model name '{Model}'; refusing to use it.", modelName);
+            return null;
+        }
 
         // Temp file for resampling to 16k
         var tempWavPath = audioPath + ".16k.wav";
-        // Robustly find whisper.cpp root
-        var currentDir = new DirectoryInfo(Directory.GetCurrentDirectory());
-        string? whisperRoot = null;
-
-        // 1. Search up to find whisper.cpp
-        for (int i = 0; i < 6; i++)
-        {
-            if (currentDir == null) break;
-            var probe = Path.Combine(currentDir.FullName, "whisper.cpp");
-            if (Directory.Exists(probe))
-            {
-                whisperRoot = probe;
-                break;
-            }
-
-            probe = Path.Combine(currentDir.FullName, "../whisper.cpp");
-            if (Directory.Exists(probe))
-            {
-                whisperRoot = Path.GetFullPath(probe);
-                break;
-            }
-
-            currentDir = currentDir.Parent;
-        }
-
-        if (whisperRoot == null)
-        {
-            var projectRoot = Directory.GetCurrentDirectory();
-            whisperRoot = Path.GetFullPath(Path.Combine(projectRoot, "../../whisper.cpp"));
-        }
-
+        var whisperRoot = FindWhisperRoot();
         var whisperBin = Path.Combine(whisperRoot, "build/bin/whisper-cli");
         var modelPath = Path.Combine(whisperRoot, $"models/ggml-{modelName}.bin");
 
-        if (!File.Exists(whisperBin) || !File.Exists(modelPath))
+        if (!File.Exists(whisperBin))
         {
-            _logger.LogError($"Whisper not found at {whisperBin} or model missing at {modelPath}. Search root was: {whisperRoot}");
+            _logger.LogError($"Whisper binary not found at {whisperBin}. Search root was: {whisperRoot}");
+            return null;
+        }
+
+        // Download the selected model on demand if it isn't present yet. Blocks
+        // this worker until ready (every queued clip needs the same model, so
+        // there is nothing else to do meanwhile).
+        if (!EnsureModelAvailable(whisperRoot, modelName))
+        {
+            _logger.LogError("Transcription model '{Model}' is not available and could not be downloaded.", modelName);
             return null;
         }
 

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -209,6 +209,17 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         _queueChannel.Writer.TryWrite((log, audioPath));
     }
 
+    public async Task<bool> RetranscribeAsync(CallLog log, string audioPath)
+    {
+        // Runs on the caller's (backfill) thread — it deliberately does not use the
+        // live worker queue, so live transmissions keep priority.
+        var transcription = TranscribeAudio(audioPath);
+        await _db.UpdateTranscriptionAsync(log.Id, transcription);
+        log.Transcription = transcription;
+        OnTranscriptionCompleted?.Invoke(log);
+        return !string.IsNullOrWhiteSpace(transcription);
+    }
+
     public TranscriptionQueueStatus GetQueueStatus()
     {
         // Unbounded channels support Count; guard anyway in case that changes.

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -191,13 +191,41 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         }
     }
 
+    // Default generic radio/dispatch prompt. Biases Whisper toward scanner
+    // terminology and style. Overridable via Transcription:Prompt config.
+    private const string DefaultPrompt = "Dispatch, Unit 1, 10-4, copy, over. Priority traffic, code 3 response to street intersection. Suspect description: white male, blue jeans. License plate, vehicle registration, bolo. Structure fire, medical emergency, staging area. Status check, affirmative, negative, stand by. Channel 2, tac channel, command post. Kilo, Tango, Zulu, X-ray. 10-20 location, 10-8 in service, 10-7 out of service.";
+
+    // Voice-tuned ffmpeg filter chain applied before handing audio to Whisper:
+    // band-limit to the narrowband voice range, denoise, and adaptively normalize
+    // loudness (replaces a flat gain that clipped hot clips and under-boosted
+    // quiet ones). Overridable via Transcription:AudioFilters config.
+    private const string DefaultAudioFilters = "highpass=f=200,lowpass=f=3500,afftdn,dynaudnorm=f=200:g=5,alimiter=limit=0.95";
+
+    // Build the whisper-cli argument string. Kept pure/static so it can be unit
+    // tested without a real whisper binary or audio file.
+    internal static string BuildWhisperArgs(string modelPath, string wavPath, string prompt, int beamSize, int threads, string? extraArgs)
+    {
+        // -nt: no timestamps, -otxt: write .txt, -l en: force English.
+        // -bs/-bo: beam search (accuracy-first). -t: internal threads.
+        // -mc 0: don't carry text context across 30s windows — radio clips are
+        //   short/independent, so this removes a common hallucination/repetition
+        //   path (equivalent to condition_on_previous_text=false).
+        // -et 2.8: entropy threshold that keeps the temperature fallback which
+        //   reduces garbage output on hard audio.
+        var args = $"-m \"{modelPath}\" -f \"{wavPath}\" -nt -otxt -l en" +
+                   $" -bs {beamSize} -bo {beamSize} -t {threads} -mc 0 -et 2.8" +
+                   $" --prompt \"{prompt}\"";
+        if (!string.IsNullOrWhiteSpace(extraArgs)) args += " " + extraArgs.Trim();
+        return args;
+    }
+
     public string? TranscribeAudio(string audioPath)
     {
         // Check setting
         var enabled = _db.GetSettingAsync("EnableTranscription").GetAwaiter().GetResult();
         if (enabled != "true") return null;
 
-        // Get model name from config (e.g. "small.en")
+        // Get model name from config (e.g. "large-v3-turbo-q5_0")
         var modelName = _config["Transcription:Model"] ?? "small.en";
 
         // Temp file for resampling to 16k
@@ -262,8 +290,10 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
 
         convertStart.ArgumentList.Add("-i");
         convertStart.ArgumentList.Add(audioPath);
+        var audioFilters = _config["Transcription:AudioFilters"];
+        if (string.IsNullOrWhiteSpace(audioFilters)) audioFilters = DefaultAudioFilters;
         convertStart.ArgumentList.Add("-af");
-        convertStart.ArgumentList.Add("volume=15dB");
+        convertStart.ArgumentList.Add(audioFilters);
         convertStart.ArgumentList.Add("-ar");
         convertStart.ArgumentList.Add("16000");
         convertStart.ArgumentList.Add("-ac");
@@ -286,10 +316,15 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
 
         if (!File.Exists(tempWavPath)) return null;
 
-        // 2. Run Whisper with Radio Context
-        // Prompt helps Whisper bias towards radio terminology and style
-        var prompt = "Dispatch, Unit 1, 10-4, copy, over. Priority traffic, code 3 response to street intersection. Suspect description: white male, blue jeans. License plate, vehicle registration, bolo. Structure fire, medical emergency, staging area. Status check, affirmative, negative, stand by. Channel 2, tac channel, command post. Kilo, Tango, Zulu, X-ray. 10-20 location, 10-8 in service, 10-7 out of service.";
-        var whisperArgs = $"-m \"{modelPath}\" -f \"{tempWavPath}\" -nt -otxt -l en --prompt \"{prompt}\"";
+        // 2. Run Whisper with radio context + accuracy-oriented decode settings.
+        var prompt = _config["Transcription:Prompt"];
+        if (string.IsNullOrWhiteSpace(prompt)) prompt = DefaultPrompt;
+        var beamSize = int.TryParse(_config["Transcription:BeamSize"], out var bs) && bs > 0 ? bs : 5;
+        var threads = int.TryParse(_config["Transcription:WhisperThreads"], out var t) && t > 0
+            ? t
+            : Math.Max(1, Environment.ProcessorCount);
+        var extraArgs = _config["Transcription:ExtraArgs"];
+        var whisperArgs = BuildWhisperArgs(modelPath, tempWavPath, prompt, beamSize, threads, extraArgs);
 
         var whisperStart = new ProcessStartInfo(whisperBin, whisperArgs)
         {
@@ -308,7 +343,10 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
                 var stdoutTask = proc.StandardOutput.ReadToEndAsync();
                 var stderrTask = proc.StandardError.ReadToEndAsync();
 
-                if (!proc.WaitForExit(120000)) // 120s timeout
+                // A large accuracy-first model on a Pi can be well below real time;
+                // allow more headroom than the old fixed 120s. Configurable.
+                var timeoutMs = (int.TryParse(_config["Transcription:TimeoutSeconds"], out var ts) && ts > 0 ? ts : 300) * 1000;
+                if (!proc.WaitForExit(timeoutMs))
                 {
                     _logger.LogError("Whisper timed out");
                     proc.Kill();

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -83,7 +83,7 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "PrepareModel failed for '{Model}'", modelName);
+                _logger.LogWarning(ex, "PrepareModel failed for '{Model}'", SafeForLog(modelName));
             }
         });
     }
@@ -282,6 +282,12 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         !string.IsNullOrWhiteSpace(name) &&
         System.Text.RegularExpressions.Regex.IsMatch(name, "^[A-Za-z0-9._-]+$");
 
+    // Strips line breaks from a user-influenced value before it is written to a log,
+    // preventing forged/injected log entries (CWE-117). Model names come from the
+    // web-app settings, so they are treated as untrusted at log sites.
+    private static string SafeForLog(string? value) =>
+        (value ?? string.Empty).Replace("\r", string.Empty).Replace("\n", string.Empty);
+
     // Walk up from the working directory to locate the cloned whisper.cpp folder.
     private static string FindWhisperRoot()
     {
@@ -328,7 +334,7 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
                 return false;
             }
 
-            _logger.LogInformation("Downloading Whisper model '{Model}'...", modelName);
+            _logger.LogInformation("Downloading Whisper model '{Model}'...", SafeForLog(modelName));
             SetModelStatus($"downloading:{modelName}");
 
             var psi = new ProcessStartInfo("bash")
@@ -356,25 +362,25 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
                 if (!proc.WaitForExit(30 * 60 * 1000))
                 {
                     proc.Kill(true);
-                    _logger.LogError("Model download for '{Model}' timed out.", modelName);
+                    _logger.LogError("Model download for '{Model}' timed out.", SafeForLog(modelName));
                     SetModelStatus("error: download timed out");
                     return false;
                 }
 
                 if (proc.ExitCode != 0 || !File.Exists(modelPath))
                 {
-                    _logger.LogError("Model download for '{Model}' failed (exit {Code}).\n{Err}", modelName, proc.ExitCode, stderr.Result);
+                    _logger.LogError("Model download for '{Model}' failed (exit {Code}).\n{Err}", SafeForLog(modelName), proc.ExitCode, stderr.Result);
                     SetModelStatus($"error: download failed");
                     return false;
                 }
 
-                _logger.LogInformation("Whisper model '{Model}' downloaded.", modelName);
+                _logger.LogInformation("Whisper model '{Model}' downloaded.", SafeForLog(modelName));
                 SetModelStatus($"ready:{modelName}");
                 return true;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error downloading Whisper model '{Model}'", modelName);
+                _logger.LogError(ex, "Error downloading Whisper model '{Model}'", SafeForLog(modelName));
                 SetModelStatus($"error: {ex.Message}");
                 return false;
             }
@@ -398,7 +404,7 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         if (string.IsNullOrWhiteSpace(modelName)) modelName = "small.en";
         if (!IsValidModelName(modelName))
         {
-            _logger.LogError("Invalid transcription model name '{Model}'; refusing to use it.", modelName);
+            _logger.LogError("Invalid transcription model name '{Model}'; refusing to use it.", SafeForLog(modelName));
             return null;
         }
 
@@ -419,7 +425,7 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         // there is nothing else to do meanwhile).
         if (!EnsureModelAvailable(whisperRoot, modelName))
         {
-            _logger.LogError("Transcription model '{Model}' is not available and could not be downloaded.", modelName);
+            _logger.LogError("Transcription model '{Model}' is not available and could not be downloaded.", SafeForLog(modelName));
             return null;
         }
 

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -477,8 +477,9 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
                 var stderrTask = proc.StandardError.ReadToEndAsync();
 
                 // A large accuracy-first model on a Pi can be well below real time;
-                // allow more headroom than the old fixed 120s. Configurable.
-                var timeoutMs = (int.TryParse(_config["Transcription:TimeoutSeconds"], out var ts) && ts > 0 ? ts : 300) * 1000;
+                // allow generous headroom (measured from when whisper starts, not
+                // from when the clip was queued). Configurable.
+                var timeoutMs = (int.TryParse(_config["Transcription:TimeoutSeconds"], out var ts) && ts > 0 ? ts : 600) * 1000;
                 if (!proc.WaitForExit(timeoutMs))
                 {
                     _logger.LogError("Whisper timed out");

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -209,6 +209,15 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         _queueChannel.Writer.TryWrite((log, audioPath));
     }
 
+    public TranscriptionQueueStatus GetQueueStatus()
+    {
+        // Unbounded channels support Count; guard anyway in case that changes.
+        var queued = _queueChannel.Reader.CanCount ? _queueChannel.Reader.Count : 0;
+        int workers;
+        lock (_workersLock) { workers = _workers.Count; }
+        return new TranscriptionQueueStatus(queued, workers);
+    }
+
     public void Dispose()
     {
         _cts.Cancel();

--- a/server/OpenScanner.Server/Sql/Transmissions/GetUntranscribedSince.sql
+++ b/server/OpenScanner.Server/Sql/Transmissions/GetUntranscribedSince.sql
@@ -1,0 +1,5 @@
+SELECT id, timestamp, frequency, alphaTag, description, lat, lon, alt, audio_path as AudioPath, duration, transcription, sourceID, targetID, detectedTone, speakerChain, isFavorite
+FROM transmissions
+WHERE (transcription IS NULL OR transcription = '')
+  AND timestamp >= @Since
+ORDER BY timestamp DESC

--- a/server/OpenScanner.Server/appsettings.json
+++ b/server/OpenScanner.Server/appsettings.json
@@ -13,7 +13,7 @@
     "Model": "large-v3-turbo-q5_0",
     "BeamSize": 5,
     "WhisperThreads": 0,
-    "TimeoutSeconds": 300,
+    "TimeoutSeconds": 600,
     "AudioFilters": "highpass=f=200,lowpass=f=3500,afftdn,dynaudnorm=f=200:g=5,alimiter=limit=0.95",
     "Prompt": "",
     "ExtraArgs": ""

--- a/server/OpenScanner.Server/appsettings.json
+++ b/server/OpenScanner.Server/appsettings.json
@@ -10,7 +10,13 @@
     "Department": ""
   },
   "Transcription": {
-    "Model": "small.en"
+    "Model": "large-v3-turbo-q5_0",
+    "BeamSize": 5,
+    "WhisperThreads": 0,
+    "TimeoutSeconds": 300,
+    "AudioFilters": "highpass=f=200,lowpass=f=3500,afftdn,dynaudnorm=f=200:g=5,alimiter=limit=0.95",
+    "Prompt": "",
+    "ExtraArgs": ""
   },
   "Radio": {
     "Provider": "RTL-SDR",

--- a/server/OpenScanner.Tests/Controllers/SettingsControllerTests.cs
+++ b/server/OpenScanner.Tests/Controllers/SettingsControllerTests.cs
@@ -9,12 +9,14 @@ namespace OpenScanner.Tests.Controllers;
 public class SettingsControllerTests
 {
     private readonly Mock<IDatabase> _dbMock;
+    private readonly Mock<ITranscriptionService> _transcriptionMock;
     private readonly SettingsController _controller;
 
     public SettingsControllerTests()
     {
         _dbMock = new Mock<IDatabase>();
-        _controller = new SettingsController(_dbMock.Object);
+        _transcriptionMock = new Mock<ITranscriptionService>();
+        _controller = new SettingsController(_dbMock.Object, _transcriptionMock.Object);
     }
 
     [Fact]
@@ -40,5 +42,18 @@ public class SettingsControllerTests
         // Assert
         Assert.NotNull(result);
         _dbMock.Verify(db => db.SetSettingAsync("Theme", "Dark"), Times.Once);
+        _transcriptionMock.Verify(t => t.PrepareModel(It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateSetting_TranscriptionModel_TriggersModelDownload()
+    {
+        // Act
+        var result = await _controller.UpdateSetting("TranscriptionModel", "medium.en") as OkResult;
+
+        // Assert
+        Assert.NotNull(result);
+        _dbMock.Verify(db => db.SetSettingAsync("TranscriptionModel", "medium.en"), Times.Once);
+        _transcriptionMock.Verify(t => t.PrepareModel("medium.en"), Times.Once);
     }
 }

--- a/server/OpenScanner.Tests/Services/SupportServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/SupportServiceTests.cs
@@ -17,12 +17,19 @@ public class SupportServiceTests
     private readonly Mock<ILoggerProvider> _loggerProviderMock = new();
     private readonly Mock<IDatabase> _dbMock = new();
     private readonly Mock<IRadioSource> _radioMock = new();
+    private readonly Mock<ITranscriptionService> _transcriptionMock = new();
+    private readonly Mock<IRecordingService> _recordingMock = new();
     private readonly Mock<GpsService> _gpsMock;
+    private readonly WebSocketBroadcaster _broadcaster;
+    private readonly RecordingCleanupService _cleanup;
 
     public SupportServiceTests()
     {
         _gpsMock = new Mock<GpsService>(new Mock<ILogger<GpsService>>().Object);
-        
+        _broadcaster = new WebSocketBroadcaster(_radioMock.Object, new Mock<ILogger<WebSocketBroadcaster>>().Object);
+        _cleanup = new RecordingCleanupService(_dbMock.Object, new Mock<ILogger<RecordingCleanupService>>().Object, new ConfigurationBuilder().Build());
+        _recordingMock.Setup(r => r.ActiveRecordingIds).Returns(new List<string>());
+
         // Setup Logger Provider
         var memLogger = new MemoryLoggerProvider();
         _loggerProviderMock.As<ILoggerProvider>(); // Just a placeholder, we'll pass concrete memLogger
@@ -33,7 +40,7 @@ public class SupportServiceTests
     {
         // Arrange
         var memLogger = new MemoryLoggerProvider();
-        var service = new SupportService(_configMock.Object, memLogger, _dbMock.Object, _radioMock.Object, _gpsMock.Object);
+        var service = new SupportService(_configMock.Object, memLogger, _dbMock.Object, _radioMock.Object, _gpsMock.Object, _transcriptionMock.Object, _broadcaster, _recordingMock.Object, _cleanup);
 
         // Act
         var info = service.GetVersionInfo();
@@ -60,7 +67,7 @@ public class SupportServiceTests
         _radioMock.Setup(r => r.GetState()).Returns(new ScannerState("IDLE", 0));
         _gpsMock.Object.OnGpsUpdate += (d) => { }; // trigger init
 
-        var service = new SupportService(_configMock.Object, memLogger, _dbMock.Object, _radioMock.Object, _gpsMock.Object);
+        var service = new SupportService(_configMock.Object, memLogger, _dbMock.Object, _radioMock.Object, _gpsMock.Object, _transcriptionMock.Object, _broadcaster, _recordingMock.Object, _cleanup);
 
         // Act
         var zipBytes = await service.CreateSupportPackageAsync();

--- a/server/OpenScanner.Tests/Services/WhisperTranscriptionServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/WhisperTranscriptionServiceTests.cs
@@ -53,4 +53,40 @@ public class WhisperTranscriptionServiceTests
         
         _dbMock.Verify(db => db.UpdateTranscriptionAsync("test_log_id", null), Times.Once);
     }
+
+    [Fact]
+    public void BuildWhisperArgs_IncludesAccuracyFlagsAndModelPromptWav()
+    {
+        var args = WhisperTranscriptionService.BuildWhisperArgs(
+            "/models/ggml-large-v3-turbo-q5_0.bin", "/tmp/clip.16k.wav", "radio prompt", 5, 4, null);
+
+        Assert.Contains("-m \"/models/ggml-large-v3-turbo-q5_0.bin\"", args);
+        Assert.Contains("-f \"/tmp/clip.16k.wav\"", args);
+        Assert.Contains("--prompt \"radio prompt\"", args);
+        Assert.Contains("-l en", args);
+        Assert.Contains("-nt", args);
+        // Accuracy / anti-hallucination flags.
+        Assert.Contains("-bs 5", args);
+        Assert.Contains("-bo 5", args);
+        Assert.Contains("-t 4", args);
+        Assert.Contains("-mc 0", args);
+        Assert.Contains("-et 2.8", args);
+    }
+
+    [Fact]
+    public void BuildWhisperArgs_AppendsExtraArgsWhenProvided()
+    {
+        var args = WhisperTranscriptionService.BuildWhisperArgs(
+            "/m.bin", "/a.wav", "p", 5, 4, "  --vad  ");
+
+        Assert.EndsWith("--vad", args);
+    }
+
+    [Fact]
+    public void BuildWhisperArgs_OmitsExtraArgsWhenNullOrBlank()
+    {
+        var args = WhisperTranscriptionService.BuildWhisperArgs("/m.bin", "/a.wav", "p", 5, 4, "   ");
+        // Blank ExtraArgs must not append anything after the prompt.
+        Assert.EndsWith("--prompt \"p\"", args);
+    }
 }


### PR DESCRIPTION
## Summary
This branch improves transcription quality and adds operational tooling for a headless OpenScanner deployment.

### Transcription
- Improved accuracy: better model default, decode flags, and audio pre-processing.
- Whisper model and PowerDMS slug are now managed from the web-app settings.
- Raised the Whisper subprocess timeout to 600s for slow hardware.
- **New: low-priority transcription backfill job** — re-transcribes recordings from the last 24h that are missing a transcription. It runs off the live worker queue and pauses whenever live work is pending, so real-time transmissions keep priority. Started/stopped/monitored from the System Debug page.

### Recording
- Store recording duration from audio length rather than wall-clock.
- Fix parallel recordings splitting mid-transmission.
- Script to compress old WAV recordings to MP3 (parallelized), plus old-duration fix.

### System Debug page (new)
Replaces the header's Download Support Package button with a System Debug page (the download button now lives inside it), showing:
- CPU/memory graphs (rolling 120s), transcription queue, running services, listening ports, and systemd (`journalctl -u openscanner`) logs.
- SDR/scanner state, GPS detail, recordings & DB stats, live WebSocket connections, storage/disk usage, and a health footer (uptime, version, model status, cleanup).
- The transcription backfill controls.

New backend endpoints under `/api/system/*` and `/api/transcription/backfill*`, fed by small getters across the DB, radio, GPS, recording, cleanup, and websocket services. RTL dongle internals (serial, tuner, PPM, dropped samples, temperature) are omitted since the SDR runs as an external subprocess.

## Testing
- Server builds on net10.0; **160/160 tests pass**.
- Client `npm run lint` and `tsc --noEmit` clean.
- Verified all new endpoints against a mock-mode server, including the backfill start/status/stop lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)