### PR TITLE
Per-channel radio aliases: name SRC/TG, with export/import

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,6 +8,7 @@ import TransmissionLog from './components/TransmissionLog';
 import ChannelManager from './components/ChannelManager';
 import FireToneManager from './components/FireToneManager';
 import SettingsManager from './components/SettingsManager';
+import AliasManager from './components/AliasManager';
 import RfDebugDialog from './components/RfDebugDialog';
 import SystemDebugDialog from './components/SystemDebugDialog';
 import UpdateManager from './components/UpdateManager';
@@ -32,6 +33,7 @@ function App() {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isDebugModalOpen, setIsDebugModalOpen] = useState(false);
   const [isSystemDebugOpen, setIsSystemDebugOpen] = useState(false);
+  const [isAliasManagerOpen, setIsAliasManagerOpen] = useState(false);
   const [isUpdateOpen, setIsUpdateOpen] = useState(false);
   const [polledAvailable, setPolledAvailable] = useState(false);
   const [isPaletteOpen, setIsPaletteOpen] = useState(false);
@@ -225,6 +227,7 @@ function App() {
           onOpenSettings={() => setIsSettingsOpen(true)}
           onOpenDebug={openDebug}
           onOpenSystemDebug={() => setIsSystemDebugOpen(true)}
+          onOpenAliases={() => setIsAliasManagerOpen(true)}
           updateAvailable={updateAvailable}
           onOpenUpdate={() => setIsUpdateOpen(true)}
         />
@@ -239,6 +242,7 @@ function App() {
                   analyser={audio.audioAnalyser}
                   channels={scanner.channels}
                   onScan={scanner.handleSkip}
+                  nameFor={scanner.nameFor}
                 />
               </Box>
               <ChannelGrid
@@ -274,6 +278,7 @@ function App() {
                   highlight={highlightLog}
                   loaded={scanner.logLoaded}
                   toneOutIds={toneOutIds}
+                  nameFor={scanner.nameFor}
                 />
               </Paper>
             </Grid>
@@ -312,6 +317,16 @@ function App() {
           onClose={() => setIsSettingsOpen(false)}
           onRecordingsDeleted={() => scanner.setCallLog([])}
         />
+        <AliasManager
+          open={isAliasManagerOpen}
+          onClose={() => setIsAliasManagerOpen(false)}
+          candidates={scanner.aliasCandidates}
+          aliases={scanner.aliases}
+          onSave={scanner.handleSaveAlias}
+          onDelete={scanner.handleDeleteAlias}
+          onImport={scanner.importAliases}
+          onOpened={() => scanner.refreshAliasCandidates(7)}
+        />
         <UpdateManager
           open={isUpdateOpen}
           onClose={() => setIsUpdateOpen(false)}
@@ -330,6 +345,7 @@ function App() {
           onOpenSettings={() => setIsSettingsOpen(true)}
           onOpenFireTones={() => setIsToneManagerOpen(true)}
           onOpenChannels={() => setIsManagerOpen(true)}
+          onOpenAliases={() => setIsAliasManagerOpen(true)}
           onOpenDebug={openDebug}
           onToggleFullscreen={toggleFullscreen}
         />

--- a/client/src/components/AliasManager.tsx
+++ b/client/src/components/AliasManager.tsx
@@ -1,0 +1,222 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+    Box, Typography, TextField, Select, MenuItem, List, ListItem, Divider, Chip,
+    Button, FormControl, InputLabel, Alert,
+} from '@mui/material';
+import BadgeIcon from '@mui/icons-material/Badge';
+import FileDownloadIcon from '@mui/icons-material/FileDownload';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+import type { RadioAlias, AliasCandidate } from '../types';
+import FormDialog from './common/FormDialog';
+import EmptyState from './common/EmptyState';
+
+interface Props {
+    open: boolean;
+    onClose: () => void;
+    candidates: AliasCandidate[];
+    aliases: RadioAlias[];
+    onSave: (alias: RadioAlias) => void;
+    onDelete: (id: number) => void;
+    /** Additive import (fills blanks, never overwrites); returns the count added. */
+    onImport: (list: RadioAlias[]) => Promise<number>;
+    /** Called when the dialog opens, to (re)load discovered candidates. */
+    onOpened: () => void;
+}
+
+const isImportableAlias = (a: unknown): a is RadioAlias => {
+    if (typeof a !== 'object' || a === null) return false;
+    const o = a as Record<string, unknown>;
+    return (o.kind === 'SRC' || o.kind === 'TG')
+        && typeof o.value === 'number'
+        && typeof o.name === 'string' && o.name.trim().length > 0
+        && typeof o.alphaTag === 'string'
+        && typeof o.frequency === 'number';
+};
+
+const MONO = '"Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
+const chKey = (alphaTag: string, frequency: number) => `${alphaTag}|${frequency.toFixed(4)}`;
+
+const shortDate = (ts?: string): string => {
+    if (!ts) return '';
+    // SQLite UTC "yyyy-MM-dd HH:mm:ss" — mark as UTC then show locale date.
+    const d = new Date(ts.includes('T') ? ts : ts.replace(' ', 'T') + 'Z');
+    return isNaN(d.getTime()) ? '' : d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+};
+
+const AliasManager: React.FC<Props> = ({ open, onClose, candidates, aliases, onSave, onDelete, onImport, onOpened }) => {
+    const [selKey, setSelKey] = useState('');
+    const [drafts, setDrafts] = useState<Record<string, string>>({});
+    const [message, setMessage] = useState<string | null>(null);
+    const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // Reload discovered candidates whenever the dialog opens (side effect only).
+    useEffect(() => { if (open) onOpened(); }, [open, onOpened]);
+
+    const handleExport = () => {
+        const data = aliases.map(({ kind, value, name, alphaTag, frequency }) => ({ kind, value, name, alphaTag, frequency }));
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'openscanner-aliases.json';
+        a.click();
+        URL.revokeObjectURL(url);
+    };
+
+    const handleImportFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        e.target.value = ''; // let the same file be re-selected later
+        if (!file) return;
+        try {
+            const parsed: unknown = JSON.parse(await file.text());
+            const list = ((Array.isArray(parsed) ? parsed : []) as unknown[]).filter(isImportableAlias);
+            if (list.length === 0) { setMessage('No valid aliases found in that file.'); return; }
+            const added = await onImport(list);
+            setMessage(`Imported ${added} new alias${added === 1 ? '' : 'es'}; existing names were kept.`);
+        } catch {
+            setMessage('Could not read that file as JSON.');
+        }
+    };
+
+    // Channels = union of channels that have candidates and/or existing aliases.
+    const channels = useMemo(() => {
+        const map = new Map<string, { alphaTag: string; frequency: number }>();
+        for (const c of candidates) map.set(chKey(c.alphaTag, c.frequency), { alphaTag: c.alphaTag, frequency: c.frequency });
+        for (const a of aliases) map.set(chKey(a.alphaTag, a.frequency), { alphaTag: a.alphaTag, frequency: a.frequency });
+        return [...map.values()].sort((x, y) => x.alphaTag.localeCompare(y.alphaTag) || x.frequency - y.frequency);
+    }, [candidates, aliases]);
+
+    // Effective selection without setState-in-effect: fall back to the first channel.
+    const effectiveKey = channels.some(c => chKey(c.alphaTag, c.frequency) === selKey)
+        ? selKey
+        : (channels[0] ? chKey(channels[0].alphaTag, channels[0].frequency) : '');
+    const selected = channels.find(c => chKey(c.alphaTag, c.frequency) === effectiveKey);
+
+    // Merge discovered candidates with existing aliases into rows for one kind.
+    const rowsFor = (kind: 'SRC' | 'TG') => {
+        if (!selected) return [] as { value: number; count?: number; lastSeen?: string; alias?: RadioAlias }[];
+        const values = new Map<number, { count?: number; lastSeen?: string; alias?: RadioAlias }>();
+        for (const c of candidates) {
+            if (c.kind === kind && chKey(c.alphaTag, c.frequency) === effectiveKey)
+                values.set(c.value, { count: c.count, lastSeen: c.lastSeen });
+        }
+        for (const a of aliases) {
+            if (a.kind === kind && chKey(a.alphaTag, a.frequency) === effectiveKey)
+                values.set(a.value, { ...(values.get(a.value) || {}), alias: a });
+        }
+        return [...values.entries()]
+            .map(([value, info]) => ({ value, ...info }))
+            .sort((x, y) => (y.count ?? 0) - (x.count ?? 0) || x.value - y.value);
+    };
+
+    const commit = (kind: 'SRC' | 'TG', value: number, alias?: RadioAlias) => {
+        if (!selected) return;
+        const key = `${effectiveKey}|${kind}|${value}`;
+        const name = (drafts[key] ?? alias?.name ?? '').trim();
+        if (name) onSave({ id: alias?.id, kind, value, name, alphaTag: selected.alphaTag, frequency: selected.frequency });
+        else if (alias?.id) onDelete(alias.id);
+    };
+
+    const renderList = (kind: 'SRC' | 'TG') => {
+        const rows = rowsFor(kind);
+        if (rows.length === 0) {
+            return <Typography variant="caption" color="text.secondary" sx={{ px: 1 }}>None seen in the last 7 days.</Typography>;
+        }
+        return (
+            <List dense disablePadding>
+                {rows.map(({ value, count, lastSeen, alias }) => {
+                    const key = `${effectiveKey}|${kind}|${value}`;
+                    return (
+                        <ListItem key={key} divider sx={{ gap: 1 }}>
+                            <Box sx={{ minWidth: 96 }}>
+                                <Typography sx={{ fontFamily: MONO, fontWeight: 700 }}>{value}</Typography>
+                                <Typography variant="caption" color="text.secondary">
+                                    {count != null ? `${count}×` : 'aliased'}{lastSeen ? ` · ${shortDate(lastSeen)}` : ''}
+                                </Typography>
+                            </Box>
+                            <TextField
+                                size="small"
+                                placeholder="Display name"
+                                fullWidth
+                                value={drafts[key] ?? alias?.name ?? ''}
+                                onChange={e => setDrafts(d => ({ ...d, [key]: e.target.value }))}
+                                onBlur={() => commit(kind, value, alias)}
+                                onKeyDown={e => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur(); }}
+                            />
+                        </ListItem>
+                    );
+                })}
+            </List>
+        );
+    };
+
+    return (
+        <FormDialog
+            open={open}
+            onClose={onClose}
+            title="Radio Aliases"
+            icon={<BadgeIcon />}
+            maxWidth="md"
+            actions={
+                <>
+                    <Button startIcon={<FileDownloadIcon />} onClick={handleExport} disabled={aliases.length === 0}>Export</Button>
+                    <Button startIcon={<FileUploadIcon />} onClick={() => fileInputRef.current?.click()}>Import</Button>
+                    <Box flexGrow={1} />
+                    <Button onClick={onClose} color="inherit">Close</Button>
+                </>
+            }
+        >
+            <input
+                ref={fileInputRef}
+                type="file"
+                accept="application/json,.json"
+                hidden
+                onChange={handleImportFile}
+            />
+            {message && (
+                <Alert severity="info" onClose={() => setMessage(null)} sx={{ mb: 2 }}>{message}</Alert>
+            )}
+            {channels.length === 0 ? (
+                <EmptyState icon={<BadgeIcon />} title="No radio IDs seen yet" hint="SRC and TG values from the last 7 days will appear here to name." />
+            ) : (
+                <Box display="flex" flexDirection="column" gap={2}>
+                    <FormControl size="small" fullWidth>
+                        <InputLabel id="alias-channel-label">Channel</InputLabel>
+                        <Select
+                            labelId="alias-channel-label"
+                            label="Channel"
+                            value={effectiveKey}
+                            onChange={e => setSelKey(e.target.value)}
+                        >
+                            {channels.map(c => (
+                                <MenuItem key={chKey(c.alphaTag, c.frequency)} value={chKey(c.alphaTag, c.frequency)}>
+                                    {c.alphaTag || '(unnamed)'} — {c.frequency.toFixed(4)} MHz
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+
+                    <Box>
+                        <Divider textAlign="left" sx={{ mb: 1 }}>
+                            <Chip label="Source IDs (SRC)" size="small" color="warning" variant="outlined" />
+                        </Divider>
+                        {renderList('SRC')}
+                    </Box>
+
+                    <Box>
+                        <Divider textAlign="left" sx={{ mb: 1 }}>
+                            <Chip label="Talkgroups (TG)" size="small" color="info" variant="outlined" />
+                        </Divider>
+                        {renderList('TG')}
+                    </Box>
+
+                    <Typography variant="caption" color="text.secondary">
+                        Names are saved per channel and appear in the log and live display. Clear a name to remove it.
+                    </Typography>
+                </Box>
+            )}
+        </FormDialog>
+    );
+};
+
+export default AliasManager;

--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -19,6 +19,7 @@ import VolumeUpIcon from '@mui/icons-material/VolumeUp';
 import MonitorIcon from '@mui/icons-material/Monitor';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
 import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
+import BadgeIcon from '@mui/icons-material/Badge';
 import type { ScannerState } from '../types';
 import StatusChip from './common/StatusChip';
 
@@ -35,6 +36,7 @@ interface Props {
   onOpenSettings: () => void;
   onOpenDebug: () => void;
   onOpenSystemDebug: () => void;
+  onOpenAliases: () => void;
   updateAvailable?: boolean;
   onOpenUpdate: () => void;
 }
@@ -45,7 +47,7 @@ const gpsMono = { fontFamily: MONO, color: 'text.primary' } as const;
 const AppHeader: React.FC<Props> = ({
   scannerState, currentTime, volume, onVolumeChange, manualHold, onResume,
   isFullscreen, onToggleFullscreen, onOpenFireTones, onOpenSettings, onOpenDebug, onOpenSystemDebug,
-  updateAvailable, onOpenUpdate,
+  onOpenAliases, updateAvailable, onOpenUpdate,
 }) => {
   const [menuAnchor, setMenuAnchor] = useState<null | HTMLElement>(null);
   const gps = scannerState.gps;
@@ -55,6 +57,7 @@ const AppHeader: React.FC<Props> = ({
   const actions = [
     ...(updateAvailable ? [{ label: 'Software Update', icon: <SystemUpdateIcon />, onClick: onOpenUpdate }] : []),
     { label: 'Fire Tone Outs', icon: <NotificationsActiveIcon />, onClick: onOpenFireTones },
+    { label: 'Radio Aliases', icon: <BadgeIcon />, onClick: onOpenAliases },
     { label: 'Settings', icon: <SettingsIcon />, onClick: onOpenSettings },
     { label: isFullscreen ? 'Exit Fullscreen' : 'Fullscreen', icon: isFullscreen ? <FullscreenExitIcon /> : <FullscreenIcon />, onClick: onToggleFullscreen },
     { label: 'RF Spectrum Debug', icon: <MonitorIcon />, onClick: onOpenDebug },

--- a/client/src/components/CommandPalette.tsx
+++ b/client/src/components/CommandPalette.tsx
@@ -7,6 +7,7 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow';
 import SkipNextIcon from '@mui/icons-material/SkipNext';
 import SettingsIcon from '@mui/icons-material/Settings';
 import NotificationsActiveIcon from '@mui/icons-material/NotificationsActive';
+import BadgeIcon from '@mui/icons-material/Badge';
 import EditIcon from '@mui/icons-material/Edit';
 import MonitorIcon from '@mui/icons-material/Monitor';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
@@ -33,13 +34,14 @@ interface Props {
   onOpenSettings: () => void;
   onOpenFireTones: () => void;
   onOpenChannels: () => void;
+  onOpenAliases: () => void;
   onOpenDebug: () => void;
   onToggleFullscreen: () => void;
 }
 
 const CommandPalette: React.FC<Props> = ({
   open, onClose, channels, manualHold, onHold, onResume, onSkip,
-  onOpenSettings, onOpenFireTones, onOpenChannels, onOpenDebug, onToggleFullscreen,
+  onOpenSettings, onOpenFireTones, onOpenChannels, onOpenAliases, onOpenDebug, onToggleFullscreen,
 }) => {
   const [query, setQuery] = useState('');
   const [active, setActive] = useState(0);
@@ -73,12 +75,13 @@ const CommandPalette: React.FC<Props> = ({
       { id: 'skip', label: 'Skip current transmission', section: 'Actions', icon: <SkipNextIcon fontSize="small" />, keywords: 'skip next avoid', run: run(onSkip) },
       { id: 'channels', label: 'Manage channels', section: 'Actions', icon: <EditIcon fontSize="small" />, keywords: 'channels edit manage add', run: run(onOpenChannels) },
       { id: 'firetones', label: 'Fire tone-outs', section: 'Actions', icon: <NotificationsActiveIcon fontSize="small" />, keywords: 'fire tone out alerts', run: run(onOpenFireTones) },
+      { id: 'aliases', label: 'Manage radio aliases', section: 'Actions', icon: <BadgeIcon fontSize="small" />, keywords: 'alias name src tg talkgroup unit id', run: run(onOpenAliases) },
       { id: 'settings', label: 'Open settings', section: 'Actions', icon: <SettingsIcon fontSize="small" />, keywords: 'settings preferences storage', run: run(onOpenSettings) },
       { id: 'debug', label: 'RF spectrum debug', section: 'Actions', icon: <MonitorIcon fontSize="small" />, keywords: 'rf spectrum debug waterfall', run: run(onOpenDebug) },
       { id: 'fullscreen', label: 'Toggle fullscreen', section: 'Actions', icon: <FullscreenIcon fontSize="small" />, keywords: 'fullscreen full screen', run: run(onToggleFullscreen) },
     ];
     return [...actionCmds, ...channelCmds];
-  }, [channels, manualHold, onHold, onResume, onSkip, onOpenChannels, onOpenFireTones, onOpenSettings, onOpenDebug, onToggleFullscreen, onClose]);
+  }, [channels, manualHold, onHold, onResume, onSkip, onOpenChannels, onOpenFireTones, onOpenAliases, onOpenSettings, onOpenDebug, onToggleFullscreen, onClose]);
 
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();

--- a/client/src/components/ScannerDisplay.tsx
+++ b/client/src/components/ScannerDisplay.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Box, Typography, Paper, Chip, ThemeProvider } from '@mui/material';
 import { alpha } from '@mui/material/styles';
 import type { ScannerState, Channel } from '../types';
+import { chainLabel, srcLabel, tgLabel, type NameFor } from '../lib/aliasLabels';
 import RadioIcon from '@mui/icons-material/Radio';
 import SignalCellularAltIcon from '@mui/icons-material/SignalCellularAlt';
 import PlayArrowIcon from '@mui/icons-material/PlayArrow';
@@ -15,11 +16,12 @@ interface Props {
     analyser?: AnalyserNode;
     onScan?: (freq?: number) => void;
     channels?: Channel[];
+    nameFor?: NameFor;
 }
 
 const monoFont = { fontFamily: '"Roboto Mono", ui-monospace, monospace' };
 
-const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [] }) => {
+const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [], nameFor }) => {
     const isReceiving = state.status === 'RECEIVING';
     const isParallel = !!state.parallelChannels && state.parallelChannels.length > 0;
     const isFastScan = !isParallel && state.status === 'SCANNING' && !state.currentFrequency && channels.length > 1;
@@ -163,7 +165,7 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                     <Typography key={pc.channel.frequency} variant="caption" sx={{
                                         color: status.warn, fontWeight: 'bold', mt: 0.5, display: 'block', ...monoFont, fontSize: '0.65rem',
                                     }}>
-                                        {pc.channel.alphaTag}: {pc.sourceID ?? '?'} {pc.targetID ? `-> TG ${pc.targetID}` : ''}
+                                        {pc.channel.alphaTag}: {srcLabel(nameFor, pc.sourceID, pc.channel.alphaTag, pc.channel.frequency)} {pc.targetID ? `-> TG ${tgLabel(nameFor, pc.targetID, pc.channel.alphaTag, pc.channel.frequency)}` : ''}
                                     </Typography>
                                 ))}
                             </>
@@ -231,9 +233,13 @@ const ScannerDisplay: React.FC<Props> = ({ state, analyser, onScan, channels = [
                                 </Box>
                                 {isReceiving && (state.speakerChain || state.sourceID || state.targetID) && (
                                     <Typography variant="caption" sx={{ color: status.warn, fontWeight: 'bold', mt: 0.5, display: 'block', ...monoFont, letterSpacing: 1 }}>
-                                        {state.speakerChain
-                                            ? `${state.speakerChain} → TG ${state.targetID ?? '?'}`
-                                            : `${state.sourceID ?? '?'} → TG ${state.targetID ?? '?'}`}
+                                        {(() => {
+                                            const at = state.currentChannel?.alphaTag ?? '';
+                                            const fq = state.currentChannel?.frequency ?? state.currentFrequency ?? 0;
+                                            return state.speakerChain
+                                                ? `${chainLabel(nameFor, state.speakerChain, at, fq)} → TG ${tgLabel(nameFor, state.targetID, at, fq)}`
+                                                : `${srcLabel(nameFor, state.sourceID, at, fq)} → TG ${tgLabel(nameFor, state.targetID, at, fq)}`;
+                                        })()}
                                     </Typography>
                                 )}
                             </>

--- a/client/src/components/TransmissionLog.tsx
+++ b/client/src/components/TransmissionLog.tsx
@@ -38,6 +38,7 @@ import {
 } from '@mui/icons-material';
 import { Chip } from '@mui/material';
 import type { CallLog, Channel } from '../types';
+import { chainLabel, srcLabel, tgLabel, type NameFor } from '../lib/aliasLabels';
 import { status } from '../theme/tokens';
 import EmptyState from './common/EmptyState';
 import PanelSkeleton from './common/PanelSkeleton';
@@ -77,6 +78,8 @@ export interface HighlightRequest {
 }
 
 const HighlightContext = createContext<HighlightRequest | null>(null);
+/** Per-channel SRC/TG display-name resolver, provided to the deeply-nested rows. */
+const AliasContext = createContext<NameFor | null>(null);
 
 interface Props {
     liveLogs: CallLog[];
@@ -88,9 +91,11 @@ interface Props {
     loaded?: boolean;
     /** Recording ids referenced by fire tone-out events (for the Tone-outs filter). */
     toneOutIds?: Set<string>;
+    /** Resolves per-channel display names for SRC/TG. */
+    nameFor?: NameFor;
 }
 
-const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelete, highlight, loaded = true, toneOutIds }) => {
+const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelete, highlight, loaded = true, toneOutIds, nameFor }) => {
     const [searchQuery, setSearchQuery] = useState('');
     const [searchResults, setSearchResults] = useState<CallLog[] | null>(null);
     const [years, setYears] = useState<string[]>([]);
@@ -183,6 +188,7 @@ const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelet
     }, [searchQuery]);
 
     return (
+        <AliasContext.Provider value={nameFor ?? null}>
         <HighlightContext.Provider value={highlight ?? null}>
         <Box data-testid="transmission-log" sx={{ flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column' }}>
             <Box sx={{ p: 1.5, borderBottom: '1px solid', borderColor: 'surface.border', display: 'flex', flexDirection: 'column', gap: 1.25 }}>
@@ -298,6 +304,7 @@ const TransmissionLog: React.FC<Props> = ({ liveLogs, playingId, onPlay, onDelet
             </Box>
         </Box>
         </HighlightContext.Provider>
+        </AliasContext.Provider>
     );
 };
 
@@ -531,7 +538,11 @@ const ChannelNode = ({ year, month, day, channel, playingId, onPlay, onDelete, o
 const LogItem =({ log, tree, playingId, onPlay, onDelete, onFavoriteToggle }: { log: CallLog; tree?: boolean } & LogNodeProps) => {
     const [isFavorite, setIsFavorite] = useState(log.isFavorite ?? false);
     const highlight = useContext(HighlightContext);
+    const nameFor = useContext(AliasContext);
     const itemRef = useRef<HTMLLIElement>(null);
+
+    // Per-channel SRC/TG display names (fall back to the raw number; raw kept on hover).
+    const at = log.alphaTag, fq = log.frequency;
 
     // Scroll into view and briefly flash when this log is the highlight target.
     // The flash is driven imperatively via the Web Animations API so the effect
@@ -681,30 +692,38 @@ const LogItem =({ log, tree, playingId, onPlay, onDelete, onFavoriteToggle }: { 
                                         <Box display="flex" alignItems="center" gap={0.4}>
                                             {log.speakerChain ? (
                                                 <>
-                                                    <Typography variant="caption" sx={{ color: status.warn, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
-                                                        {log.speakerChain}
-                                                    </Typography>
+                                                    <Tooltip title={log.speakerChain}>
+                                                        <Typography variant="caption" sx={{ color: status.warn, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
+                                                            {chainLabel(nameFor, log.speakerChain, at, fq)}
+                                                        </Typography>
+                                                    </Tooltip>
                                                     {log.targetID && (
                                                         <>
                                                             <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.65rem' }}>→</Typography>
                                                             <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.65rem', ...monoFont }}>TG</Typography>
-                                                            <Typography variant="caption" sx={{ color: status.info, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
-                                                                {log.targetID}
-                                                            </Typography>
+                                                            <Tooltip title={String(log.targetID)}>
+                                                                <Typography variant="caption" sx={{ color: status.info, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
+                                                                    {tgLabel(nameFor, log.targetID, at, fq)}
+                                                                </Typography>
+                                                            </Tooltip>
                                                         </>
                                                     )}
                                                 </>
                                             ) : (
                                                 <>
                                                     <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.65rem', ...monoFont }}>SRC</Typography>
-                                                    <Typography variant="caption" sx={{ color: status.warn, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
-                                                        {log.sourceID ?? '?'}
-                                                    </Typography>
+                                                    <Tooltip title={log.sourceID != null ? String(log.sourceID) : ''}>
+                                                        <Typography variant="caption" sx={{ color: status.warn, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
+                                                            {srcLabel(nameFor, log.sourceID, at, fq)}
+                                                        </Typography>
+                                                    </Tooltip>
                                                     <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.65rem' }}>→</Typography>
                                                     <Typography variant="caption" sx={{ color: 'text.disabled', fontSize: '0.65rem', ...monoFont }}>TG</Typography>
-                                                    <Typography variant="caption" sx={{ color: status.info, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
-                                                        {log.targetID ?? '?'}
-                                                    </Typography>
+                                                    <Tooltip title={log.targetID != null ? String(log.targetID) : ''}>
+                                                        <Typography variant="caption" sx={{ color: status.info, fontSize: '0.7rem', ...monoFont, fontWeight: 'bold' }}>
+                                                            {tgLabel(nameFor, log.targetID, at, fq)}
+                                                        </Typography>
+                                                    </Tooltip>
                                                 </>
                                             )}
                                         </Box>

--- a/client/src/hooks/useScannerSocket.ts
+++ b/client/src/hooks/useScannerSocket.ts
@@ -1,5 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import type { ScannerState, Channel, CallLog, FireToneSet, RadioEvent, UpdateProgress, UpdateState } from '../types';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ScannerState, Channel, CallLog, FireToneSet, RadioEvent, RadioAlias, AliasCandidate, UpdateProgress, UpdateState } from '../types';
+import type { NameFor } from '../lib/aliasLabels';
+
+// Channel-scoped alias key; toFixed(4) neutralizes REAL float equality on both sides.
+const aliasKey = (kind: string, value: number, alphaTag: string, frequency: number) =>
+  `${alphaTag}|${frequency.toFixed(4)}|${kind}|${value}`;
 
 interface Options {
   /** Called when a state update indicates whether the live stream is stereo. */
@@ -17,6 +22,8 @@ export function useScannerSocket({ onParallel }: Options = {}) {
   const [fireTones, setFireTones] = useState<FireToneSet[]>([]);
   const [callLog, setCallLog] = useState<CallLog[]>([]);
   const [radioEvents, setRadioEvents] = useState<RadioEvent[]>([]);
+  const [aliases, setAliases] = useState<RadioAlias[]>([]);
+  const [aliasCandidates, setAliasCandidates] = useState<AliasCandidate[]>([]);
   const [updateLog, setUpdateLog] = useState<string[]>([]);
   const [updateState, setUpdateState] = useState<UpdateState>('idle');
 
@@ -116,6 +123,71 @@ export function useScannerSocket({ onParallel }: Options = {}) {
     }
   }, [refreshFireTones]);
 
+  const refreshAliases = useCallback(() => {
+    fetch('/api/aliases')
+      .then(res => res.json())
+      .then(data => setAliases(data))
+      .catch(err => console.error('Failed to fetch aliases:', err));
+  }, []);
+
+  const refreshAliasCandidates = useCallback((days = 7) => {
+    fetch(`/api/aliases/candidates?days=${days}`)
+      .then(res => res.json())
+      .then(data => setAliasCandidates(data))
+      .catch(err => console.error('Failed to fetch alias candidates:', err));
+  }, []);
+
+  const handleSaveAlias = useCallback(async (alias: RadioAlias) => {
+    const method = alias.id ? 'PUT' : 'POST';
+    const url = alias.id ? `/api/aliases/${alias.id}` : '/api/aliases';
+    try {
+      await fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(alias) });
+      refreshAliases();
+    } catch (e) {
+      console.error('Save alias failed:', e);
+    }
+  }, [refreshAliases]);
+
+  const handleDeleteAlias = useCallback(async (id: number) => {
+    try {
+      await fetch(`/api/aliases/${id}`, { method: 'DELETE' });
+      refreshAliases();
+    } catch (e) {
+      console.error('Delete alias failed:', e);
+    }
+  }, [refreshAliases]);
+
+  // Additive import: fills in blanks server-side without overwriting existing names.
+  // Returns the number of aliases added.
+  const importAliases = useCallback(async (list: RadioAlias[]): Promise<number> => {
+    try {
+      const res = await fetch('/api/aliases/import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(list),
+      });
+      const data = await res.json().catch(() => ({ added: 0 }));
+      refreshAliases();
+      return data?.added ?? 0;
+    } catch (e) {
+      console.error('Import aliases failed:', e);
+      return 0;
+    }
+  }, [refreshAliases]);
+
+  // App-wide per-channel name lookup for SRC/TG, rebuilt when aliases change.
+  const aliasIndex = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const a of aliases) m.set(aliasKey(a.kind, a.value, a.alphaTag, a.frequency), a.name);
+    return m;
+  }, [aliases]);
+
+  const nameFor = useCallback<NameFor>(
+    (kind, value, alphaTag, frequency) =>
+      value == null ? undefined : aliasIndex.get(aliasKey(kind, value, alphaTag, frequency)),
+    [aliasIndex],
+  );
+
   const deleteEntry = useCallback(async (id: string) => {
     try {
       const response = await fetch(`/api/history/${id}`, { method: 'DELETE' });
@@ -149,6 +221,8 @@ export function useScannerSocket({ onParallel }: Options = {}) {
       .catch(err => console.error('Failed to fetch history:', err)).finally(() => setLogLoaded(true));
     fetch('/api/events').then(r => r.json()).then(setRadioEvents)
       .catch(err => console.error('Failed to fetch events:', err));
+    fetch('/api/aliases').then(r => r.json()).then(setAliases)
+      .catch(err => console.error('Failed to fetch aliases:', err));
 
     const connectControlWs = () => {
       wsControl.current = new WebSocket(wsControlUrl);
@@ -207,6 +281,13 @@ export function useScannerSocket({ onParallel }: Options = {}) {
     fireTones,
     callLog,
     radioEvents,
+    aliases,
+    aliasCandidates,
+    nameFor,
+    refreshAliasCandidates,
+    handleSaveAlias,
+    handleDeleteAlias,
+    importAliases,
     updateLog,
     updateState,
     seedUpdate,

--- a/client/src/lib/aliasLabels.ts
+++ b/client/src/lib/aliasLabels.ts
@@ -1,0 +1,42 @@
+/**
+ * Per-channel radio-alias label helpers. A "channel" is the (alphaTag, frequency)
+ * pair, matching how transmissions are keyed. `nameFor` resolves a display Name for
+ * a SRC/TG on a channel, or undefined when unmapped.
+ */
+export type NameFor = (
+  kind: 'SRC' | 'TG',
+  value: number | null | undefined,
+  alphaTag: string,
+  frequency: number,
+) => string | undefined;
+
+/** Display a source ID: mapped name, else the raw number, else '?'. */
+export const srcLabel = (
+  nameFor: NameFor | null | undefined,
+  value: number | null | undefined,
+  alphaTag: string,
+  frequency: number,
+): string => (value == null ? '?' : nameFor?.('SRC', value, alphaTag, frequency) ?? String(value));
+
+/** Display a talkgroup: mapped name, else the raw number, else '?'. */
+export const tgLabel = (
+  nameFor: NameFor | null | undefined,
+  value: number | null | undefined,
+  alphaTag: string,
+  frequency: number,
+): string => (value == null ? '?' : nameFor?.('TG', value, alphaTag, frequency) ?? String(value));
+
+/**
+ * Map each numeric token in a speaker chain (e.g. "101 → 102") as a SRC on the
+ * channel, leaving any non-numeric separators intact.
+ */
+export const chainLabel = (
+  nameFor: NameFor | null | undefined,
+  chain: string,
+  alphaTag: string,
+  frequency: number,
+): string =>
+  chain
+    .split(/\s*(?:→|->)\s*/)
+    .map(tok => (/^\d+$/.test(tok) ? srcLabel(nameFor, Number(tok), alphaTag, frequency) : tok))
+    .join(' → ');

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -96,6 +96,26 @@ export interface RadioEvent {
     transmissionId?: string;
 }
 
+/** A per-channel display name for a source ID (SRC) or talkgroup (TG). */
+export interface RadioAlias {
+    id?: number;
+    kind: 'SRC' | 'TG';
+    value: number;
+    name: string;
+    alphaTag: string;
+    frequency: number;
+}
+
+/** A distinct SRC/TG seen on a channel within the lookback window. */
+export interface AliasCandidate {
+    alphaTag: string;
+    frequency: number;
+    kind: 'SRC' | 'TG';
+    value: number;
+    count: number;
+    lastSeen?: string;
+}
+
 export type UpdateState = 'idle' | 'checking' | 'available' | 'updating' | 'success' | 'failed';
 
 export interface UpdateStatus {

--- a/server/OpenScanner.Server/Controllers/AliasesController.cs
+++ b/server/OpenScanner.Server/Controllers/AliasesController.cs
@@ -1,0 +1,81 @@
+using Microsoft.AspNetCore.Mvc;
+using OpenScanner.Server.Models;
+using OpenScanner.Server.Interfaces;
+
+namespace OpenScanner.Server.Controllers;
+
+/// <summary>
+/// Controller for per-channel radio aliases: display names for source IDs (SRC)
+/// and talkgroups (TG), plus discovery of recently-seen candidates.
+/// </summary>
+[ApiController]
+[Route("api/aliases")]
+[Produces("application/json")]
+public class AliasesController : ControllerBase
+{
+    private readonly IDatabase _db;
+
+    public AliasesController(IDatabase db)
+    {
+        _db = db;
+    }
+
+    /// <summary>Retrieves all configured radio aliases.</summary>
+    [HttpGet("")]
+    [ProducesResponseType(typeof(IEnumerable<RadioAlias>), StatusCodes.Status200OK)]
+    public async Task<IEnumerable<RadioAlias>> GetAliases()
+    {
+        return await _db.GetAliasesAsync();
+    }
+
+    /// <summary>
+    /// Lists the distinct SRC and TG values seen on each channel within the last
+    /// <paramref name="days"/> days (default 7), with counts and last-seen times.
+    /// </summary>
+    [HttpGet("candidates")]
+    [ProducesResponseType(typeof(IEnumerable<AliasCandidate>), StatusCodes.Status200OK)]
+    public async Task<IEnumerable<AliasCandidate>> GetCandidates([FromQuery] int days = 7)
+    {
+        return await _db.GetAliasCandidatesAsync(days);
+    }
+
+    /// <summary>Adds (or updates on conflict) a radio alias.</summary>
+    [HttpPost("")]
+    [ProducesResponseType(typeof(RadioAlias), StatusCodes.Status201Created)]
+    public async Task<IActionResult> AddAlias(RadioAlias alias)
+    {
+        alias.Id = await _db.AddAliasAsync(alias);
+        return CreatedAtAction(nameof(GetAliases), new { id = alias.Id }, alias);
+    }
+
+    /// <summary>Updates an existing radio alias.</summary>
+    [HttpPut("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> UpdateAlias(int id, RadioAlias alias)
+    {
+        alias.Id = id;
+        await _db.UpdateAliasAsync(alias);
+        return Ok();
+    }
+
+    /// <summary>Deletes a radio alias.</summary>
+    [HttpDelete("{id}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> DeleteAlias(int id)
+    {
+        await _db.DeleteAliasAsync(id);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Imports aliases additively — fills in blanks without overwriting existing names.
+    /// Returns the count added.
+    /// </summary>
+    [HttpPost("import")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> Import(IEnumerable<RadioAlias> aliases)
+    {
+        var added = await _db.ImportAliasesAsync(aliases);
+        return Ok(new { added });
+    }
+}

--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -200,6 +200,53 @@ public class Database : IDatabase
     }
 
     /// <inheritdoc />
+    public async Task<IEnumerable<RadioAlias>> GetAliasesAsync()
+    {
+        using var conn = GetConnection();
+        return await conn.QueryAsync<RadioAlias>(SqlLoader.GetSql("Aliases/GetAll.sql"));
+    }
+
+    /// <inheritdoc />
+    public async Task<int> AddAliasAsync(RadioAlias alias)
+    {
+        using var conn = GetConnection();
+        return await conn.ExecuteScalarAsync<int>(SqlLoader.GetSql("Aliases/Insert.sql"), alias);
+    }
+
+    /// <inheritdoc />
+    public async Task UpdateAliasAsync(RadioAlias alias)
+    {
+        using var conn = GetConnection();
+        await conn.ExecuteAsync(SqlLoader.GetSql("Aliases/Update.sql"), alias);
+    }
+
+    /// <inheritdoc />
+    public async Task DeleteAliasAsync(int id)
+    {
+        using var conn = GetConnection();
+        await conn.ExecuteAsync(SqlLoader.GetSql("Aliases/Delete.sql"), new { Id = id });
+    }
+
+    /// <inheritdoc />
+    public async Task<int> ImportAliasesAsync(IEnumerable<RadioAlias> aliases)
+    {
+        var list = aliases?.Where(a => !string.IsNullOrWhiteSpace(a.Name)).ToList() ?? new List<RadioAlias>();
+        if (list.Count == 0) return 0;
+        using var conn = GetConnection();
+        // ON CONFLICT DO NOTHING means conflicting rows affect 0; the sum is the number
+        // of blanks actually filled.
+        return await conn.ExecuteAsync(SqlLoader.GetSql("Aliases/InsertIfAbsent.sql"), list);
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<AliasCandidate>> GetAliasCandidatesAsync(int days)
+    {
+        using var conn = GetConnection();
+        var window = $"-{Math.Max(1, days)} days";
+        return await conn.QueryAsync<AliasCandidate>(SqlLoader.GetSql("Aliases/Candidates.sql"), new { Window = window });
+    }
+
+    /// <inheritdoc />
     public async Task SaveTransmissionAsync(CallLog log)
     {
         using var conn = GetConnection();

--- a/server/OpenScanner.Server/Interfaces/IDatabase.cs
+++ b/server/OpenScanner.Server/Interfaces/IDatabase.cs
@@ -193,6 +193,32 @@ public interface IDatabase
     /// <param name="id">The ID of the tone set to delete.</param>
     Task DeleteFireToneAsync(int id);
 
+    // Radio Aliases (per-channel display names for SRC / TG)
+
+    /// <summary>Retrieves all radio aliases.</summary>
+    Task<IEnumerable<RadioAlias>> GetAliasesAsync();
+
+    /// <summary>Adds (or updates on conflict) a radio alias; returns its row id.</summary>
+    Task<int> AddAliasAsync(RadioAlias alias);
+
+    /// <summary>Updates an existing radio alias by id.</summary>
+    Task UpdateAliasAsync(RadioAlias alias);
+
+    /// <summary>Deletes a radio alias by id.</summary>
+    Task DeleteAliasAsync(int id);
+
+    /// <summary>
+    /// Imports aliases additively: inserts only those whose (kind, value, channel) is
+    /// not already named, never overwriting existing names. Returns the number added.
+    /// </summary>
+    Task<int> ImportAliasesAsync(IEnumerable<RadioAlias> aliases);
+
+    /// <summary>
+    /// Returns the distinct SRC and TG values seen on each channel within the last
+    /// <paramref name="days"/> days, with occurrence counts and last-seen timestamps.
+    /// </summary>
+    Task<IEnumerable<AliasCandidate>> GetAliasCandidatesAsync(int days);
+
     // Radio Events (fire tone-out and MDC1200 detections)
 
     /// <summary>

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -245,6 +245,46 @@ public class FireToneSet
 }
 
 /// <summary>
+/// A per-channel display name for a radio source ID (SRC) or talkgroup (TG).
+/// A "channel" is identified by the (AlphaTag, Frequency) pair, matching how
+/// transmissions are keyed in history.
+/// </summary>
+public class RadioAlias
+{
+    /// <summary>Unique identifier.</summary>
+    public int? Id { get; set; }
+
+    /// <summary>Namespace of <see cref="Value"/>: "SRC" (radio/unit ID) or "TG" (talkgroup).</summary>
+    public string Kind { get; set; } = "SRC";
+
+    /// <summary>The radio ID or talkgroup number being named.</summary>
+    public int Value { get; set; }
+
+    /// <summary>The display name to show instead of the raw number.</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Channel alpha tag this alias applies to.</summary>
+    public string AlphaTag { get; set; } = string.Empty;
+
+    /// <summary>Channel frequency (MHz) this alias applies to.</summary>
+    public double Frequency { get; set; }
+}
+
+/// <summary>
+/// A distinct SRC or TG observed on a channel within a lookback window — the
+/// candidates a user can assign a <see cref="RadioAlias"/> name to.
+/// </summary>
+public class AliasCandidate
+{
+    public string AlphaTag { get; set; } = string.Empty;
+    public double Frequency { get; set; }
+    public string Kind { get; set; } = string.Empty;
+    public int Value { get; set; }
+    public int Count { get; set; }
+    public string? LastSeen { get; set; }
+}
+
+/// <summary>
 /// A decoded signaling event surfaced to the event log — either a fire tone-out
 /// (two-tone / Quick Call II) detection or an MDC1200 data packet.
 /// </summary>

--- a/server/OpenScanner.Server/Sql/Aliases/Candidates.sql
+++ b/server/OpenScanner.Server/Sql/Aliases/Candidates.sql
@@ -1,0 +1,12 @@
+SELECT alphaTag, frequency, 'SRC' AS Kind, sourceID AS Value,
+       COUNT(*) AS Count, MAX(timestamp) AS LastSeen
+FROM transmissions
+WHERE datetime(timestamp) >= datetime('now', @Window) AND sourceID IS NOT NULL
+GROUP BY alphaTag, frequency, sourceID
+UNION ALL
+SELECT alphaTag, frequency, 'TG' AS Kind, targetID AS Value,
+       COUNT(*) AS Count, MAX(timestamp) AS LastSeen
+FROM transmissions
+WHERE datetime(timestamp) >= datetime('now', @Window) AND targetID IS NOT NULL
+GROUP BY alphaTag, frequency, targetID
+ORDER BY alphaTag, frequency, Kind, Count DESC

--- a/server/OpenScanner.Server/Sql/Aliases/Delete.sql
+++ b/server/OpenScanner.Server/Sql/Aliases/Delete.sql
@@ -1,0 +1,1 @@
+DELETE FROM aliases WHERE id = @Id

--- a/server/OpenScanner.Server/Sql/Aliases/GetAll.sql
+++ b/server/OpenScanner.Server/Sql/Aliases/GetAll.sql
@@ -1,0 +1,3 @@
+SELECT id, kind, value, name, alphaTag, frequency
+FROM aliases
+ORDER BY alphaTag, frequency, kind, value

--- a/server/OpenScanner.Server/Sql/Aliases/Insert.sql
+++ b/server/OpenScanner.Server/Sql/Aliases/Insert.sql
@@ -1,0 +1,4 @@
+INSERT INTO aliases (kind, value, name, alphaTag, frequency)
+VALUES (@Kind, @Value, @Name, @AlphaTag, @Frequency)
+ON CONFLICT(kind, value, alphaTag, frequency) DO UPDATE SET name = excluded.name
+RETURNING id

--- a/server/OpenScanner.Server/Sql/Aliases/InsertIfAbsent.sql
+++ b/server/OpenScanner.Server/Sql/Aliases/InsertIfAbsent.sql
@@ -1,0 +1,3 @@
+INSERT INTO aliases (kind, value, name, alphaTag, frequency)
+VALUES (@Kind, @Value, @Name, @AlphaTag, @Frequency)
+ON CONFLICT(kind, value, alphaTag, frequency) DO NOTHING

--- a/server/OpenScanner.Server/Sql/Aliases/Update.sql
+++ b/server/OpenScanner.Server/Sql/Aliases/Update.sql
@@ -1,0 +1,3 @@
+UPDATE aliases
+SET kind = @Kind, value = @Value, name = @Name, alphaTag = @AlphaTag, frequency = @Frequency
+WHERE id = @Id

--- a/server/OpenScanner.Server/Sql/Initialize.sql
+++ b/server/OpenScanner.Server/Sql/Initialize.sql
@@ -23,6 +23,16 @@ CREATE TABLE IF NOT EXISTS fire_tones (
     description TEXT
 );
 
+CREATE TABLE IF NOT EXISTS aliases (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,          -- 'SRC' | 'TG'
+    value INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    alphaTag TEXT NOT NULL,
+    frequency REAL NOT NULL,
+    UNIQUE(kind, value, alphaTag, frequency)
+);
+
 CREATE TABLE IF NOT EXISTS channels (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     frequency REAL UNIQUE,

--- a/server/OpenScanner.Tests/Controllers/AliasesControllerTests.cs
+++ b/server/OpenScanner.Tests/Controllers/AliasesControllerTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using OpenScanner.Server.Controllers;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Models;
+using Xunit;
+
+namespace OpenScanner.Tests.Controllers;
+
+public class AliasesControllerTests
+{
+    private readonly Mock<IDatabase> _dbMock = new();
+    private readonly AliasesController _controller;
+
+    public AliasesControllerTests()
+    {
+        _controller = new AliasesController(_dbMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAliases_ReturnsAliases()
+    {
+        _dbMock.Setup(db => db.GetAliasesAsync())
+            .ReturnsAsync(new[] { new RadioAlias { Kind = "SRC", Value = 101, Name = "Car 1", AlphaTag = "PD", Frequency = 155.0 } });
+
+        var result = await _controller.GetAliases();
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public async Task GetCandidates_PassesDaysThrough()
+    {
+        _dbMock.Setup(db => db.GetAliasCandidatesAsync(7)).ReturnsAsync(Array.Empty<AliasCandidate>());
+
+        await _controller.GetCandidates(7);
+
+        _dbMock.Verify(db => db.GetAliasCandidatesAsync(7), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddAlias_ReturnsCreatedWithId()
+    {
+        var alias = new RadioAlias { Kind = "TG", Value = 4021, Name = "Dispatch", AlphaTag = "FD", Frequency = 154.4 };
+        _dbMock.Setup(db => db.AddAliasAsync(alias)).ReturnsAsync(9);
+
+        var result = await _controller.AddAlias(alias) as CreatedAtActionResult;
+
+        Assert.NotNull(result);
+        Assert.Equal(9, ((RadioAlias)result!.Value!).Id);
+    }
+
+    [Fact]
+    public async Task UpdateAlias_SetsIdAndUpdates()
+    {
+        var alias = new RadioAlias { Kind = "SRC", Value = 5, Name = "Engine 1", AlphaTag = "FD", Frequency = 154.4 };
+
+        var result = await _controller.UpdateAlias(3, alias) as OkResult;
+
+        Assert.NotNull(result);
+        _dbMock.Verify(db => db.UpdateAliasAsync(It.Is<RadioAlias>(a => a.Id == 3 && a.Name == "Engine 1")), Times.Once);
+    }
+
+    [Fact]
+    public async Task DeleteAlias_Deletes()
+    {
+        var result = await _controller.DeleteAlias(3) as OkResult;
+
+        Assert.NotNull(result);
+        _dbMock.Verify(db => db.DeleteAliasAsync(3), Times.Once);
+    }
+}

--- a/server/OpenScanner.Tests/Database/DatabaseTests.cs
+++ b/server/OpenScanner.Tests/Database/DatabaseTests.cs
@@ -78,6 +78,74 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public async Task AddAlias_ShouldPersist_AndUpsertOnConflict()
+    {
+        var id = await _db.AddAliasAsync(new RadioAlias { Kind = "SRC", Value = 101, Name = "Car 1", AlphaTag = "PD", Frequency = 155.0 });
+        Assert.True(id > 0);
+
+        var all = await _db.GetAliasesAsync();
+        Assert.Single(all);
+        Assert.Equal("Car 1", all.First().Name);
+
+        // Same (kind, value, alphaTag, frequency) upserts the name rather than adding a row.
+        await _db.AddAliasAsync(new RadioAlias { Kind = "SRC", Value = 101, Name = "Engine 1", AlphaTag = "PD", Frequency = 155.0 });
+        all = await _db.GetAliasesAsync();
+        Assert.Single(all);
+        Assert.Equal("Engine 1", all.First().Name);
+    }
+
+    [Fact]
+    public async Task UpdateAndDeleteAlias_ShouldWork()
+    {
+        var id = await _db.AddAliasAsync(new RadioAlias { Kind = "TG", Value = 4021, Name = "Dispatch", AlphaTag = "FD", Frequency = 154.4 });
+
+        await _db.UpdateAliasAsync(new RadioAlias { Id = id, Kind = "TG", Value = 4021, Name = "Main Dispatch", AlphaTag = "FD", Frequency = 154.4 });
+        Assert.Equal("Main Dispatch", (await _db.GetAliasesAsync()).First().Name);
+
+        await _db.DeleteAliasAsync(id);
+        Assert.Empty(await _db.GetAliasesAsync());
+    }
+
+    [Fact]
+    public async Task ImportAliases_ShouldFillBlanks_WithoutOverwriting()
+    {
+        await _db.AddAliasAsync(new RadioAlias { Kind = "SRC", Value = 101, Name = "Original", AlphaTag = "PD", Frequency = 155.0 });
+
+        var added = await _db.ImportAliasesAsync(new[]
+        {
+            new RadioAlias { Kind = "SRC", Value = 101, Name = "Should Not Win", AlphaTag = "PD", Frequency = 155.0 }, // conflict → skipped
+            new RadioAlias { Kind = "TG", Value = 4021, Name = "Dispatch", AlphaTag = "PD", Frequency = 155.0 },        // new → added
+        });
+
+        Assert.Equal(1, added);
+        var all = (await _db.GetAliasesAsync()).ToList();
+        Assert.Equal(2, all.Count);
+        Assert.Equal("Original", all.First(a => a.Kind == "SRC" && a.Value == 101).Name); // not overwritten
+        Assert.Contains(all, a => a.Kind == "TG" && a.Value == 4021 && a.Name == "Dispatch");
+    }
+
+    [Fact]
+    public async Task GetAliasCandidates_ShouldGroupDistinctSrcAndTgPerChannel_WithinWindow()
+    {
+        var now = DateTime.UtcNow.ToString("o");
+        // Same channel + SRC 101 twice (count 2), SRC 202 once, TG 4021.
+        await _db.SaveTransmissionAsync(new CallLog("c1", now, 155.0, "PD", "d", null, null, null, 1.0, null, 101, 4021));
+        await _db.SaveTransmissionAsync(new CallLog("c2", now, 155.0, "PD", "d", null, null, null, 1.0, null, 101, 4021));
+        await _db.SaveTransmissionAsync(new CallLog("c3", now, 155.0, "PD", "d", null, null, null, 1.0, null, 202, null));
+        // Stale (30 days ago) must be excluded from the 7-day window.
+        var old = DateTime.UtcNow.AddDays(-30).ToString("o");
+        await _db.SaveTransmissionAsync(new CallLog("c4", old, 155.0, "PD", "d", null, null, null, 1.0, null, 999, null));
+
+        var cands = (await _db.GetAliasCandidatesAsync(7)).ToList();
+
+        var src = cands.Where(c => c.Kind == "SRC").ToList();
+        Assert.Contains(src, c => c.Value == 101 && c.Count == 2 && c.AlphaTag == "PD");
+        Assert.Contains(src, c => c.Value == 202 && c.Count == 1);
+        Assert.DoesNotContain(src, c => c.Value == 999);
+        Assert.Contains(cands, c => c.Kind == "TG" && c.Value == 4021);
+    }
+
+    [Fact]
     public async Task GetTransmissionById_ShouldReturnMatchingLog()
     {
         var log = new CallLog("target_id", DateTime.UtcNow.ToString("o"), 155.0, "Tag", "Desc", 45.0, -122.0, "audio.raw", 5.0, "Linked transcription", 1234, 5678);


### PR DESCRIPTION
## Summary
Adds per-channel **display names** for radio source IDs (SRC) and talkgroups (TG). Names replace the raw numbers in the **transmission log** and the **live scanner display** (falling back to the number when unmapped; raw number kept on hover).

A new **Radio Aliases** manager (header + ⌘K palette) lets you pick a channel and see every distinct SRC/TG seen in the **last 7 days** (with hit counts + last-seen) and type a name for each. It also supports **export/import** of all bindings.

## Behavior
- **Naming scope:** per channel (a channel = the `(alphaTag, frequency)` pair, matching how transmissions are keyed). The same ID can be named differently on different channels. `SRC` and `TG` are separate namespaces.
- **Export:** downloads all bindings as `openscanner-aliases.json`.
- **Import:** additive — `POST /api/aliases/import` uses `ON CONFLICT … DO NOTHING`, so it **fills in blanks but never overwrites** an existing name; returns the count added.

## Implementation
- **Server:** `aliases` table (`UNIQUE(kind,value,alphaTag,frequency)`); `RadioAlias`/`AliasCandidate` models; `Sql/Aliases/*` (upsert `Insert`, fill-blanks `InsertIfAbsent`, distinct-per-channel `Candidates` with a `datetime('now','-N days')` window); `IDatabase`/`Database` methods; `AliasesController` (`GET /`, `GET /candidates?days=`, `POST/PUT/DELETE`, `POST /import`).
- **Client:** alias types; `useScannerSocket` alias state + CRUD + import + a memoized per-channel `nameFor` (`toFixed(4)` key to neutralize float equality); shared `lib/aliasLabels.ts` (incl. speaker-chain token parsing); substitution in `TransmissionLog` (via a new `AliasContext`, mirroring `HighlightContext`) and `ScannerDisplay`; new `AliasManager` dialog wired into `App`/`AppHeader`/`CommandPalette`.

## Testing
- Server builds on net10.0; **169/169 tests pass** (added controller + DB tests: upsert, candidates window/grouping, import fill-blanks/no-overwrite).
- Client `npm run lint` + `npm run build` clean; `vitest` green.
- Mock-server round-trip verified: `candidates` returns real per-channel distinct SRC/TG with counts + last-seen; CRUD + upsert; and import kept `SRC 101 = "Original"` while adding `TG 4021 = "Dispatch"` (`{"added":1}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)