### PR TITLE
Add in-UI auto-updater (ribbon indicator + live update console)

### DIFF
--- a/client/e2e/flows/settings.spec.ts
+++ b/client/e2e/flows/settings.spec.ts
@@ -14,24 +14,34 @@ test.describe('Settings', () => {
     await expect(page.getByText('test-commit-hash')).toBeVisible();
   });
 
-  test('displays update notification when newer version available', async ({ page }) => {
-    // Mock GitHub API for a newer version
-    await page.route('https://api.github.com/repos/briannippert/OpenScanner/releases/latest', async route => {
-        await route.fulfill({ json: { 
-            tag_name: "v9.9.9", 
-            html_url: "https://github.com/briannippert/OpenScanner/releases/tag/v9.9.9",
-            body: "Big update!"
-        } });
+  test('shows the ribbon update indicator and opens the update dialog when a newer release is available', async ({ page }) => {
+    // The server reports update availability at /api/update/status.
+    await page.route(/\/api\/update\/status/, async route => {
+      await route.fulfill({ json: {
+        state: 'available',
+        currentVersion: '1.0.0',
+        currentCommit: 'test-commit-hash',
+        latestTag: 'v9.9.9',
+        latestName: 'Release 9.9.9',
+        releaseNotes: 'Big update!',
+        releaseUrl: 'https://github.com/briannippert/OpenScanner/releases/tag/v9.9.9',
+        commitsBehind: 3,
+        updateAvailable: true,
+        log: [],
+      } });
     });
 
-    // Reload to trigger version check
+    // Reload so the ribbon poll picks up the mocked status.
     await page.reload();
-    
-    // Open Settings
-    await page.getByRole('button', { name: 'Settings' }).click();
-    
-    // Verify Update Alert is visible
-    await expect(page.getByText('Update Available: v9.9.9')).toBeVisible();
-    await expect(page.getByRole('link', { name: 'VIEW' })).toHaveAttribute('href', /releases\/tag\/v9.9.9/);
+
+    // The UPDATE chip appears in the header ribbon.
+    const updateChip = page.getByText('UPDATE', { exact: true });
+    await expect(updateChip).toBeVisible();
+
+    // Clicking it opens the Software Update dialog targeting the new release.
+    await updateChip.click();
+    await expect(page.getByText('Software Update')).toBeVisible();
+    await expect(page.getByText(/latest v9\.9\.9/)).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Release notes' })).toHaveAttribute('href', /releases\/tag\/v9\.9\.9/);
   });
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,11 +10,13 @@ import FireToneManager from './components/FireToneManager';
 import SettingsManager from './components/SettingsManager';
 import RfDebugDialog from './components/RfDebugDialog';
 import SystemDebugDialog from './components/SystemDebugDialog';
+import UpdateManager from './components/UpdateManager';
 import NowPlayingBar from './components/NowPlayingBar';
 import CommandPalette from './components/CommandPalette';
 import { useAudioPipeline } from './hooks/useAudioPipeline';
 import { useScannerSocket } from './hooks/useScannerSocket';
-import type { Channel } from './types';
+import { apiJson } from './components/common/apiBase';
+import type { Channel, UpdateStatus } from './types';
 
 function App() {
   const [currentTime, setCurrentTime] = useState(new Date());
@@ -30,6 +32,8 @@ function App() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isDebugModalOpen, setIsDebugModalOpen] = useState(false);
   const [isSystemDebugOpen, setIsSystemDebugOpen] = useState(false);
+  const [isUpdateOpen, setIsUpdateOpen] = useState(false);
+  const [polledAvailable, setPolledAvailable] = useState(false);
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const [debugFreq, setDebugFreq] = useState<string>('155.500');
   const [debugGain, setDebugGain] = useState<number>(40);
@@ -44,6 +48,24 @@ function App() {
     const timer = setInterval(() => setCurrentTime(new Date()), 1000);
     return () => clearInterval(timer);
   }, []);
+
+  // Poll update availability for the ribbon indicator.
+  useEffect(() => {
+    let cancelled = false;
+    const check = async () => {
+      const s = await apiJson<UpdateStatus>('/api/update/status');
+      if (!cancelled && s) setPolledAvailable(s.updateAvailable);
+    };
+    check();
+    const id = setInterval(check, 120000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, []);
+
+  // Ribbon indicator: live WS state wins; otherwise fall back to the poll. Hidden
+  // while an update is running/done or when a check found nothing.
+  const updateState = scanner.updateState;
+  const updateAvailable = updateState === 'available'
+    || (polledAvailable && updateState !== 'updating' && updateState !== 'success' && updateState !== 'idle');
 
   // Command palette: Ctrl/⌘-K toggles it from anywhere.
   useEffect(() => {
@@ -203,6 +225,8 @@ function App() {
           onOpenSettings={() => setIsSettingsOpen(true)}
           onOpenDebug={openDebug}
           onOpenSystemDebug={() => setIsSystemDebugOpen(true)}
+          updateAvailable={updateAvailable}
+          onOpenUpdate={() => setIsUpdateOpen(true)}
         />
 
         <Box sx={{ flexGrow: 1, p: { xs: 1, sm: 2 }, height: '100%', overflowY: { xs: 'auto', md: 'hidden' } }}>
@@ -287,6 +311,13 @@ function App() {
           open={isSettingsOpen}
           onClose={() => setIsSettingsOpen(false)}
           onRecordingsDeleted={() => scanner.setCallLog([])}
+        />
+        <UpdateManager
+          open={isUpdateOpen}
+          onClose={() => setIsUpdateOpen(false)}
+          log={scanner.updateLog}
+          state={scanner.updateState}
+          onSeed={scanner.seedUpdate}
         />
         <CommandPalette
           open={isPaletteOpen}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -61,11 +61,11 @@ function App() {
     return () => { cancelled = true; clearInterval(id); };
   }, []);
 
-  // Ribbon indicator: live WS state wins; otherwise fall back to the poll. Hidden
-  // while an update is running/done or when a check found nothing.
+  // Ribbon indicator: show when the poll or a live WS check reports an update,
+  // hidden only while an update is actively running or just finished.
   const updateState = scanner.updateState;
-  const updateAvailable = updateState === 'available'
-    || (polledAvailable && updateState !== 'updating' && updateState !== 'success' && updateState !== 'idle');
+  const updateAvailable = (updateState === 'available' || polledAvailable)
+    && updateState !== 'updating' && updateState !== 'success';
 
   // Command palette: Ctrl/⌘-K toggles it from anywhere.
   useEffect(() => {

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -18,6 +18,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import MonitorIcon from '@mui/icons-material/Monitor';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
+import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
 import type { ScannerState } from '../types';
 import StatusChip from './common/StatusChip';
 
@@ -34,6 +35,8 @@ interface Props {
   onOpenSettings: () => void;
   onOpenDebug: () => void;
   onOpenSystemDebug: () => void;
+  updateAvailable?: boolean;
+  onOpenUpdate: () => void;
 }
 
 const MONO = '"Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
@@ -42,6 +45,7 @@ const gpsMono = { fontFamily: MONO, color: 'text.primary' } as const;
 const AppHeader: React.FC<Props> = ({
   scannerState, currentTime, volume, onVolumeChange, manualHold, onResume,
   isFullscreen, onToggleFullscreen, onOpenFireTones, onOpenSettings, onOpenDebug, onOpenSystemDebug,
+  updateAvailable, onOpenUpdate,
 }) => {
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const gps = scannerState.gps;
@@ -49,6 +53,7 @@ const AppHeader: React.FC<Props> = ({
 
   // The toolbar actions, shared between the desktop icon row and the mobile menu.
   const actions = [
+    ...(updateAvailable ? [{ label: 'Software Update', icon: <SystemUpdateIcon />, onClick: onOpenUpdate }] : []),
     { label: 'Fire Tone Outs', icon: <NotificationsActiveIcon />, onClick: onOpenFireTones },
     { label: 'Settings', icon: <SettingsIcon />, onClick: onOpenSettings },
     { label: isFullscreen ? 'Exit Fullscreen' : 'Fullscreen', icon: isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />, onClick: onToggleFullscreen },
@@ -136,6 +141,14 @@ const AppHeader: React.FC<Props> = ({
             <StatusChip label="HOLD" tone="warn" variant="filled" icon={<PauseIcon />} sx={{ display: { xs: 'none', sm: 'flex' } }} />
             <StatusChip label="RESUME" tone="live" variant="filled" icon={<PlayArrowIcon />} onClick={onResume} />
           </Box>
+        )}
+
+        {updateAvailable && (
+          <Tooltip title="A new version is available — click to update">
+            <Box sx={{ mr: { xs: 1, sm: 2 } }}>
+              <StatusChip label="UPDATE" tone="warn" variant="filled" icon={<SystemUpdateIcon />} onClick={onOpenUpdate} />
+            </Box>
+          </Tooltip>
         )}
 
         <Box sx={{ ml: 2, display: 'flex', alignItems: 'center', gap: 2, width: { xs: 80, sm: 120, md: 150 } }}>

--- a/client/src/components/SettingsManager.tsx
+++ b/client/src/components/SettingsManager.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import {
     Button, Switch,
-    Box, CircularProgress, Alert, AlertTitle, Link, TextField,
+    Box, CircularProgress, TextField,
     Typography, LinearProgress, Select, MenuItem,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
-import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import FormDialog from './common/FormDialog';
 import { apiFetch } from './common/apiBase';
@@ -78,7 +77,6 @@ const Row: React.FC<{ label: string; description?: string; control: React.ReactN
 const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }) => {
     const [settings, setSettings] = useState<Record<string, string>>({});
     const [systemInfo, setSystemInfo] = useState<Record<string, string>>({});
-    const [updateInfo, setUpdateInfo] = useState<{ latestVersion: string, url: string, body?: string } | null>(null);
     const [loading, setLoading] = useState(false);
     const [storage, setStorage] = useState<StorageInfo | null>(null);
     const [confirmDelete, setConfirmDelete] = useState(false);
@@ -88,7 +86,6 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
         if (open) {
             fetchSettings();
             fetchSystemInfo();
-            fetchLatestVersion();
             fetchStorage();
         }
     }, [open]);
@@ -153,37 +150,6 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
         }
     };
 
-    const fetchLatestVersion = async () => {
-        try {
-            const res = await fetch('https://api.github.com/repos/briannippert/OpenScanner/releases/latest');
-            if (res.ok) {
-                const data = await res.json();
-                setUpdateInfo({
-                    latestVersion: data.tag_name,
-                    url: data.html_url,
-                    body: data.body
-                });
-            }
-        } catch (error) {
-            console.error("Failed to fetch latest version from GitHub", error);
-        }
-    };
-
-    const isNewer = (current: string, latest: string) => {
-        if (!current || !latest) return false;
-        const c = current.split('+')[0].replace(/^v/, '').split('.').map(Number);
-        const l = latest.replace(/^v/, '').split('.').map(Number);
-        for (let i = 0; i < Math.max(c.length, l.length); i++) {
-            const cv = c[i] || 0;
-            const lv = l[i] || 0;
-            if (lv > cv) return true;
-            if (cv > lv) return false;
-        }
-        return false;
-    };
-
-    const updateAvailable = updateInfo && isNewer(systemInfo.Version, updateInfo.latestVersion);
-
     const handleToggle = async (key: string, currentValue: string) => {
         const newValue = currentValue === 'true' ? 'false' : 'true';
         
@@ -235,28 +201,6 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
             maxWidth="md"
             actions={<Button onClick={onClose} color="inherit">Close</Button>}
         >
-                {updateAvailable && (
-                    <Alert
-                        severity="success"
-                        icon={<SystemUpdateIcon />}
-                        sx={{ mb: 2 }}
-                        action={
-                            <Button 
-                                color="inherit" 
-                                size="small" 
-                                component={Link} 
-                                href={updateInfo?.url} 
-                                target="_blank"
-                                rel="noopener"
-                            >
-                                VIEW
-                            </Button>
-                        }
-                    >
-                        <AlertTitle>Update Available: {updateInfo?.latestVersion}</AlertTitle>
-                        A newer version of OpenScanner is available on GitHub.
-                    </Alert>
-                )}
                 {loading ? (
                     <Box display="flex" justifyContent="center" p={4}>
                         <CircularProgress />

--- a/client/src/components/UpdateManager.tsx
+++ b/client/src/components/UpdateManager.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Box, Button, Typography, Alert, CircularProgress, Chip, Link } from '@mui/material';
+import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
+import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import FormDialog from './common/FormDialog';
+import { apiFetch, apiJson } from './common/apiBase';
+import type { UpdateStatus, UpdateState } from '../types';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Live update console lines, accumulated from the control WebSocket. */
+  log: string[];
+  /** Live update state from the control WebSocket. */
+  state: UpdateState;
+  /** Seed/replace the shared console (snapshot on open, clear on start). */
+  onSeed: (lines: string[], state: UpdateState) => void;
+}
+
+const MONO = '"Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
+
+const shortCommit = (c?: string) => (c ? c.slice(0, 8) : '');
+
+const UpdateManager: React.FC<Props> = ({ open, onClose, log, state, onSeed }) => {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [restarted, setRestarted] = useState(false);
+  const logBoxRef = useRef<HTMLDivElement>(null);
+
+  // Seed from the authoritative snapshot whenever the dialog opens.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    (async () => {
+      const s = await apiJson<UpdateStatus>('/api/update/status');
+      if (cancelled || !s) return;
+      setStatus(s);
+      setRestarted(false);
+      onSeed(s.log ?? [], s.state);
+    })();
+    return () => { cancelled = true; };
+  }, [open, onSeed]);
+
+  // Auto-scroll the console to the newest line.
+  useEffect(() => {
+    const el = logBoxRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [log]);
+
+  // Once the build succeeds, poll for the restart to complete (commit changes).
+  useEffect(() => {
+    if (!open || state !== 'success' || restarted) return;
+    const before = status?.currentCommit;
+    let cancelled = false;
+    const id = setInterval(async () => {
+      const info = await apiJson<Record<string, string>>('/api/system/info');
+      if (cancelled) return;
+      if (info && before && info.Commit && info.Commit !== before) {
+        setRestarted(true);
+        clearInterval(id);
+      }
+    }, 3000);
+    return () => { cancelled = true; clearInterval(id); };
+  }, [open, state, restarted, status?.currentCommit]);
+
+  const start = useCallback(async () => {
+    onSeed([], 'updating');
+    setRestarted(false);
+    await apiFetch('/api/update/start', { method: 'POST' });
+  }, [onSeed]);
+
+  const failed = state === 'failed';
+  const updating = state === 'updating';
+  const available = status?.updateAvailable ?? false;
+
+  const actionButton = (() => {
+    if (state === 'success') {
+      return restarted
+        ? <Button onClick={onClose} variant="contained" color="success">Done</Button>
+        : <Button disabled variant="contained" startIcon={<CircularProgress size={16} />}>Restarting…</Button>;
+    }
+    if (updating) {
+      return <Button disabled variant="contained" startIcon={<CircularProgress size={16} />}>Updating…</Button>;
+    }
+    if (failed) {
+      return <Button onClick={start} variant="contained" color="warning">Retry</Button>;
+    }
+    return (
+      <Button onClick={start} variant="contained" startIcon={<SystemUpdateIcon />} disabled={!available}>
+        {available ? `Update to ${status?.latestTag ?? 'latest'}` : 'Up to date'}
+      </Button>
+    );
+  })();
+
+  return (
+    <FormDialog
+      open={open}
+      onClose={onClose}
+      title="Software Update"
+      icon={<SystemUpdateIcon />}
+      maxWidth="md"
+      disableClose={updating}
+      actions={
+        <>
+          <Button onClick={onClose} color="inherit" disabled={updating}>Close</Button>
+          {actionButton}
+        </>
+      }
+    >
+      {/* Version summary */}
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 2 }}>
+        <Chip
+          size="small"
+          label={`current ${status?.currentVersion || '—'} (${shortCommit(status?.currentCommit)})`}
+          sx={{ fontFamily: MONO }}
+        />
+        {status?.latestTag && (
+          <>
+            <Typography color="text.secondary">→</Typography>
+            <Chip
+              size="small"
+              color={available ? 'warning' : 'default'}
+              label={`latest ${status.latestTag}${status.commitsBehind ? ` (${status.commitsBehind} behind)` : ''}`}
+              sx={{ fontFamily: MONO }}
+            />
+          </>
+        )}
+        {status?.releaseUrl && (
+          <Link href={status.releaseUrl} target="_blank" rel="noopener" variant="caption" sx={{ ml: 'auto' }}>
+            Release notes
+          </Link>
+        )}
+      </Box>
+
+      {state === 'success' && restarted && (
+        <Alert severity="success" icon={<CheckCircleIcon />} sx={{ mb: 2 }}>
+          Updated and restarted. You’re now on the latest version.
+        </Alert>
+      )}
+      {state === 'success' && !restarted && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Build succeeded — the service is restarting. This page will reconnect automatically.
+        </Alert>
+      )}
+      {failed && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {status?.error || 'Update failed. The running version is unchanged — see the log below.'}
+        </Alert>
+      )}
+      {!status?.latestTag && !updating && state !== 'success' && (
+        <Alert severity="info" sx={{ mb: 2 }}>
+          Checking for the latest release… If this persists, the server may be offline from GitHub.
+        </Alert>
+      )}
+
+      {/* Live console */}
+      <Box
+        ref={logBoxRef}
+        sx={{
+          fontFamily: MONO,
+          fontSize: 12,
+          lineHeight: 1.5,
+          whiteSpace: 'pre-wrap',
+          wordBreak: 'break-word',
+          bgcolor: '#0a0a0a',
+          color: failed ? 'error.light' : 'grey.400',
+          p: 1.5,
+          borderRadius: 1,
+          height: 340,
+          overflowY: 'auto',
+          border: '1px solid',
+          borderColor: failed ? 'error.main' : 'surface.border',
+        }}
+      >
+        {log.length ? log.join('\n') : <Typography component="span" sx={{ color: 'text.disabled', fontSize: 12 }}>No output yet.</Typography>}
+      </Box>
+    </FormDialog>
+  );
+};
+
+export default UpdateManager;

--- a/client/src/hooks/useScannerSocket.ts
+++ b/client/src/hooks/useScannerSocket.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ScannerState, Channel, CallLog, FireToneSet, RadioEvent } from '../types';
+import type { ScannerState, Channel, CallLog, FireToneSet, RadioEvent, UpdateProgress, UpdateState } from '../types';
 
 interface Options {
   /** Called when a state update indicates whether the live stream is stereo. */
@@ -17,6 +17,14 @@ export function useScannerSocket({ onParallel }: Options = {}) {
   const [fireTones, setFireTones] = useState<FireToneSet[]>([]);
   const [callLog, setCallLog] = useState<CallLog[]>([]);
   const [radioEvents, setRadioEvents] = useState<RadioEvent[]>([]);
+  const [updateLog, setUpdateLog] = useState<string[]>([]);
+  const [updateState, setUpdateState] = useState<UpdateState>('idle');
+
+  // Seed/replace the update console (from a status snapshot on open, or clear on start).
+  const seedUpdate = useCallback((lines: string[], state: UpdateState) => {
+    setUpdateLog(lines);
+    setUpdateState(state);
+  }, []);
   const [isConnected, setIsConnected] = useState(false);
   const [reconnectAt, setReconnectAt] = useState<number | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -173,6 +181,10 @@ export function useScannerSocket({ onParallel }: Options = {}) {
               if (events.some(x => x.id === newEvent.id)) return events;
               return [newEvent, ...events].slice(0, 100);
             });
+          } else if (message.type === 'UPDATE_PROGRESS') {
+            const p = message.payload as UpdateProgress;
+            if (p.state) setUpdateState(p.state);
+            if (p.line) setUpdateLog(prev => [...prev, p.line]);
           } else if (message.type === 'ERROR') {
             setErrorMsg(message.payload);
           }
@@ -195,6 +207,9 @@ export function useScannerSocket({ onParallel }: Options = {}) {
     fireTones,
     callLog,
     radioEvents,
+    updateLog,
+    updateState,
+    seedUpdate,
     isConnected,
     reconnectAt,
     errorMsg,

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -96,6 +96,31 @@ export interface RadioEvent {
     transmissionId?: string;
 }
 
+export type UpdateState = 'idle' | 'checking' | 'available' | 'updating' | 'success' | 'failed';
+
+export interface UpdateStatus {
+    state: UpdateState;
+    currentVersion: string;
+    currentCommit: string;
+    latestTag?: string;
+    latestName?: string;
+    releaseNotes?: string;
+    releaseUrl?: string;
+    commitsBehind: number;
+    updateAvailable: boolean;
+    phase?: string;
+    log: string[];
+    error?: string;
+    lastCheckedUtc?: string;
+}
+
+/** A single live self-update progress message from the control WebSocket. */
+export interface UpdateProgress {
+    phase: string;
+    line: string;
+    state: UpdateState;
+}
+
 declare global {
     interface Window {
         audioCtx?: AudioContext;

--- a/scripts/finalize_update.sh
+++ b/scripts/finalize_update.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# finalize_update.sh — swap a freshly-built server into place and restart the service.
+#
+# Invoked (detached, in its own transient systemd unit) by UpdateService after a
+# successful staging build, so that stopping the openscanner service does not kill
+# this script mid-swap:
+#
+#   systemd-run --collect --unit=openscanner-selfupdate --property=Type=oneshot \
+#       /bin/bash <repo>/scripts/finalize_update.sh <staging> <publish> <unit>
+#
+# Args: $1=staging dir  $2=publish dir  $3=systemd unit (default: openscanner)
+set -u
+
+STAGING="${1:?staging dir required}"
+PUBLISH="${2:?publish dir required}"
+UNIT="${3:-openscanner}"
+BACKUP="${PUBLISH%/}_backup"
+
+log() { echo "[finalize] $*"; }
+
+# Whatever happens, never leave the service down: always try to start it on exit.
+cleanup() {
+    if ! systemctl is-active --quiet "$UNIT"; then
+        log "Ensuring $UNIT is started"
+        systemctl start "$UNIT" || true
+    fi
+}
+trap cleanup EXIT
+
+if [ ! -d "$STAGING" ] || [ -z "$(ls -A "$STAGING" 2>/dev/null)" ]; then
+    log "ERROR: staging dir '$STAGING' is missing or empty; aborting swap"
+    exit 1
+fi
+
+log "Stopping $UNIT"
+systemctl stop "$UNIT" || true
+
+# Keep the previous build for rollback.
+if [ -d "$PUBLISH" ]; then
+    rm -rf "$BACKUP"
+    cp -a "$PUBLISH" "$BACKUP" || log "WARN: could not snapshot previous build"
+fi
+
+log "Swapping in new build"
+if command -v rsync >/dev/null 2>&1; then
+    if ! rsync -a --delete "$STAGING"/ "$PUBLISH"/; then
+        log "ERROR: rsync failed; rolling back"
+        [ -d "$BACKUP" ] && rsync -a --delete "$BACKUP"/ "$PUBLISH"/
+    fi
+else
+    mkdir -p "$PUBLISH"
+    rm -rf "${PUBLISH:?}/"*
+    if ! cp -a "$STAGING"/. "$PUBLISH"/; then
+        log "ERROR: cp failed; rolling back"
+        [ -d "$BACKUP" ] && cp -a "$BACKUP"/. "$PUBLISH"/
+    fi
+fi
+
+chmod +x "$PUBLISH/OpenScanner.Server" 2>/dev/null || true
+
+log "Starting $UNIT"
+systemctl start "$UNIT"
+log "Done"

--- a/server/OpenScanner.Server/Controllers/UpdateController.cs
+++ b/server/OpenScanner.Server/Controllers/UpdateController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Controllers;
+
+/// <summary>
+/// Controller for the in-UI self-updater: reports update availability and applies updates.
+/// </summary>
+[ApiController]
+[Route("api/update")]
+[Produces("application/json")]
+public class UpdateController : ControllerBase
+{
+    private readonly IUpdateService _update;
+
+    public UpdateController(IUpdateService update)
+    {
+        _update = update;
+    }
+
+    /// <summary>Returns the current updater snapshot (state, versions, availability, and log).</summary>
+    [HttpGet("status")]
+    [ProducesResponseType(typeof(UpdateStatus), StatusCodes.Status200OK)]
+    public IActionResult GetStatus() => Ok(_update.GetStatus());
+
+    /// <summary>Forces a check against the latest GitHub release and returns the refreshed snapshot.</summary>
+    [HttpPost("check")]
+    [ProducesResponseType(typeof(UpdateStatus), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Check() => Ok(await _update.CheckAsync(force: true));
+
+    /// <summary>
+    /// Starts an update in the background. Returns 202 Accepted, or 409 Conflict if an
+    /// update is already running.
+    /// </summary>
+    [HttpPost("start")]
+    [ProducesResponseType(typeof(UpdateStatus), StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status409Conflict)]
+    public IActionResult Start()
+    {
+        if (!_update.TryStartUpdate())
+            return Conflict(new { message = "An update is already in progress." });
+        return Accepted(_update.GetStatus());
+    }
+}

--- a/server/OpenScanner.Server/Interfaces/IUpdateService.cs
+++ b/server/OpenScanner.Server/Interfaces/IUpdateService.cs
@@ -1,0 +1,25 @@
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Interfaces;
+
+/// <summary>
+/// Drives the in-UI self-updater: checks GitHub for a newer release and applies it
+/// (git reset to the release tag, rebuild, restart) while streaming progress.
+/// </summary>
+public interface IUpdateService
+{
+    /// <summary>Returns the current snapshot (state, versions, availability, and log).</summary>
+    UpdateStatus GetStatus();
+
+    /// <summary>
+    /// Checks the latest GitHub release against the running checkout and updates the
+    /// cached availability. Safe to call periodically; skipped while an update runs.
+    /// </summary>
+    Task<UpdateStatus> CheckAsync(bool force);
+
+    /// <summary>
+    /// Starts an update in the background if one is not already running.
+    /// Returns false if an update is already in progress.
+    /// </summary>
+    bool TryStartUpdate();
+}

--- a/server/OpenScanner.Server/Models/UpdateStatus.cs
+++ b/server/OpenScanner.Server/Models/UpdateStatus.cs
@@ -1,0 +1,67 @@
+namespace OpenScanner.Server.Models;
+
+/// <summary>
+/// Lifecycle of the in-UI updater. Serialized to the client as a lowercase string.
+/// </summary>
+public enum UpdateState
+{
+    /// <summary>No update in progress and none known to be available.</summary>
+    Idle,
+    /// <summary>A version/availability check is running.</summary>
+    Checking,
+    /// <summary>A newer release is available to install.</summary>
+    Available,
+    /// <summary>An update is currently being applied.</summary>
+    Updating,
+    /// <summary>The update built successfully; the service is restarting.</summary>
+    Success,
+    /// <summary>The update failed; the running build is unchanged and the log is retained.</summary>
+    Failed,
+}
+
+/// <summary>
+/// Snapshot of the updater exposed at <c>GET /api/update/status</c>. The
+/// <see cref="State"/> is the lowercase name of <see cref="UpdateState"/> so the
+/// client can use it as a discriminated string union.
+/// </summary>
+public record UpdateStatus
+{
+    /// <summary>Lowercase <see cref="UpdateState"/> name (idle|checking|available|updating|success|failed).</summary>
+    public string State { get; init; } = "idle";
+
+    /// <summary>Currently running app version (nbgv informational version).</summary>
+    public string CurrentVersion { get; init; } = "";
+
+    /// <summary>Currently running git commit.</summary>
+    public string CurrentCommit { get; init; } = "";
+
+    /// <summary>Tag of the latest GitHub release, if a check has run.</summary>
+    public string? LatestTag { get; init; }
+
+    /// <summary>Human-friendly name of the latest release.</summary>
+    public string? LatestName { get; init; }
+
+    /// <summary>Release notes (markdown body) of the latest release.</summary>
+    public string? ReleaseNotes { get; init; }
+
+    /// <summary>URL of the latest release on GitHub.</summary>
+    public string? ReleaseUrl { get; init; }
+
+    /// <summary>Number of commits the running checkout is behind the latest release tag.</summary>
+    public int CommitsBehind { get; init; }
+
+    /// <summary>True when the latest release differs from (and is ahead of) the running commit.</summary>
+    public bool UpdateAvailable { get; init; }
+
+    /// <summary>Current step of an in-progress update (fetch|reset|build|finalize).</summary>
+    public string? Phase { get; init; }
+
+    /// <summary>Accumulated update output (bounded), newest last.</summary>
+    public string[] Log { get; init; } = System.Array.Empty<string>();
+
+    /// <summary>Error summary when <see cref="State"/> is failed, or a check error.</summary>
+    public string? Error { get; init; }
+
+    /// <summary>ISO-8601 timestamp of the last successful availability check.</summary>
+    public string? LastCheckedUtc { get; init; }
+}

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -64,6 +64,9 @@ else
 builder.Services.AddSingleton<IBackfillService, BackfillTranscriptionService>();
 builder.Services.AddSingleton<ISupportService, SupportService>();
 builder.Services.AddSingleton<WebSocketBroadcaster>();
+builder.Services.AddHttpClient();
+builder.Services.AddSingleton<IUpdateService, UpdateService>();
+builder.Services.AddHostedService(sp => (UpdateService)sp.GetRequiredService<IUpdateService>());
 builder.Services.AddCors();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApiDocument(config => 

--- a/server/OpenScanner.Server/Services/UpdateService.cs
+++ b/server/OpenScanner.Server/Services/UpdateService.cs
@@ -1,0 +1,525 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+
+namespace OpenScanner.Server.Services;
+
+/// <summary>
+/// In-UI self-updater. Compares the running checkout against the latest GitHub
+/// release and, on request, applies it: <c>git fetch --tags</c> → <c>git reset --hard &lt;tag&gt;</c>
+/// → <c>dotnet build</c> into a staging dir → hand off a detached finalizer that swaps the
+/// build in and restarts the systemd unit. Output streams to clients over the control
+/// WebSocket as <c>UPDATE_PROGRESS</c>, and a snapshot is available via <see cref="GetStatus"/>.
+/// </summary>
+public class UpdateService : IUpdateService, IHostedService
+{
+    private const string RepoSlug = "briannippert/OpenScanner";
+    private const string ServiceUnit = "openscanner";
+    private const int MaxLogLines = 2000;
+    private static readonly TimeSpan CheckInterval = TimeSpan.FromMinutes(30);
+
+    private readonly ILogger<UpdateService> _logger;
+    private readonly WebSocketBroadcaster _broadcaster;
+    private readonly ISupportService _support;
+    private readonly IHttpClientFactory _httpFactory;
+    private readonly IConfiguration _config;
+
+    private readonly object _lock = new();
+    private readonly List<string> _log = new();
+    private UpdateState _state = UpdateState.Idle;
+    private bool _running;
+    private string? _phase;
+    private string? _error;
+
+    // Latest known release / comparison, refreshed by CheckAsync.
+    private string _currentVersion = "";
+    private string _currentCommit = "";
+    private string? _latestTag;
+    private string? _latestName;
+    private string? _releaseNotes;
+    private string? _releaseUrl;
+    private int _commitsBehind;
+    private bool _updateAvailable;
+    private string? _lastCheckedUtc;
+
+    private CancellationTokenSource? _periodicCts;
+
+    public UpdateService(
+        ILogger<UpdateService> logger,
+        WebSocketBroadcaster broadcaster,
+        ISupportService support,
+        IHttpClientFactory httpFactory,
+        IConfiguration config)
+    {
+        _logger = logger;
+        _broadcaster = broadcaster;
+        _support = support;
+        _httpFactory = httpFactory;
+        _config = config;
+    }
+
+    // MARK: - Paths / environment
+
+    private static string RepoRoot => Path.GetFullPath(Path.Combine(Directory.GetCurrentDirectory(), "..", ".."));
+    private static string ServerProjDir => Path.Combine(RepoRoot, "server", "OpenScanner.Server");
+    private static string PublishDir => Path.Combine(ServerProjDir, "bin", "Release", "net10.0", "publish");
+    private static string StagingDir => Path.Combine(ServerProjDir, "bin", "Release", "net10.0", "_staging");
+    private static string FinalizeScript => Path.Combine(RepoRoot, "scripts", "finalize_update.sh");
+    private static string AppSettingsPath => Path.Combine(ServerProjDir, "appsettings.json");
+
+    private static bool IsLinux => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+
+    /// <summary>Resolves the dotnet host: prefer a config override, then ~/.dotnet/dotnet (dev), else PATH.</summary>
+    private string DotnetPath
+    {
+        get
+        {
+            var configured = _config["Update:DotnetPath"];
+            if (!string.IsNullOrWhiteSpace(configured)) return configured;
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var dotnetHome = Path.Combine(home, ".dotnet", "dotnet");
+            return File.Exists(dotnetHome) ? dotnetHome : "dotnet";
+        }
+    }
+
+    // MARK: - IHostedService (periodic availability check)
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _periodicCts = new CancellationTokenSource();
+        var ct = _periodicCts.Token;
+        _ = Task.Run(async () =>
+        {
+            try { await Task.Delay(TimeSpan.FromSeconds(10), ct); } catch { return; }
+            while (!ct.IsCancellationRequested)
+            {
+                try { await CheckAsync(force: false); }
+                catch (Exception ex) { _logger.LogDebug(ex, "Periodic update check failed"); }
+                try { await Task.Delay(CheckInterval, ct); } catch { break; }
+            }
+        }, ct);
+        return Task.CompletedTask;
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        _periodicCts?.Cancel();
+        return Task.CompletedTask;
+    }
+
+    // MARK: - Public API
+
+    public UpdateStatus GetStatus()
+    {
+        lock (_lock)
+        {
+            return new UpdateStatus
+            {
+                State = _state.ToString().ToLowerInvariant(),
+                CurrentVersion = _currentVersion,
+                CurrentCommit = _currentCommit,
+                LatestTag = _latestTag,
+                LatestName = _latestName,
+                ReleaseNotes = _releaseNotes,
+                ReleaseUrl = _releaseUrl,
+                CommitsBehind = _commitsBehind,
+                UpdateAvailable = _updateAvailable,
+                Phase = _phase,
+                Log = _log.ToArray(),
+                Error = _error,
+                LastCheckedUtc = _lastCheckedUtc,
+            };
+        }
+    }
+
+    public async Task<UpdateStatus> CheckAsync(bool force)
+    {
+        lock (_lock)
+        {
+            if (_running) return GetStatusLocked();
+            if (_state != UpdateState.Updating) _state = UpdateState.Checking;
+        }
+
+        var verInfo = _support.GetVersionInfo();
+        var currentVersion = verInfo.GetValueOrDefault("Version", "");
+
+        try
+        {
+            var (tag, name, notes, url) = await FetchLatestReleaseAsync();
+
+            // Align local git metadata with the release tag.
+            await RunCaptureAsync("git", new[] { "fetch", "--tags", "--prune", "origin" }, RepoRoot, 60_000);
+            var head = (await RunCaptureAsync("git", new[] { "rev-parse", "HEAD" }, RepoRoot, 15_000))?.Trim() ?? "";
+            string? tagCommit = null;
+            var behind = 0;
+            if (!string.IsNullOrEmpty(tag))
+            {
+                tagCommit = (await RunCaptureAsync("git", new[] { "rev-list", "-n", "1", tag! }, RepoRoot, 15_000))?.Trim();
+                var cnt = (await RunCaptureAsync("git", new[] { "rev-list", "--count", $"HEAD..{tag}" }, RepoRoot, 15_000))?.Trim();
+                int.TryParse(cnt, out behind);
+            }
+
+            var available = !string.IsNullOrEmpty(tagCommit)
+                            && !string.IsNullOrEmpty(head)
+                            && !string.Equals(tagCommit, head, StringComparison.OrdinalIgnoreCase)
+                            && behind > 0;
+
+            lock (_lock)
+            {
+                _currentVersion = currentVersion;
+                _currentCommit = string.IsNullOrEmpty(head) ? verInfo.GetValueOrDefault("Commit", "") : head;
+                _latestTag = tag;
+                _latestName = name ?? tag;
+                _releaseNotes = notes;
+                _releaseUrl = url;
+                _commitsBehind = behind;
+                _updateAvailable = available;
+                _lastCheckedUtc = DateTime.UtcNow.ToString("o");
+                _error = null;
+                if (!_running) _state = available ? UpdateState.Available : UpdateState.Idle;
+            }
+            BroadcastState();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Update check failed");
+            lock (_lock)
+            {
+                _currentVersion = currentVersion;
+                _lastCheckedUtc = DateTime.UtcNow.ToString("o");
+                _error = $"Update check failed: {ex.Message}";
+                // Do not flip to "available" on a failed check.
+                if (!_running && _state == UpdateState.Checking) _state = _updateAvailable ? UpdateState.Available : UpdateState.Idle;
+            }
+        }
+
+        return GetStatus();
+    }
+
+    public bool TryStartUpdate()
+    {
+        lock (_lock)
+        {
+            if (_running) return false;
+            _running = true;
+            _state = UpdateState.Updating;
+            _phase = "start";
+            _error = null;
+            _log.Clear();
+        }
+        _ = Task.Run(RunUpdateAsync);
+        return true;
+    }
+
+    // MARK: - Update pipeline
+
+    private async Task RunUpdateAsync()
+    {
+        try
+        {
+            var tag = _latestTag;
+            if (string.IsNullOrEmpty(tag))
+            {
+                Emit("start", "No cached release; checking for the latest release…");
+                await CheckAsync(force: true);
+                tag = _latestTag;
+            }
+            if (string.IsNullOrEmpty(tag))
+            {
+                Fail("Could not determine the latest release to update to.");
+                return;
+            }
+
+            Emit("start", $"Updating to release {tag}…");
+
+            if (await RunStreamingAsync("git", new[] { "fetch", "--tags", "--prune", "origin" }, RepoRoot, "fetch", 120_000) != 0)
+            { Fail("git fetch failed."); return; }
+
+            // Preserve the operator-configured PowerDMS department across the hard reset.
+            var savedDept = TryReadPowerDmsDepartment();
+
+            if (await RunStreamingAsync("git", new[] { "reset", "--hard", tag! }, RepoRoot, "reset", 60_000) != 0)
+            { Fail("git reset failed."); return; }
+
+            if (!string.IsNullOrEmpty(savedDept) && RestorePowerDmsDepartment(savedDept!))
+                Emit("reset", $"Preserved PowerDMS department \"{savedDept}\".");
+
+            Emit("build", "Building server and client (this can take several minutes)…");
+            if (await RunStreamingAsync(DotnetPath, new[] { "build", "-c", "Release", "-o", StagingDir }, ServerProjDir, "build", 20 * 60_000) != 0)
+            { Fail("Build failed. The running version is unchanged."); return; }
+
+            if (IsLinux && HasSystemd())
+            {
+                SetState(UpdateState.Success, "finalize");
+                Emit("finalize", "Build succeeded. Swapping in the new build and restarting…");
+                LaunchFinalizer();
+            }
+            else
+            {
+                SetState(UpdateState.Success, "finalize");
+                Emit("finalize", "Build succeeded. No systemd detected (dev) — restart the server manually to run the new build.");
+            }
+        }
+        catch (Exception ex)
+        {
+            Fail($"Update crashed: {ex.Message}");
+        }
+        finally
+        {
+            lock (_lock) { _running = false; }
+        }
+    }
+
+    private void LaunchFinalizer()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("systemd-run")
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            psi.ArgumentList.Add("--collect");
+            psi.ArgumentList.Add("--unit=openscanner-selfupdate");
+            psi.ArgumentList.Add("--property=Type=oneshot");
+            psi.ArgumentList.Add("/bin/bash");
+            psi.ArgumentList.Add(FinalizeScript);
+            psi.ArgumentList.Add(StagingDir);
+            psi.ArgumentList.Add(PublishDir);
+            psi.ArgumentList.Add(ServiceUnit);
+            using var proc = Process.Start(psi);
+            // systemd-run registers the transient unit and returns immediately; the
+            // finalizer (in its own cgroup) then stops us, swaps, and restarts.
+            proc?.WaitForExit(10_000);
+            _logger.LogInformation("Launched openscanner-selfupdate finalizer.");
+        }
+        catch (Exception ex)
+        {
+            Fail($"Failed to launch finalizer: {ex.Message}");
+        }
+    }
+
+    // MARK: - GitHub
+
+    private async Task<(string? tag, string? name, string? notes, string? url)> FetchLatestReleaseAsync()
+    {
+        var http = _httpFactory.CreateClient();
+        http.Timeout = TimeSpan.FromSeconds(15);
+        http.DefaultRequestHeaders.UserAgent.ParseAdd("OpenScanner-Updater");
+        http.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
+
+        var resp = await http.GetAsync($"https://api.github.com/repos/{RepoSlug}/releases/latest");
+        if (!resp.IsSuccessStatusCode)
+            throw new InvalidOperationException($"GitHub returned {(int)resp.StatusCode}");
+
+        using var doc = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        var root = doc.RootElement;
+        var tag = root.TryGetProperty("tag_name", out var t) ? t.GetString() : null;
+        var name = root.TryGetProperty("name", out var n) ? n.GetString() : null;
+        var notes = root.TryGetProperty("body", out var b) ? b.GetString() : null;
+        var url = root.TryGetProperty("html_url", out var u) ? u.GetString() : null;
+        return (tag, name, notes, url);
+    }
+
+    // MARK: - PowerDMS preservation
+
+    private string? TryReadPowerDmsDepartment()
+    {
+        try
+        {
+            if (!File.Exists(AppSettingsPath)) return null;
+            var node = JsonNode.Parse(File.ReadAllText(AppSettingsPath));
+            var dept = node?["PowerDMS"]?["Department"]?.GetValue<string>();
+            return string.IsNullOrEmpty(dept) ? null : dept;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Could not read PowerDMS department for preservation");
+            return null;
+        }
+    }
+
+    private bool RestorePowerDmsDepartment(string dept)
+    {
+        try
+        {
+            if (!File.Exists(AppSettingsPath)) return false;
+            var node = JsonNode.Parse(File.ReadAllText(AppSettingsPath)) as JsonObject;
+            if (node == null) return false;
+            var powerDms = node["PowerDMS"] as JsonObject;
+            if (powerDms == null) { powerDms = new JsonObject(); node["PowerDMS"] = powerDms; }
+            if (string.Equals(powerDms["Department"]?.GetValue<string>(), dept, StringComparison.Ordinal)) return false;
+            powerDms["Department"] = dept;
+            File.WriteAllText(AppSettingsPath, node.ToJsonString(new JsonSerializerOptions { WriteIndented = true }));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to restore PowerDMS department after reset");
+            return false;
+        }
+    }
+
+    // MARK: - Process helpers
+
+    /// <summary>Runs a command, streaming each stdout/stderr line to clients and the log. Returns the exit code (-1 on timeout/failure to start).</summary>
+    private async Task<int> RunStreamingAsync(string file, string[] args, string workingDir, string phase, int timeoutMs)
+    {
+        Emit(phase, $"$ {Path.GetFileName(file)} {string.Join(' ', args)}");
+        try
+        {
+            var psi = new ProcessStartInfo(file)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = workingDir,
+            };
+            foreach (var a in args) psi.ArgumentList.Add(a);
+
+            using var proc = new Process { StartInfo = psi };
+            proc.OutputDataReceived += (_, e) => { if (e.Data != null) Emit(phase, e.Data); };
+            proc.ErrorDataReceived += (_, e) => { if (e.Data != null) Emit(phase, e.Data); };
+            if (!proc.Start()) { Emit(phase, "[failed to start process]"); return -1; }
+            proc.BeginOutputReadLine();
+            proc.BeginErrorReadLine();
+
+            using var cts = new CancellationTokenSource(timeoutMs);
+            try
+            {
+                await proc.WaitForExitAsync(cts.Token);
+            }
+            catch (OperationCanceledException)
+            {
+                try { proc.Kill(true); } catch { }
+                Emit(phase, $"[timed out after {timeoutMs / 1000}s]");
+                return -1;
+            }
+            return proc.ExitCode;
+        }
+        catch (Exception ex)
+        {
+            Emit(phase, $"[error: {ex.Message}]");
+            return -1;
+        }
+    }
+
+    /// <summary>Runs a command and returns stdout (or null), without streaming. Used for the availability check.</summary>
+    private async Task<string?> RunCaptureAsync(string file, string[] args, string workingDir, int timeoutMs)
+    {
+        try
+        {
+            var psi = new ProcessStartInfo(file)
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                WorkingDirectory = workingDir,
+            };
+            foreach (var a in args) psi.ArgumentList.Add(a);
+            using var proc = Process.Start(psi);
+            if (proc == null) return null;
+            var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+            _ = proc.StandardError.ReadToEndAsync();
+            using var cts = new CancellationTokenSource(timeoutMs);
+            try { await proc.WaitForExitAsync(cts.Token); }
+            catch (OperationCanceledException) { try { proc.Kill(true); } catch { } return null; }
+            return await stdoutTask;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Capture command '{Cmd}' failed", file);
+            return null;
+        }
+    }
+
+    private static bool HasSystemd()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo("systemctl", "--version")
+            {
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            using var proc = Process.Start(psi);
+            if (proc == null) return false;
+            proc.WaitForExit(3000);
+            return proc.HasExited && proc.ExitCode == 0;
+        }
+        catch { return false; }
+    }
+
+    // MARK: - State / logging
+
+    private void Emit(string phase, string line)
+    {
+        string state;
+        lock (_lock)
+        {
+            _phase = phase;
+            _log.Add(line);
+            if (_log.Count > MaxLogLines) _log.RemoveRange(0, _log.Count - MaxLogLines);
+            state = _state.ToString().ToLowerInvariant();
+        }
+        _broadcaster.BroadcastUpdateProgress(phase, line, state);
+    }
+
+    private void SetState(UpdateState state, string? phase = null)
+    {
+        lock (_lock)
+        {
+            _state = state;
+            if (phase != null) _phase = phase;
+        }
+        BroadcastState();
+    }
+
+    private void Fail(string message)
+    {
+        lock (_lock)
+        {
+            _state = UpdateState.Failed;
+            _error = message;
+        }
+        Emit(_phase ?? "update", $"ERROR: {message}");
+        BroadcastState();
+    }
+
+    /// <summary>Broadcasts a state-only progress message (empty line) so clients update their console/ribbon.</summary>
+    private void BroadcastState()
+    {
+        string state, phase;
+        lock (_lock) { state = _state.ToString().ToLowerInvariant(); phase = _phase ?? ""; }
+        _broadcaster.BroadcastUpdateProgress(phase, "", state);
+    }
+
+    private UpdateStatus GetStatusLocked()
+    {
+        return new UpdateStatus
+        {
+            State = _state.ToString().ToLowerInvariant(),
+            CurrentVersion = _currentVersion,
+            CurrentCommit = _currentCommit,
+            LatestTag = _latestTag,
+            LatestName = _latestName,
+            ReleaseNotes = _releaseNotes,
+            ReleaseUrl = _releaseUrl,
+            CommitsBehind = _commitsBehind,
+            UpdateAvailable = _updateAvailable,
+            Phase = _phase,
+            Log = _log.ToArray(),
+            Error = _error,
+            LastCheckedUtc = _lastCheckedUtc,
+        };
+    }
+}

--- a/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
+++ b/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
@@ -185,6 +185,16 @@ public class WebSocketBroadcaster
         _ = BroadcastJson(msg);
     }
 
+    /// <summary>
+    /// Broadcasts a self-update progress line to control clients as
+    /// <c>{ type: "UPDATE_PROGRESS", payload: { phase, line, state } }</c>.
+    /// </summary>
+    public void BroadcastUpdateProgress(string phase, string line, string state)
+    {
+        var msg = new { type = "UPDATE_PROGRESS", payload = new { phase, line, state } };
+        _ = BroadcastJson(msg);
+    }
+
     private void BroadcastAudio(byte[] audioData)
     {
         // _logger.LogInformation($"Broadcasting audio: {audioData.Length} bytes to {_audioSessions.Count} clients");


### PR DESCRIPTION
## Summary
Adds an in-UI self-updater so the box can be updated from the browser instead of SSHing in to re-run the installer. Moves the "new version available" signal out of the Settings dialog and into the **top ribbon**; clicking it opens an **Update** panel that streams the live build output and restarts the service on the new version. On failure, the full log stays on the page and nothing restarts.

Update source is the **latest GitHub release** (compared to the running checkout); the update checks out that release tag.

## How it works
- **Check (server-authoritative):** `GET api.github.com/.../releases/latest` → tag; `git fetch --tags` + compare to `HEAD` (commits-behind). Periodic 30-min background check + manual `POST /api/update/check`. Replaces the old client-side GitHub check buried in Settings.
- **Update pipeline (single-flight, streamed):** `git fetch --tags` → preserve `PowerDMS.Department` → `git reset --hard <tag>` → restore it → `dotnet build -c Release -o …/_staging`. Every stdout/stderr line is broadcast over the control WebSocket as `UPDATE_PROGRESS` and retained in a bounded in-memory log. Any nonzero exit → `failed`, log kept, **no restart**.
- **Restart without ETXTBSY:** the build goes to a staging dir while the service keeps running (so output streams); on success a **detached `systemd-run` transient unit** runs `scripts/finalize_update.sh` (stop → rsync staging→publish with `_backup` rollback + start-on-exit trap → start). Using a transient unit avoids the service's own cgroup being killed mid-swap. Dev/macOS (no systemd) reports success + "restart manually."
- **Client:** amber **UPDATE** chip in `AppHeader` (+ mobile menu) → `UpdateManager` dialog with current→latest version, release-notes link, live auto-scrolling console, red failure log + Retry, and a "Restarting…→Up to date" flow that polls `/api/system/info` for the new commit. The old Settings update alert is removed.

## Key files
- Server: `Services/UpdateService.cs`, `Models/UpdateStatus.cs`, `Interfaces/IUpdateService.cs`, `Controllers/UpdateController.cs`, `WebSocketBroadcaster.BroadcastUpdateProgress`, `Program.cs` (DI + `AddHttpClient`), `scripts/finalize_update.sh`.
- Client: `components/UpdateManager.tsx`, `AppHeader.tsx`, `App.tsx`, `hooks/useScannerSocket.ts`, `types.ts`, `SettingsManager.tsx` (cleanup).

## Testing
- Server builds on net10.0, **160/160 tests pass**; client `npm run lint` + `npm run build` clean.
- Mock server: `GET /api/update/status` (idle), `POST /api/update/check` (pulled `v0.1.239` + release notes, computed availability, **working tree untouched**), and the control WebSocket delivered an `UPDATE_PROGRESS` frame.
- The destructive start→build→restart path (git reset + staging build + `systemd-run` finalizer + restart) is designed for the Pi and needs on-device verification. Note: since Update checks out the latest **release**, dogfooding the full loop means merging this and cutting a release so the running box is behind a release that contains the updater.

🤖 Generated with [Claude Code](https://claude.com/claude-code)