### PR TITLE
Add CPU/SoC temperature to System Debug

### DIFF
--- a/client/src/components/SystemDebugDialog.tsx
+++ b/client/src/components/SystemDebugDialog.tsx
@@ -20,6 +20,7 @@ interface SystemStats {
   memPercent: number;
   memUsedMb: number;
   memTotalMb: number;
+  tempCelsius?: number | null;
   transcription: TranscriptionQueueStatus;
 }
 interface ServiceStatus { name: string; state: string; detail: string; }
@@ -62,6 +63,9 @@ interface BackfillStatus {
 }
 type SystemInfo = Record<string, string>;
 
+// Celsius (as reported by the sensors) to Fahrenheit for display.
+const cToF = (c: number): number => c * 9 / 5 + 32;
+
 // Byte / time formatting helpers.
 const fmtBytes = (n: number): string => {
   if (!n || n < 0) return '0 B';
@@ -93,7 +97,7 @@ const MONO = '"Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
 // How many one-second samples to retain — the graphs cover the last 120 seconds.
 const WINDOW = 120;
 
-interface Sample { t: number; cpu: number; mem: number; }
+interface Sample { t: number; cpu: number; mem: number; temp: number | null; }
 
 /**
  * Single-series area+line chart over the last WINDOW seconds with a fixed 0-100%
@@ -105,7 +109,9 @@ const ResourceGraph: React.FC<{
   samples: Sample[];
   value: (s: Sample) => number;
   currentText: string;
-}> = ({ label, color, samples, value, currentText }) => {
+  max?: number;
+  unit?: string;
+}> = ({ label, color, samples, value, currentText, max = 100, unit = '%' }) => {
   const theme = useTheme();
   const W = 520;
   const H = 140;
@@ -121,7 +127,7 @@ const ResourceGraph: React.FC<{
   // Map a sample index to an x coordinate. The window is right-aligned so the
   // newest sample sits at the right edge even before the buffer is full.
   const x = (i: number) => padL + plotW * (i - (samples.length - WINDOW)) / (WINDOW - 1);
-  const y = (v: number) => padT + plotH * (1 - Math.max(0, Math.min(100, v)) / 100);
+  const y = (v: number) => padT + plotH * (1 - Math.max(0, Math.min(max, v)) / max);
 
   const linePath = samples.map((s, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${y(value(s)).toFixed(1)}`).join(' ');
   const areaPath = samples.length
@@ -159,10 +165,10 @@ const ResourceGraph: React.FC<{
         onMouseLeave={() => setHover(null)}
         sx={{ width: '100%', height: 'auto', display: 'block' }}
       >
-        {[0, 25, 50, 75, 100].map((g) => (
+        {[0, 0.25, 0.5, 0.75, 1].map((f) => f * max).map((g) => (
           <g key={g}>
             <line x1={padL} x2={W - padR} y1={y(g)} y2={y(g)} stroke={gridColor} strokeWidth={1} opacity={0.5} />
-            <text x={padL - 6} y={y(g) + 3} textAnchor="end" fontSize={9} fill={inkMuted} fontFamily={MONO}>{g}</text>
+            <text x={padL - 6} y={y(g) + 3} textAnchor="end" fontSize={9} fill={inkMuted} fontFamily={MONO}>{Math.round(g)}</text>
           </g>
         ))}
         {areaPath && <path d={areaPath} fill={color} opacity={0.14} />}
@@ -178,7 +184,7 @@ const ResourceGraph: React.FC<{
               fontFamily={MONO}
               fill={theme.palette.text.primary}
             >
-              {value(hoverSample).toFixed(0)}%
+              {value(hoverSample).toFixed(0)}{unit}
             </text>
           </g>
         )}
@@ -271,7 +277,7 @@ const SystemDebugDialog: React.FC<Props> = ({ open, onClose, onDownloadSupport }
       if (cancelled || !s) return;
       setStats(s);
       setSamples((prev) => {
-        const next = [...prev, { t: Date.now(), cpu: s.cpuPercent, mem: s.memPercent }];
+        const next = [...prev, { t: Date.now(), cpu: s.cpuPercent, mem: s.memPercent, temp: s.tempCelsius != null ? cToF(s.tempCelsius) : null }];
         return next.length > WINDOW ? next.slice(next.length - WINDOW) : next;
       });
     };
@@ -362,9 +368,11 @@ const SystemDebugDialog: React.FC<Props> = ({ open, onClose, onDownloadSupport }
   const memText = stats
     ? `${stats.memPercent.toFixed(0)}%  (${stats.memUsedMb}/${stats.memTotalMb} MB)`
     : '—';
+  const tempText = stats?.tempCelsius != null ? `${cToF(stats.tempCelsius).toFixed(0)}°F` : 'N/A';
 
   const cpuColor = theme.palette.primary.main;
   const memColor = theme.palette.statusColors.info;
+  const tempColor = theme.palette.statusColors.warn;
 
   const sortedPorts = useMemo(() => services?.ports ?? [], [services]);
 
@@ -397,6 +405,9 @@ const SystemDebugDialog: React.FC<Props> = ({ open, onClose, onDownloadSupport }
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
               <ResourceGraph label="CPU" color={cpuColor} samples={samples} value={(s) => s.cpu} currentText={cpuText} />
               <ResourceGraph label="Memory" color={memColor} samples={samples} value={(s) => s.mem} currentText={memText} />
+              {stats?.tempCelsius != null && (
+                <ResourceGraph label="Temp" color={tempColor} samples={samples} value={(s) => s.temp ?? 0} currentText={tempText} max={212} unit="°F" />
+              )}
             </Box>
           </Paper>
         </Grid>

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -440,7 +440,8 @@ public record SystemStats(
     double MemPercent,
     long MemUsedMb,
     long MemTotalMb,
-    TranscriptionQueueStatus Transcription
+    TranscriptionQueueStatus Transcription,
+    double? TempCelsius        // CPU/SoC temperature in °C; null when no thermal sensor is available
 );
 
 /// <summary>State of a systemd unit (or the process itself when systemd is absent).</summary>

--- a/server/OpenScanner.Server/Services/SupportService.cs
+++ b/server/OpenScanner.Server/Services/SupportService.cs
@@ -170,13 +170,15 @@ public class SupportService : ISupportService
         var cpu = GetCpuPercent();
         var (usedBytes, totalBytes) = GetMemoryBytes();
         var memPct = totalBytes > 0 ? (double)usedBytes / totalBytes * 100.0 : 0;
+        var temp = GetCpuTempCelsius();
 
         return new SystemStats(
             Math.Round(cpu, 1),
             Math.Round(memPct, 1),
             usedBytes / 1024 / 1024,
             totalBytes / 1024 / 1024,
-            _transcription.GetQueueStatus());
+            _transcription.GetQueueStatus(),
+            temp.HasValue ? Math.Round(temp.Value, 1) : (double?)null);
     }
 
     /// <inheritdoc />
@@ -330,6 +332,68 @@ public class SupportService : ISupportService
             _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to read process memory");
             return (0, 0);
         }
+    }
+
+    // CPU/SoC temperature in °C, or null when no sensor is available. Reads the
+    // Linux thermal sysfs first (covers Raspberry Pi and x86 boards), then falls
+    // back to best-effort shell commands for boards/OSes that don't expose sysfs.
+    private double? GetCpuTempCelsius()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            try
+            {
+                double? best = null;
+                double? preferred = null;
+                foreach (var zone in Directory.EnumerateDirectories("/sys/class/thermal", "thermal_zone*"))
+                {
+                    var tempPath = Path.Combine(zone, "temp");
+                    if (!File.Exists(tempPath)) continue;
+                    if (!long.TryParse(File.ReadAllText(tempPath).Trim(), out var milli)) continue;
+                    var celsius = milli / 1000.0;
+                    if (celsius <= 0 || celsius > 200) continue; // ignore obviously bogus readings
+
+                    best = best is { } b ? Math.Max(b, celsius) : celsius;
+
+                    var typePath = Path.Combine(zone, "type");
+                    if (preferred is null && File.Exists(typePath))
+                    {
+                        var type = File.ReadAllText(typePath).Trim().ToLowerInvariant();
+                        if (type.Contains("cpu") || type.Contains("x86_pkg") || type.Contains("soc"))
+                            preferred = celsius;
+                    }
+                }
+                if (preferred is { } p) return p;
+                if (best is { } m) return m;
+            }
+            catch (Exception ex)
+            {
+                _loggerProvider.CreateLogger(nameof(SupportService)).LogDebug(ex, "Failed to read thermal sysfs");
+            }
+
+            // Raspberry Pi boards without a usable thermal zone expose vcgencmd.
+            var vc = ParseTempOutput(RunCommand("vcgencmd", new[] { "measure_temp" }, 1500));
+            if (vc.HasValue) return vc;
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            // Optional Homebrew tool; fails cleanly (returns null) when not installed.
+            var osx = ParseTempOutput(RunCommand("osx-cpu-temp", Array.Empty<string>(), 1500));
+            if (osx.HasValue) return osx;
+        }
+
+        return null;
+    }
+
+    // Extracts the first temperature number from strings like "temp=54.3'C" or "55.2°C".
+    private static double? ParseTempOutput(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output)) return null;
+        var match = System.Text.RegularExpressions.Regex.Match(output, @"-?\d+(?:\.\d+)?");
+        if (match.Success && double.TryParse(match.Value, System.Globalization.CultureInfo.InvariantCulture, out var v)
+            && v > 0 && v <= 200)
+            return v;
+        return null;
     }
 
     // "MemTotal:       8123456 kB" -> 8123456

--- a/server/OpenScanner.Tests/Services/SupportServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/SupportServiceTests.cs
@@ -99,4 +99,23 @@ public class SupportServiceTests
         Assert.Contains("Network", sysContent);
         Assert.Contains("RunningProcesses", sysContent);
     }
+
+    [Fact]
+    public void GetSystemStats_ReturnsStats_WithPlausibleTemperature()
+    {
+        // Arrange
+        var memLogger = new MemoryLoggerProvider();
+        _transcriptionMock.Setup(t => t.GetQueueStatus()).Returns(new TranscriptionQueueStatus(0, 0));
+        var service = new SupportService(_configMock.Object, memLogger, _dbMock.Object, _radioMock.Object, _gpsMock.Object, _transcriptionMock.Object, _broadcaster, _recordingMock.Object, _cleanup);
+
+        // Act
+        var stats = service.GetSystemStats();
+
+        // Assert
+        Assert.NotNull(stats);
+        // TempCelsius is null when no thermal sensor is available (e.g. macOS/CI without /sys/class/thermal);
+        // when present it must be a plausible reading.
+        if (stats.TempCelsius.HasValue)
+            Assert.InRange(stats.TempCelsius.Value, 0.1, 200.0);
+    }
 }


### PR DESCRIPTION
## Summary
Adds host temperature monitoring to the System Debug page, graphed alongside CPU and Memory. Displayed in **°F**.

Temperature rides in the existing once-per-second `/api/system/stats` sample rather than adding a new endpoint, matching how CPU/memory are already handled.

## Changes
- **Server** (`SupportService.cs`, `Models.cs`): nullable `TempCelsius` added to the `SystemStats` record. New `GetCpuTempCelsius()` reads Linux thermal sysfs first (`/sys/class/thermal/thermal_zone*`, preferring a `cpu`/`x86_pkg`/`soc` zone, else the hottest), then best-effort shell fallback (`vcgencmd` on Pi, `osx-cpu-temp` on macOS) via the existing `RunCommand` helper. Returns `null` when no sensor is available.
- **Client** (`SystemDebugDialog.tsx`): `ResourceGraph` gained optional `max`/`unit` props (default `100`/`%`), so the Temp graph scales on a 0–212 °F domain while CPU/Memory are unchanged. Celsius→Fahrenheit conversion happens in the display layer (the wire format stays sensor-native Celsius). The Temp graph only renders when a reading exists; otherwise the readout shows `N/A`.

## Testing
- `dotnet build` + `dotnet test` — added `GetSystemStats_ReturnsStats_WithPlausibleTemperature`; all pass.
- Client `npm run lint` clean, `npm run build` (typecheck) passes.
- Verified the graceful macOS fallback: with no sensor tool installed, `GetCpuTempCelsius()` returns null and the UI shows `N/A` with the graph hidden — no crash.
- The Linux/Pi path (graph appears, tracks °F, rises under load) requires target hardware to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)