### PR TITLE
Fix update banner: version-based check + git safe.directory for root service

### DIFF
--- a/server/OpenScanner.Server/Services/UpdateService.cs
+++ b/server/OpenScanner.Server/Services/UpdateService.cs
@@ -85,6 +85,35 @@ public class UpdateService : IUpdateService, IHostedService
         }
     }
 
+    // Prefixes git args with `-c safe.directory=*` so the root-run service can operate
+    // on a repo owned by another user (avoids git's "dubious ownership" refusal).
+    private static string[] Git(params string[] args) =>
+        new[] { "-c", "safe.directory=*" }.Concat(args).ToArray();
+
+    /// <summary>
+    /// True when <paramref name="latestTag"/> is a newer version than the running
+    /// <paramref name="current"/> build, comparing dotted numeric segments (leading
+    /// 'v' and any '+build'/'-prerelease' suffix stripped).
+    /// </summary>
+    internal static bool IsNewerRelease(string? current, string? latestTag)
+    {
+        if (string.IsNullOrWhiteSpace(current) || string.IsNullOrWhiteSpace(latestTag)) return false;
+        static int[] Parse(string v)
+        {
+            var core = v.TrimStart('v', 'V').Split('+', '-')[0];
+            return core.Split('.').Select(p => int.TryParse(p, out var n) ? n : 0).ToArray();
+        }
+        var c = Parse(current);
+        var l = Parse(latestTag);
+        for (int i = 0; i < Math.Max(c.Length, l.Length); i++)
+        {
+            var cv = i < c.Length ? c[i] : 0;
+            var lv = i < l.Length ? l[i] : 0;
+            if (lv != cv) return lv > cv;
+        }
+        return false;
+    }
+
     // MARK: - IHostedService (periodic availability check)
 
     public Task StartAsync(CancellationToken cancellationToken)
@@ -150,22 +179,23 @@ public class UpdateService : IUpdateService, IHostedService
         {
             var (tag, name, notes, url) = await FetchLatestReleaseAsync();
 
-            // Align local git metadata with the release tag.
-            await RunCaptureAsync("git", new[] { "fetch", "--tags", "--prune", "origin" }, RepoRoot, 60_000);
-            var head = (await RunCaptureAsync("git", new[] { "rev-parse", "HEAD" }, RepoRoot, 15_000))?.Trim() ?? "";
-            string? tagCommit = null;
+            // Availability is decided by comparing the running build version to the
+            // latest release tag. This is robust — it does not depend on the local git
+            // graph being in sync (git may be unavailable/blocked when the service runs
+            // as root on a differently-owned repo). The git steps below only provide the
+            // informational commits-behind count and the current HEAD.
+            var available = IsNewerRelease(currentVersion, tag);
+
+            // Best-effort git metadata (commits behind + HEAD); may be empty if git is
+            // unavailable, which is fine — availability is already decided above.
+            await RunCaptureAsync("git", Git("fetch", "--tags", "--prune", "origin"), RepoRoot, 60_000);
+            var head = (await RunCaptureAsync("git", Git("rev-parse", "HEAD"), RepoRoot, 15_000))?.Trim() ?? "";
             var behind = 0;
             if (!string.IsNullOrEmpty(tag))
             {
-                tagCommit = (await RunCaptureAsync("git", new[] { "rev-list", "-n", "1", tag! }, RepoRoot, 15_000))?.Trim();
-                var cnt = (await RunCaptureAsync("git", new[] { "rev-list", "--count", $"HEAD..{tag}" }, RepoRoot, 15_000))?.Trim();
+                var cnt = (await RunCaptureAsync("git", Git("rev-list", "--count", $"HEAD..{tag}"), RepoRoot, 15_000))?.Trim();
                 int.TryParse(cnt, out behind);
             }
-
-            var available = !string.IsNullOrEmpty(tagCommit)
-                            && !string.IsNullOrEmpty(head)
-                            && !string.Equals(tagCommit, head, StringComparison.OrdinalIgnoreCase)
-                            && behind > 0;
 
             lock (_lock)
             {
@@ -235,13 +265,13 @@ public class UpdateService : IUpdateService, IHostedService
 
             Emit("start", $"Updating to release {tag}…");
 
-            if (await RunStreamingAsync("git", new[] { "fetch", "--tags", "--prune", "origin" }, RepoRoot, "fetch", 120_000) != 0)
+            if (await RunStreamingAsync("git", Git("fetch", "--tags", "--prune", "origin"), RepoRoot, "fetch", 120_000) != 0)
             { Fail("git fetch failed."); return; }
 
             // Preserve the operator-configured PowerDMS department across the hard reset.
             var savedDept = TryReadPowerDmsDepartment();
 
-            if (await RunStreamingAsync("git", new[] { "reset", "--hard", tag! }, RepoRoot, "reset", 60_000) != 0)
+            if (await RunStreamingAsync("git", Git("reset", "--hard", tag!), RepoRoot, "reset", 60_000) != 0)
             { Fail("git reset failed."); return; }
 
             if (!string.IsNullOrEmpty(savedDept) && RestorePowerDmsDepartment(savedDept!))

--- a/server/OpenScanner.Tests/Services/UpdateServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/UpdateServiceTests.cs
@@ -1,0 +1,27 @@
+using OpenScanner.Server.Services;
+using Xunit;
+
+namespace OpenScanner.Tests.Services;
+
+public class UpdateServiceTests
+{
+    [Theory]
+    // Newer release available (the pi5 case: running 0.1.242, released v0.1.244).
+    [InlineData("0.1.242", "v0.1.244", true)]
+    [InlineData("0.1.242", "0.1.243", true)]
+    [InlineData("0.1.9", "v0.1.10", true)]
+    [InlineData("1.0.0", "v1.0.1", true)]
+    // Up to date or ahead → not available.
+    [InlineData("0.1.244", "v0.1.244", false)]
+    [InlineData("0.1.245", "v0.1.244", false)]
+    // Build metadata / prerelease suffixes are ignored.
+    [InlineData("0.1.242+abc123", "v0.1.244", true)]
+    [InlineData("0.1.244+abc123", "v0.1.244", false)]
+    // Missing/garbage inputs → not available.
+    [InlineData("", "v0.1.244", false)]
+    [InlineData("0.1.244", "", false)]
+    public void IsNewerRelease_ComparesVersions(string current, string latestTag, bool expected)
+    {
+        Assert.Equal(expected, UpdateService.IsNewerRelease(current, latestTag));
+    }
+}


### PR DESCRIPTION
## Problem
On the Pi, the **update banner never appears** even when a newer release exists (`v0.1.244` while the box runs `0.1.242`). `GET /api/update/status` returns `updateAvailable: false`, `commitsBehind: 0`, but the correct `latestTag: v0.1.244`.

## Root cause
`UpdateService.CheckAsync` decided availability from a local `git rev-list --count HEAD..<tag>`. The service runs as **root** against a repo owned by `brian`, so git's *"dubious ownership"* protection makes every git command in the check silently no-op (returns empty → `behind = 0` → `updateAvailable = false`). The GitHub API half works (hence the correct `latestTag`), so the mismatch went unnoticed. The same root/ownership issue would also break the update **action** (`git fetch`/`git reset`).

## Fix
- **Decide availability by version comparison** — running build version vs latest release tag (dotted-numeric, `v`/`+build` stripped). This is robust and independent of the local git graph. Commits-behind is kept as best-effort info only.
- **Prefix all git invocations with `-c safe.directory=*`** so the root-run service can operate on the user-owned repo (unblocks the fetch/reset in both the check and the update action).

## Testing
- Server builds on net10.0; **179/179 tests pass**, including a new `IsNewerRelease` theory (covers the exact pi5 case `0.1.242` → `v0.1.244` = available, plus up-to-date/ahead/build-suffix/garbage cases).

## Note on rollout (bootstrap)
The Pi currently runs the *old* buggy checker, so it can't detect this fix on its own. After merging (which cuts a new release), the Pi needs **one manual update** (`./scripts/install_service.sh`) to pick up the fixed checker. From then on the banner appears for new releases and in-UI updates work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)