### PR TITLE
Fix MDC1200 unit IDs missing on recordings in parallel scan mode

### DIFF
--- a/server/OpenScanner.Server/Devices/ChannelPipeline.cs
+++ b/server/OpenScanner.Server/Devices/ChannelPipeline.cs
@@ -1,6 +1,7 @@
 using OpenScanner.Server.DSP;
 using OpenScanner.Server.Interfaces;
 using OpenScanner.Server.Models;
+using OpenScanner.Server.Services;
 
 namespace OpenScanner.Server.Devices;
 
@@ -16,12 +17,18 @@ public class ChannelPipeline : IDisposable
     private readonly Channelizer _channelizer;
     private readonly IDecoderFactory _decoderFactory;
     private readonly ILogger _logger;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly double _squelchDb;
 
     private IDecoder? _decoder;
     private CancellationTokenSource? _decoderCts;
     private bool _decoderStarted;
     private bool _disposed;
+
+    // Per-channel MDC1200 decoder for analog modes. Each parallel channel needs its
+    // own decoder so bursts are attributed to the right channel (a single shared
+    // decoder fed interleaved audio can neither decode reliably nor attribute).
+    private Mdc1200Decoder? _mdc;
 
     // Pre-allocated output buffer for channelizer (avoids per-call allocation)
     private byte[] _audioBuffer;
@@ -80,11 +87,13 @@ public class ChannelPipeline : IDisposable
         double centerFreqMhz,
         IDecoderFactory decoderFactory,
         ILogger logger,
+        ILoggerFactory loggerFactory,
         double squelchDb = -55.0)
     {
         _channel = channel;
         _decoderFactory = decoderFactory;
         _logger = logger;
+        _loggerFactory = loggerFactory;
         _squelchDb = squelchDb;
 
         // Frequency offset from SDR center (in Hz)
@@ -112,6 +121,14 @@ public class ChannelPipeline : IDisposable
         if (needsDecoder)
         {
             StartDecoderProcess(_decoderCts.Token);
+        }
+        else
+        {
+            // Analog channel: decode MDC1200 unit IDs from the demodulated FM audio and
+            // surface them as this channel's source ID via the normal activity path.
+            _mdc = new Mdc1200Decoder(_loggerFactory.CreateLogger<Mdc1200Decoder>());
+            _mdc.OnPacket += pkt =>
+                OnActivity?.Invoke(_channel, pkt.UnitId, null, pkt.IsEmergency ? "EMRG" : null);
         }
 
         _logger.LogInformation(
@@ -174,6 +191,10 @@ public class ChannelPipeline : IDisposable
                 var chunk = new byte[audioBytes];
                 Buffer.BlockCopy(_audioBuffer, 0, chunk, 0, audioBytes);
                 OnAudio?.Invoke(_channel, chunk);
+
+                // Feed the same carrier audio to this channel's MDC1200 decoder so a
+                // PTT/emergency burst is attributed to this channel.
+                _mdc?.ProcessAudio(chunk);
             }
             else if (_isActive && (DateTime.UtcNow - _lastActivityTime).TotalSeconds > 2.0)
             {
@@ -194,6 +215,7 @@ public class ChannelPipeline : IDisposable
         _decoderCts?.Cancel();
         _decoder?.Stop();
         _decoder = null;
+        _mdc = null;
         _decoderCts?.Dispose();
     }
 

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -15,6 +15,7 @@ public class RtlDevice : BackgroundService, IRadioSource
 {
     private readonly IDatabase _db;
     private readonly ILogger<RtlDevice> _logger;
+    private readonly ILoggerFactory _loggerFactory;
     private readonly GpsService _gps;
     private readonly ToneDetector _toneDetector;
     private readonly Mdc1200Decoder _mdc;
@@ -96,18 +97,20 @@ public class RtlDevice : BackgroundService, IRadioSource
     /// Initializes a new instance of the <see cref="RtlDevice"/> class.
     /// </summary>
     public RtlDevice(
-        IDatabase db, 
-        ILogger<RtlDevice> logger, 
+        IDatabase db,
+        ILogger<RtlDevice> logger,
+        ILoggerFactory loggerFactory,
         GpsService gps,
         ToneDetector toneDetector,
         Mdc1200Decoder mdc,
         IDecoderFactory decoderFactory,
-        ITranscriptionService transcriptionService, 
+        ITranscriptionService transcriptionService,
         IRecordingService recordingService,
         IChannelService channelService)
     {
         _db = db;
         _logger = logger;
+        _loggerFactory = loggerFactory;
         _gps = gps;
         _toneDetector = toneDetector;
         _mdc = mdc;
@@ -618,7 +621,7 @@ public class RtlDevice : BackgroundService, IRadioSource
 
             var pipeline = new ChannelPipeline(
                 ch, sampleRate, outputRate, bank.CenterFrequency,
-                _decoderFactory, _logger, _state.Squelch ?? -55.0);
+                _decoderFactory, _logger, _loggerFactory, _state.Squelch ?? -55.0);
 
             // Wire up events
             pipeline.OnAudio += HandleParallelAudio;
@@ -856,7 +859,9 @@ public class RtlDevice : BackgroundService, IRadioSource
     private void HandleParallelAudio(Channel channel, byte[] audio)
     {
         _toneDetector.ProcessAudio(audio);
-        _mdc.ProcessAudio(audio);
+        // MDC1200 is decoded per-channel inside each ChannelPipeline (analog modes),
+        // which attributes the unit ID to the correct channel; the shared decoder here
+        // could neither decode interleaved multi-channel audio nor attribute it.
 
         // Enqueue mono samples for the mixer instead of broadcasting per-channel stereo.
         int monoSamples = audio.Length / 2;

--- a/server/OpenScanner.Tests/Devices/MixedScanTests.cs
+++ b/server/OpenScanner.Tests/Devices/MixedScanTests.cs
@@ -29,6 +29,7 @@ public class MixedScanTests
         return new RtlDevice(
             db.Object,
             logger.Object,
+            Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance,
             gps.Object,
             toneDetector.Object,
             new Mdc1200Decoder(new Mock<ILogger<Mdc1200Decoder>>().Object),
@@ -190,7 +191,7 @@ public class MixedScanTests
                    .Returns(async (Channel _, CancellationToken t) => await Task.Delay(Timeout.Infinite, t).ContinueWith(_ => { }));
 
         var device = new RtlDevice(
-            db.Object, logger.Object, gps.Object, toneDetector.Object,
+            db.Object, logger.Object, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance, gps.Object, toneDetector.Object,
             new Mdc1200Decoder(new Mock<ILogger<Mdc1200Decoder>>().Object),
             decoderFactory.Object, transcription.Object, recording.Object, channelService.Object);
 
@@ -251,7 +252,7 @@ public class MixedScanTests
                    .Returns(async (Channel _, CancellationToken t) => await Task.Delay(Timeout.Infinite, t).ContinueWith(_ => { }));
 
         var device = new RtlDevice(
-            db.Object, logger.Object, gps.Object, toneDetector.Object,
+            db.Object, logger.Object, Microsoft.Extensions.Logging.Abstractions.NullLoggerFactory.Instance, gps.Object, toneDetector.Object,
             new Mdc1200Decoder(new Mock<ILogger<Mdc1200Decoder>>().Object),
             decoderFactory.Object, transcription.Object, recording.Object, channelService.Object);
 


### PR DESCRIPTION
## Problem
MDC1200 unit IDs stopped appearing as the **SRC** on transmission recordings. Reproduced in **parallel/FastScan mode** (multiple channels scanned at once).

## Root cause
MDC packets were routed only through the single-channel `HandleActivity(_state.CurrentChannel, …)`, which early-returns when `CurrentChannel` is `null` — and it is `null` during parallel scanning. So decoded unit IDs were silently dropped. P25/DMR avoid this by using the per-channel `HandleParallelActivity(channel, …)` path, which MDC never used. A single shared `Mdc1200Decoder` fed interleaved audio from every channel also couldn't decode or attribute reliably.

(Tone-outs still showed because they go through `RaiseRadioEvent`, which tolerates a null channel — hence tones worked but MDC didn't.)

## Fix
Give each analog `ChannelPipeline` its own `Mdc1200Decoder` and raise the pipeline's existing `OnActivity(channel, unitId, …)` — the same per-channel attribution path P25/DMR use — so the unit ID lands on that channel's recording `SourceID` (emergencies as `EMRG`). The decoder is created in `Start()` (analog modes only) and cleared on `Dispose()`.

- `ChannelPipeline.cs` — per-channel MDC decoder, fed the demodulated carrier audio.
- `RtlDevice.cs` — thread `ILoggerFactory` into pipelines; remove the shared, mis-attributed `_mdc.ProcessAudio` from `HandleParallelAudio` (single-channel hold still uses the shared decoder).
- `MixedScanTests.cs` — updated the 3 `RtlDevice` constructors for the new arg.

No client change needed — `TransmissionLog` already renders SRC; it was just never populated for MDC in parallel mode.

## Testing
- Server builds on net10.0; **160/160 tests pass**.
- Live RF confirmation (an MDC transmission on an analog channel while parallel-scanning shows the unit ID as SRC) to be done on the Pi.

## Follow-up (not in this PR)
The tone detector has the same shared-decoder-in-parallel shape; it can get the same per-channel treatment for tighter attribution if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)