### PR TITLE
Fix "database is locked" errors under concurrent writes

### DIFF
--- a/server/OpenScanner.Server/Database/Database.cs
+++ b/server/OpenScanner.Server/Database/Database.cs
@@ -64,6 +64,13 @@ public class Database : IDatabase
     private void Initialize()
     {
         using var conn = GetConnection();
+        // Enable Write-Ahead Logging so readers and a single writer don't block
+        // each other. This is a persistent property of the database file, so
+        // setting it once here applies to every subsequent connection. Without
+        // it, the constant transmission writes serialize against user-triggered
+        // writes (e.g. saving an alias) and surface as "database is locked".
+        conn.Execute("PRAGMA journal_mode=WAL;");
+
         var sql = SqlLoader.GetSql("Initialize.sql");
         conn.Execute(sql);
         
@@ -145,7 +152,18 @@ public class Database : IDatabase
     }
 
     /// <inheritdoc />
-    public SqliteConnection GetConnection() => new SqliteConnection(_connectionString);
+    public SqliteConnection GetConnection()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        conn.Open();
+        // busy_timeout is per-connection-handle and resets when a pooled handle
+        // is reused, so set it on every open. Any transient SQLITE_BUSY now waits
+        // up to 5s for the lock instead of failing immediately.
+        using var pragma = conn.CreateCommand();
+        pragma.CommandText = "PRAGMA busy_timeout=5000;";
+        pragma.ExecuteNonQuery();
+        return conn;
+    }
 
     /// <inheritdoc />
     public async Task<IEnumerable<Channel>> GetAllChannelsAsync()

--- a/server/OpenScanner.Tests/Database/DatabaseTests.cs
+++ b/server/OpenScanner.Tests/Database/DatabaseTests.cs
@@ -78,6 +78,32 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public async Task ConcurrentReadsAndWrites_ShouldNotThrowDatabaseLocked()
+    {
+        // Regression guard for "SQLite Error 5: 'database is locked'": with WAL
+        // journaling plus a busy_timeout, many concurrent writers and readers on
+        // separate connections must all succeed rather than failing on lock
+        // contention (as they did in the default rollback-journal mode).
+        var now = DateTime.UtcNow.ToString("o");
+        var tasks = new List<Task>();
+        for (int i = 0; i < 50; i++)
+        {
+            var id = $"concurrent_{i}";
+            tasks.Add(_db.SaveTransmissionAsync(
+                new CallLog(id, now, 155.0, "PD", "d", null, null, null, 1.0, null, i, 4021)));
+            tasks.Add(_db.AddAliasAsync(
+                new RadioAlias { Kind = "SRC", Value = i, Name = $"Unit {i}", AlphaTag = "PD", Frequency = 155.0 }));
+            tasks.Add(_db.GetHistoryAsync(100));
+        }
+
+        // Any lock contention would surface as a faulted task here.
+        await Task.WhenAll(tasks);
+
+        Assert.Equal(50, (await _db.GetHistoryAsync(1000)).Count());
+        Assert.Equal(50, (await _db.GetAliasesAsync()).Count());
+    }
+
+    [Fact]
     public async Task AddAlias_ShouldPersist_AndUpsertOnConflict()
     {
         var id = await _db.AddAliasAsync(new RadioAlias { Kind = "SRC", Value = 101, Name = "Car 1", AlphaTag = "PD", Frequency = 155.0 });


### PR DESCRIPTION
## Problem
The Pi logs showed repeated unhandled `SQLite Error 5: 'database is locked'` from `AddAliasAsync` — thrown whenever saving a radio alias raced the server's constant transmission writes.

## Root cause
`Database.GetConnection()` created a bare `SqliteConnection` with:
- **no `busy_timeout`** — any transient `SQLITE_BUSY` fails immediately instead of waiting, and
- **default rollback-journal mode** — a single writer blocks all readers/writers.

Under normal scanning load these two combine so a user-triggered write collides with transmission inserts and throws instead of briefly waiting.

## Fix
- Enable **WAL journaling** once in `Initialize()` (persisted in the DB file) so readers and one writer stop blocking each other.
- Open each connection eagerly and set **`PRAGMA busy_timeout=5000`** so transient locks wait up to 5s. The pragma is per-connection-handle and resets on pooled reuse, so it's set on every open.
- Add a concurrency regression test that fires 50× parallel writes + reads and asserts none fault.

## Verification
- `dotnet test` — 180/180 pass (new concurrency test included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)