### PR TITLE
Fix speaker chain lost in parallel-scan mode

### DIFF
--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -975,9 +975,13 @@ public class RtlDevice : BackgroundService, IRadioSource
         {
             rs.StartParallelRecording(channel, src, tgt, null);
         }
-        else if (rs != null && src.HasValue)
+        else if (rs != null)
         {
+            // Already recording this channel: update the current SRC/TGT and, on a
+            // talker change, append to the speaker chain (AppendSpeaker de-dupes
+            // consecutive repeats). Mirrors the single-channel HandleActivity path.
             rs.UpdateSourceTarget(channel.Frequency, src, tgt);
+            if (src.HasValue) rs.AppendSpeaker(channel.Frequency, src.Value);
         }
 
         // Reset per-channel activity timeout

--- a/server/OpenScanner.Tests/Services/RecordingServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/RecordingServiceTests.cs
@@ -171,6 +171,29 @@ public class RecordingServiceTests
     }
 
     [Fact]
+    public void ParallelRecording_AppendSpeaker_BuildsOrderedSpeakerChain()
+    {
+        CallLog? saved = null;
+        _db.Setup(d => d.SaveTransmissionAsync(It.IsAny<CallLog>()))
+           .Callback<CallLog>(l => saved = l)
+           .Returns(Task.CompletedTask);
+
+        // First talker seeded by StartParallelRecording; subsequent talkers appended.
+        _service.StartParallelRecording(Chan(155.0), 1, 2, new LinkedList<byte[]>());
+        _service.AppendSpeaker(155.0, 2);
+        _service.AppendSpeaker(155.0, 2); // consecutive repeat -> de-duped
+        _service.AppendSpeaker(155.0, 1);
+
+        // Feed enough audio to clear the 4KB minimum, then wait out the 0.5s floor.
+        _service.ProcessAudio(155.0, new byte[8192]);
+        Thread.Sleep(600);
+        _service.StopParallelRecording(155.0, null);
+
+        Assert.NotNull(saved);
+        Assert.Equal("1 → 2 → 1", saved!.SpeakerChain);
+    }
+
+    [Fact]
     public void StartParallelRecording_SameFrequencyTwice_IsIgnored()
     {
         _service.StartParallelRecording(Chan(155.0), 1, 2, new LinkedList<byte[]>());


### PR DESCRIPTION
## Problem
In parallel/FastScan mode, a transmission where several units talk only recorded the **last** radio ID instead of the full ordered chain (e.g. `101 → 202 → 101`). Single-channel scanning was unaffected.

## Root cause
The speaker-chain feature originally wired only the single-channel activity path. Parallel mode added the `AppendSpeaker(double frequency, int src)` overload and `ActiveRecording.SpeakerList`, but `HandleParallelActivity` was never wired to call it:

- It only called `UpdateSourceTarget(freq, src, tgt)`, which **overwrites** `rec.SourceID` with the latest talker.
- `AppendSpeaker(double, int)` had **zero callers**, so `SpeakerList` never grew past the one speaker seeded at `StartParallelRecording`.
- `StopParallelRecording` then saw `SpeakerList.Count <= 1` and saved `speakerChain = null`, so the UI fell back to showing only `sourceID`.

## Fix
Wire `AppendSpeaker(channel.Frequency, src.Value)` into `HandleParallelActivity` alongside `UpdateSourceTarget`, mirroring the single-channel handler. `AppendSpeaker` de-dupes consecutive repeats, so the chain grows only on real talker changes; `StartParallelRecording` already seeds the first speaker. Also lets a TGT-only update reach `UpdateSourceTarget` in parallel mode (matches single-channel behavior).

## Verification
- New `RecordingServiceTests` case: parallel recording with `AppendSpeaker` calls (incl. a consecutive duplicate) produces `SpeakerChain == "1 → 2 → 1"`.
- `dotnet test` → 181/181.
- Manual: a parallel-channel transmission with a talker change now shows the full `A → B` chain (raw IDs on hover) in the log and live display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)