### PR TITLE
Add remote transcription backend (offload to WhisperServer)

### DIFF
--- a/client/src/components/SettingsManager.tsx
+++ b/client/src/components/SettingsManager.tsx
@@ -17,6 +17,13 @@ interface StorageInfo {
     diskTotalBytes: number;
 }
 
+interface RemoteModel {
+    id: string;
+    label: string;
+}
+
+type RemoteHealth = { status: 'idle' | 'testing' | 'ok' | 'error'; message: string };
+
 interface Props {
     open: boolean;
     onClose: () => void;
@@ -81,6 +88,11 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
     const [storage, setStorage] = useState<StorageInfo | null>(null);
     const [confirmDelete, setConfirmDelete] = useState(false);
     const [deleting, setDeleting] = useState(false);
+    const [remoteModels, setRemoteModels] = useState<RemoteModel[]>([]);
+    const [remoteHealth, setRemoteHealth] = useState<RemoteHealth>({ status: 'idle', message: '' });
+
+    const backend = settings['TranscriptionBackend'] || 'local';
+    const remoteUrl = settings['RemoteTranscriptionUrl'] || '';
 
     useEffect(() => {
         if (open) {
@@ -97,6 +109,42 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
         const id = setInterval(fetchSettings, 3000);
         return () => clearInterval(id);
     }, [open, modelDownloading]);
+
+    // When the remote backend is selected, query the server for the models it has
+    // installed to populate the dropdown. Debounced so typing the URL doesn't spam it.
+    useEffect(() => {
+        if (!open || backend !== 'remote' || !remoteUrl) return;
+        let cancelled = false;
+        const run = async () => {
+            try {
+                const res = await apiFetch(`/api/transcription/remote/models?url=${encodeURIComponent(remoteUrl)}`);
+                if (cancelled) return;
+                setRemoteModels(res.ok ? await res.json() : []);
+            } catch {
+                if (!cancelled) setRemoteModels([]);
+            }
+        };
+        const id = setTimeout(run, 500);
+        return () => { cancelled = true; clearTimeout(id); };
+    }, [open, backend, remoteUrl]);
+
+    const testRemoteServer = async () => {
+        if (!remoteUrl) return;
+        setRemoteHealth({ status: 'testing', message: 'Testing…' });
+        try {
+            const res = await apiFetch(`/api/transcription/remote/health?url=${encodeURIComponent(remoteUrl)}`);
+            const data = await res.json();
+            if (res.ok && data.ok) {
+                const h = data.health || {};
+                const accel = h.acceleration ? ` (${h.acceleration})` : '';
+                setRemoteHealth({ status: 'ok', message: `Connected${accel}` });
+            } else {
+                setRemoteHealth({ status: 'error', message: data.error || 'Server unreachable' });
+            }
+        } catch {
+            setRemoteHealth({ status: 'error', message: 'Server unreachable' });
+        }
+    };
 
     const fetchStorage = async () => {
         try {
@@ -224,42 +272,119 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
                             {settings['EnableTranscription'] === 'true' && (
                                 <>
                                     <Row
-                                        label="Model"
-                                        description={(() => {
-                                            const s = parseModelStatus(settings['TranscriptionModelStatus']);
-                                            return s.text
-                                                ? `Larger models are more accurate but slower on a Pi. Status: ${s.text}`
-                                                : 'Larger models are more accurate but slower on a Pi. Downloaded automatically when changed.';
-                                        })()}
+                                        label="Backend"
+                                        description="Transcribe on this device, or offload to a remote OpenScanner.WhisperServer."
                                         control={
                                             <Select
                                                 size="small"
                                                 variant="outlined"
-                                                style={{ minWidth: 260 }}
-                                                value={settings['TranscriptionModel'] || 'large-v3-turbo-q5_0'}
-                                                onChange={(e) => handleValueChange('TranscriptionModel', e.target.value)}
+                                                style={{ minWidth: 160 }}
+                                                value={backend}
+                                                onChange={(e) => handleValueChange('TranscriptionBackend', e.target.value)}
                                             >
-                                                {TRANSCRIPTION_MODELS.map((m) => (
-                                                    <MenuItem key={m.value} value={m.value}>{m.label}</MenuItem>
-                                                ))}
+                                                <MenuItem value="local">Local (this device)</MenuItem>
+                                                <MenuItem value="remote">Remote server</MenuItem>
                                             </Select>
                                         }
                                     />
-                                    <Row
-                                        label="Transcription Threads"
-                                        description={`Number of recordings transcribed at once. With a large model, 1 is recommended (each run already uses all cores). CPU cores: ${systemInfo.CpuCores || 'Unknown'}`}
-                                        control={
-                                            <TextField
-                                                type="number"
-                                                size="small"
-                                                variant="outlined"
-                                                style={{ width: '80px', minWidth: '80px' }}
-                                                value={settings['TranscriptionThreads'] || ''}
-                                                inputProps={{ min: 1, max: 32 }}
-                                                onChange={(e) => handleValueChange('TranscriptionThreads', e.target.value)}
+                                    {backend === 'local' ? (
+                                        <>
+                                            <Row
+                                                label="Model"
+                                                description={(() => {
+                                                    const s = parseModelStatus(settings['TranscriptionModelStatus']);
+                                                    return s.text
+                                                        ? `Larger models are more accurate but slower on a Pi. Status: ${s.text}`
+                                                        : 'Larger models are more accurate but slower on a Pi. Downloaded automatically when changed.';
+                                                })()}
+                                                control={
+                                                    <Select
+                                                        size="small"
+                                                        variant="outlined"
+                                                        style={{ minWidth: 260 }}
+                                                        value={settings['TranscriptionModel'] || 'large-v3-turbo-q5_0'}
+                                                        onChange={(e) => handleValueChange('TranscriptionModel', e.target.value)}
+                                                    >
+                                                        {TRANSCRIPTION_MODELS.map((m) => (
+                                                            <MenuItem key={m.value} value={m.value}>{m.label}</MenuItem>
+                                                        ))}
+                                                    </Select>
+                                                }
                                             />
-                                        }
-                                    />
+                                            <Row
+                                                label="Transcription Threads"
+                                                description={`Number of recordings transcribed at once. With a large model, 1 is recommended (each run already uses all cores). CPU cores: ${systemInfo.CpuCores || 'Unknown'}`}
+                                                control={
+                                                    <TextField
+                                                        type="number"
+                                                        size="small"
+                                                        variant="outlined"
+                                                        style={{ width: '80px', minWidth: '80px' }}
+                                                        value={settings['TranscriptionThreads'] || ''}
+                                                        inputProps={{ min: 1, max: 32 }}
+                                                        onChange={(e) => handleValueChange('TranscriptionThreads', e.target.value)}
+                                                    />
+                                                }
+                                            />
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Row
+                                                label="Server URL"
+                                                description={
+                                                    remoteHealth.status === 'ok' ? `✓ ${remoteHealth.message}`
+                                                    : remoteHealth.status === 'error' ? `✗ ${remoteHealth.message}`
+                                                    : 'Address of the WhisperServer, e.g. http://192.168.1.100:8090'
+                                                }
+                                                control={
+                                                    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                                                        <TextField
+                                                            size="small"
+                                                            variant="outlined"
+                                                            placeholder="http://192.168.1.100:8090"
+                                                            style={{ width: '240px' }}
+                                                            value={remoteUrl}
+                                                            onChange={(e) => handleValueChange('RemoteTranscriptionUrl', e.target.value)}
+                                                        />
+                                                        <Button
+                                                            size="small"
+                                                            variant="outlined"
+                                                            onClick={testRemoteServer}
+                                                            disabled={!remoteUrl || remoteHealth.status === 'testing'}
+                                                        >
+                                                            {remoteHealth.status === 'testing' ? '…' : 'Test'}
+                                                        </Button>
+                                                    </Box>
+                                                }
+                                            />
+                                            <Row
+                                                label="Model"
+                                                description={
+                                                    remoteModels.length > 0
+                                                        ? 'Models installed on the remote server.'
+                                                        : 'Enter a reachable server URL to load its available models.'
+                                                }
+                                                control={
+                                                    <Select
+                                                        size="small"
+                                                        variant="outlined"
+                                                        displayEmpty
+                                                        style={{ minWidth: 260 }}
+                                                        value={settings['RemoteTranscriptionModel'] || ''}
+                                                        onChange={(e) => handleValueChange('RemoteTranscriptionModel', e.target.value)}
+                                                        disabled={remoteModels.length === 0}
+                                                    >
+                                                        <MenuItem value="" disabled>
+                                                            {remoteModels.length === 0 ? 'No models loaded' : 'Select a model'}
+                                                        </MenuItem>
+                                                        {remoteModels.map((m) => (
+                                                            <MenuItem key={m.id} value={m.id}>{m.label}</MenuItem>
+                                                        ))}
+                                                    </Select>
+                                                }
+                                            />
+                                        </>
+                                    )}
                                 </>
                             )}
                         </Section>

--- a/server/OpenScanner.Server/Controllers/TranscriptionController.cs
+++ b/server/OpenScanner.Server/Controllers/TranscriptionController.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Mvc;
 using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Services;
 
 namespace OpenScanner.Server.Controllers;
 
 /// <summary>
-/// Controls the on-demand transcription backfill job.
+/// Controls the on-demand transcription backfill job and proxies queries to a
+/// remote OpenScanner.WhisperServer (models list / health) for the settings UI.
 /// </summary>
 [ApiController]
 [Route("api/transcription")]
@@ -12,10 +14,12 @@ namespace OpenScanner.Server.Controllers;
 public class TranscriptionController : ControllerBase
 {
     private readonly IBackfillService _backfill;
+    private readonly RemoteTranscriptionClient _remoteClient;
 
-    public TranscriptionController(IBackfillService backfill)
+    public TranscriptionController(IBackfillService backfill, RemoteTranscriptionClient remoteClient)
     {
         _backfill = backfill;
+        _remoteClient = remoteClient;
     }
 
     /// <summary>
@@ -48,5 +52,47 @@ public class TranscriptionController : ControllerBase
     {
         _backfill.Stop();
         return Ok(_backfill.GetStatus());
+    }
+
+    /// <summary>
+    /// Lists the models installed on a remote WhisperServer, used to populate the
+    /// remote-model dropdown. Proxied server-side so the browser stays same-origin.
+    /// </summary>
+    [HttpGet("remote/models")]
+    [ProducesResponseType(typeof(IReadOnlyList<RemoteModel>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetRemoteModels([FromQuery] string url, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            return BadRequest(new { error = "A valid absolute server URL is required." });
+        }
+        try
+        {
+            var models = await _remoteClient.GetModelsAsync(url, ct);
+            return Ok(models);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(StatusCodes.Status502BadGateway, new { error = $"Could not reach server: {ex.Message}" });
+        }
+    }
+
+    /// <summary>
+    /// Probes a remote WhisperServer's /health endpoint for the settings "Test" button.
+    /// </summary>
+    [HttpGet("remote/health")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetRemoteHealth([FromQuery] string url, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(url) || !Uri.TryCreate(url, UriKind.Absolute, out _))
+        {
+            return BadRequest(new { error = "A valid absolute server URL is required." });
+        }
+        var health = await _remoteClient.HealthAsync(url, ct);
+        if (health == null)
+        {
+            return StatusCode(StatusCodes.Status502BadGateway, new { ok = false, error = "Could not reach server." });
+        }
+        return Ok(new { ok = true, health = health.Value });
     }
 }

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -42,6 +42,7 @@ builder.Services.AddTransient<OpenScanner.Server.Decoders.NFM>();
 builder.Services.AddTransient<OpenScanner.Server.Decoders.AM>();
 builder.Services.AddTransient<OpenScanner.Server.Decoders.WFM>();
 builder.Services.AddSingleton<IDecoderFactory, OpenScanner.Server.Decoders.DecoderFactory>();
+builder.Services.AddSingleton<RemoteTranscriptionClient>();
 builder.Services.AddSingleton<ITranscriptionService, WhisperTranscriptionService>();
 builder.Services.AddSingleton<IRecordingService, RecordingService>();
 builder.Services.AddSingleton<IChannelService, ChannelService>();

--- a/server/OpenScanner.Server/Services/RemoteTranscriptionClient.cs
+++ b/server/OpenScanner.Server/Services/RemoteTranscriptionClient.cs
@@ -1,0 +1,134 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using OpenScanner.Server.Interfaces;
+
+namespace OpenScanner.Server.Services;
+
+/// <summary>A model advertised by a remote OpenScanner.WhisperServer.</summary>
+public record RemoteModel(string Id, string Label);
+
+/// <summary>
+/// Talks to a remote <c>OpenScanner.WhisperServer</c> over HTTP so transcription can be
+/// offloaded from the Pi. The base URL is read from the <c>RemoteTranscriptionUrl</c> setting
+/// for the live transcribe path; the model/health probes take an explicit URL so the settings
+/// UI can test a server before the value is saved.
+/// </summary>
+public class RemoteTranscriptionClient
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IDatabase _db;
+    private readonly IConfiguration _config;
+    private readonly ILogger<RemoteTranscriptionClient> _logger;
+
+    public RemoteTranscriptionClient(IHttpClientFactory httpClientFactory, IDatabase db, IConfiguration config, ILogger<RemoteTranscriptionClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _db = db;
+        _config = config;
+        _logger = logger;
+    }
+
+    private int TimeoutSeconds =>
+        int.TryParse(_config["Transcription:RemoteTimeoutSeconds"], out var t) && t > 0 ? t : 120;
+
+    private static string Normalize(string url) => url.TrimEnd('/');
+
+    /// <summary>The configured remote server base URL, or null when not set.</summary>
+    public async Task<string?> GetConfiguredUrlAsync()
+    {
+        var url = await _db.GetSettingAsync("RemoteTranscriptionUrl");
+        return string.IsNullOrWhiteSpace(url) ? null : Normalize(url);
+    }
+
+    /// <summary>
+    /// Send a (16 kHz mono) WAV to the configured remote server and return the transcript.
+    /// Returns null on any failure or empty/blank result so the caller can fall through.
+    /// </summary>
+    public async Task<string?> TranscribeAsync(string wavPath, string model, string prompt, CancellationToken ct = default)
+    {
+        var baseUrl = await GetConfiguredUrlAsync();
+        if (baseUrl == null)
+        {
+            _logger.LogError("Remote transcription selected but RemoteTranscriptionUrl is not set.");
+            return null;
+        }
+
+        try
+        {
+            using var content = new MultipartFormDataContent();
+            await using var fs = File.OpenRead(wavPath);
+            var fileContent = new StreamContent(fs);
+            fileContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("audio/wav");
+            content.Add(fileContent, "file", Path.GetFileName(wavPath));
+            if (!string.IsNullOrWhiteSpace(model)) content.Add(new StringContent(model), "model");
+            if (!string.IsNullOrEmpty(prompt)) content.Add(new StringContent(prompt), "prompt");
+
+            var client = _httpClientFactory.CreateClient();
+            client.Timeout = TimeSpan.FromSeconds(TimeoutSeconds);
+
+            using var resp = await client.PostAsync($"{baseUrl}/transcribe", content, ct);
+            if (!resp.IsSuccessStatusCode)
+            {
+                var body = await resp.Content.ReadAsStringAsync(ct);
+                _logger.LogError("Remote transcription failed (HTTP {Code}): {Body}", (int)resp.StatusCode, body);
+                return null;
+            }
+
+            var json = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            var text = json.TryGetProperty("text", out var t) ? t.GetString()?.Trim() : null;
+            if (string.IsNullOrEmpty(text)) return null;
+            if (text.StartsWith('[') && text.EndsWith(']')) return null;
+            return text;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error calling remote transcription server at {Url}", baseUrl);
+            return null;
+        }
+    }
+
+    /// <summary>Query the models installed on a remote server (used to populate the UI dropdown).</summary>
+    public async Task<IReadOnlyList<RemoteModel>> GetModelsAsync(string url, CancellationToken ct = default)
+    {
+        var baseUrl = Normalize(url);
+        var client = _httpClientFactory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(15);
+
+        using var resp = await client.GetAsync($"{baseUrl}/models", ct);
+        resp.EnsureSuccessStatusCode();
+        var json = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+
+        var models = new List<RemoteModel>();
+        if (json.TryGetProperty("models", out var arr) && arr.ValueKind == JsonValueKind.Array)
+        {
+            foreach (var m in arr.EnumerateArray())
+            {
+                var id = m.TryGetProperty("id", out var idProp) ? idProp.GetString() : null;
+                if (string.IsNullOrWhiteSpace(id)) continue;
+                var label = m.TryGetProperty("label", out var lblProp) ? lblProp.GetString() : null;
+                models.Add(new RemoteModel(id!, string.IsNullOrWhiteSpace(label) ? id! : label!));
+            }
+        }
+        return models;
+    }
+
+    /// <summary>Probe a remote server's /health endpoint. Returns the raw JSON for the "Test" button.</summary>
+    public async Task<JsonElement?> HealthAsync(string url, CancellationToken ct = default)
+    {
+        var baseUrl = Normalize(url);
+        var client = _httpClientFactory.CreateClient();
+        client.Timeout = TimeSpan.FromSeconds(15);
+        try
+        {
+            using var resp = await client.GetAsync($"{baseUrl}/health", ct);
+            var json = await resp.Content.ReadFromJsonAsync<JsonElement>(cancellationToken: ct);
+            return json;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Health probe failed for {Url}", baseUrl);
+            return null;
+        }
+    }
+}

--- a/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
+++ b/server/OpenScanner.Server/Services/WhisperTranscriptionService.cs
@@ -16,6 +16,7 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
     private readonly IDatabase _db;
     private readonly ILogger<WhisperTranscriptionService> _logger;
     private readonly IConfiguration _config;
+    private readonly RemoteTranscriptionClient _remoteClient;
 
     private readonly System.Threading.Channels.Channel<(CallLog Log, string AudioPath)> _queueChannel = System.Threading.Channels.Channel.CreateUnbounded<(CallLog Log, string AudioPath)>();
     private readonly List<TranscriptionWorker> _workers = new();
@@ -41,11 +42,12 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         }
     }
 
-    public WhisperTranscriptionService(IDatabase db, ILogger<WhisperTranscriptionService> logger, IConfiguration config)
+    public WhisperTranscriptionService(IDatabase db, ILogger<WhisperTranscriptionService> logger, IConfiguration config, RemoteTranscriptionClient remoteClient)
     {
         _db = db;
         _logger = logger;
         _config = config;
+        _remoteClient = remoteClient;
 
         // Initialize workers based on current setting
         var targetCount = GetTargetThreadCount();
@@ -56,7 +58,24 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
 
         // Proactively ensure the configured model is present (and reflect its
         // status) so the first transmission isn't blocked on a large download.
-        PrepareModel(GetConfiguredModel());
+        // Only meaningful for the local backend — remote uses the server's models.
+        if (GetBackend() == "local")
+        {
+            PrepareModel(GetConfiguredModel());
+        }
+    }
+
+    // Transcription backend: "local" (whisper-cli on this machine) or "remote"
+    // (offloaded to an OpenScanner.WhisperServer over HTTP). Stored in settings.
+    private string GetBackend()
+    {
+        try
+        {
+            var backend = _db.GetSettingAsync("TranscriptionBackend").GetAwaiter().GetResult();
+            if (string.Equals(backend, "remote", StringComparison.OrdinalIgnoreCase)) return "remote";
+        }
+        catch { /* fall through to local */ }
+        return "local";
     }
 
     private string GetConfiguredModel()
@@ -391,44 +410,11 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
         }
     }
 
-    public string? TranscribeAudio(string audioPath)
+    // Resample an input recording (raw 48k s16le or an encoded file) to 16 kHz mono
+    // WAV with the radio voice-filter chain. Shared by the local and remote backends.
+    // Returns true when the output file was produced.
+    private bool ConvertTo16kWav(string audioPath, string tempWavPath)
     {
-        // Check setting
-        var enabled = _db.GetSettingAsync("EnableTranscription").GetAwaiter().GetResult();
-        if (enabled != "true") return null;
-
-        // Model is managed from the web-app settings (DB), falling back to
-        // appsettings then a safe default.
-        var modelName = _db.GetSettingAsync("TranscriptionModel").GetAwaiter().GetResult();
-        if (string.IsNullOrWhiteSpace(modelName)) modelName = _config["Transcription:Model"];
-        if (string.IsNullOrWhiteSpace(modelName)) modelName = "small.en";
-        if (!IsValidModelName(modelName))
-        {
-            _logger.LogError("Invalid transcription model name '{Model}'; refusing to use it.", SafeForLog(modelName));
-            return null;
-        }
-
-        // Temp file for resampling to 16k
-        var tempWavPath = audioPath + ".16k.wav";
-        var whisperRoot = FindWhisperRoot();
-        var whisperBin = Path.Combine(whisperRoot, "build/bin/whisper-cli");
-        var modelPath = Path.Combine(whisperRoot, $"models/ggml-{modelName}.bin");
-
-        if (!File.Exists(whisperBin))
-        {
-            _logger.LogError($"Whisper binary not found at {whisperBin}. Search root was: {whisperRoot}");
-            return null;
-        }
-
-        // Download the selected model on demand if it isn't present yet. Blocks
-        // this worker until ready (every queued clip needs the same model, so
-        // there is nothing else to do meanwhile).
-        if (!EnsureModelAvailable(whisperRoot, modelName))
-        {
-            _logger.LogError("Transcription model '{Model}' is not available and could not be downloaded.", SafeForLog(modelName));
-            return null;
-        }
-
         var convertStart = new ProcessStartInfo(PlatformTools.Ffmpeg)
         {
             RedirectStandardOutput = true,
@@ -473,7 +459,71 @@ public class WhisperTranscriptionService : ITranscriptionService, IDisposable
             }
         }
 
-        if (!File.Exists(tempWavPath)) return null;
+        return File.Exists(tempWavPath);
+    }
+
+    public string? TranscribeAudio(string audioPath)
+    {
+        // Check setting
+        var enabled = _db.GetSettingAsync("EnableTranscription").GetAwaiter().GetResult();
+        if (enabled != "true") return null;
+
+        var backend = GetBackend();
+
+        // Shared preprocessing target: resample to 16 kHz mono with the radio
+        // voice-filter chain (used by both the local and remote backends).
+        var tempWavPath = audioPath + ".16k.wav";
+
+        // Remote backend: offload to an OpenScanner.WhisperServer over HTTP. We still
+        // do the radio-tuned resample locally so the server just transcribes.
+        if (backend == "remote")
+        {
+            try
+            {
+                if (!ConvertTo16kWav(audioPath, tempWavPath)) return null;
+                var remoteModel = _db.GetSettingAsync("RemoteTranscriptionModel").GetAwaiter().GetResult() ?? string.Empty;
+                var remotePrompt = _config["Transcription:Prompt"];
+                if (string.IsNullOrWhiteSpace(remotePrompt)) remotePrompt = DefaultPrompt;
+                return _remoteClient.TranscribeAsync(tempWavPath, remoteModel, remotePrompt).GetAwaiter().GetResult();
+            }
+            finally
+            {
+                if (File.Exists(tempWavPath)) File.Delete(tempWavPath);
+            }
+        }
+
+        // ---- Local backend (whisper-cli on this machine) ----
+        // Model is managed from the web-app settings (DB), falling back to
+        // appsettings then a safe default.
+        var modelName = _db.GetSettingAsync("TranscriptionModel").GetAwaiter().GetResult();
+        if (string.IsNullOrWhiteSpace(modelName)) modelName = _config["Transcription:Model"];
+        if (string.IsNullOrWhiteSpace(modelName)) modelName = "small.en";
+        if (!IsValidModelName(modelName))
+        {
+            _logger.LogError("Invalid transcription model name '{Model}'; refusing to use it.", SafeForLog(modelName));
+            return null;
+        }
+
+        var whisperRoot = FindWhisperRoot();
+        var whisperBin = Path.Combine(whisperRoot, "build/bin/whisper-cli");
+        var modelPath = Path.Combine(whisperRoot, $"models/ggml-{modelName}.bin");
+
+        if (!File.Exists(whisperBin))
+        {
+            _logger.LogError($"Whisper binary not found at {whisperBin}. Search root was: {whisperRoot}");
+            return null;
+        }
+
+        // Download the selected model on demand if it isn't present yet. Blocks
+        // this worker until ready (every queued clip needs the same model, so
+        // there is nothing else to do meanwhile).
+        if (!EnsureModelAvailable(whisperRoot, modelName))
+        {
+            _logger.LogError("Transcription model '{Model}' is not available and could not be downloaded.", SafeForLog(modelName));
+            return null;
+        }
+
+        if (!ConvertTo16kWav(audioPath, tempWavPath)) return null;
 
         // 2. Run Whisper with radio context + accuracy-oriented decode settings.
         var prompt = _config["Transcription:Prompt"];

--- a/server/OpenScanner.Server/appsettings.json
+++ b/server/OpenScanner.Server/appsettings.json
@@ -14,6 +14,7 @@
     "BeamSize": 5,
     "WhisperThreads": 0,
     "TimeoutSeconds": 600,
+    "RemoteTimeoutSeconds": 120,
     "AudioFilters": "highpass=f=200,lowpass=f=3500,afftdn,dynaudnorm=f=200:g=5,alimiter=limit=0.95",
     "Prompt": "",
     "ExtraArgs": ""

--- a/server/OpenScanner.Tests/Services/WhisperTranscriptionServiceTests.cs
+++ b/server/OpenScanner.Tests/Services/WhisperTranscriptionServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -18,6 +19,13 @@ public class WhisperTranscriptionServiceTests
     private readonly Mock<ILogger<WhisperTranscriptionService>> _loggerMock = new();
     private readonly Mock<IConfiguration> _configMock = new();
 
+    private RemoteTranscriptionClient CreateRemoteClient() =>
+        new RemoteTranscriptionClient(
+            Mock.Of<IHttpClientFactory>(),
+            _dbMock.Object,
+            _configMock.Object,
+            Mock.Of<ILogger<RemoteTranscriptionClient>>());
+
     [Fact]
     public async Task QueueTranscription_ProcessesJobAndFiresCompletedEvent()
     {
@@ -25,7 +33,7 @@ public class WhisperTranscriptionServiceTests
         _dbMock.Setup(db => db.GetSettingAsync("TranscriptionThreads")).ReturnsAsync("2");
         _dbMock.Setup(db => db.GetSettingAsync("EnableTranscription")).ReturnsAsync("false");
 
-        using var service = new WhisperTranscriptionService(_dbMock.Object, _loggerMock.Object, _configMock.Object);
+        using var service = new WhisperTranscriptionService(_dbMock.Object, _loggerMock.Object, _configMock.Object, CreateRemoteClient());
 
         var log = new CallLog
         {
@@ -88,5 +96,21 @@ public class WhisperTranscriptionServiceTests
         var args = WhisperTranscriptionService.BuildWhisperArgs("/m.bin", "/a.wav", "p", 5, 4, "   ");
         // Blank ExtraArgs must not append anything after the prompt.
         Assert.EndsWith("--prompt \"p\"", args);
+    }
+
+    [Fact]
+    public async Task RemoteClient_GetConfiguredUrl_TrimsTrailingSlash()
+    {
+        _dbMock.Setup(db => db.GetSettingAsync("RemoteTranscriptionUrl")).ReturnsAsync("http://host:8090/");
+        var client = CreateRemoteClient();
+        Assert.Equal("http://host:8090", await client.GetConfiguredUrlAsync());
+    }
+
+    [Fact]
+    public async Task RemoteClient_GetConfiguredUrl_NullWhenUnset()
+    {
+        _dbMock.Setup(db => db.GetSettingAsync("RemoteTranscriptionUrl")).ReturnsAsync((string?)null);
+        var client = CreateRemoteClient();
+        Assert.Null(await client.GetConfiguredUrlAsync());
     }
 }


### PR DESCRIPTION
## Summary
Adds a **Local / Remote** transcription setting. When *Remote* is selected, the user enters an [OpenScanner.WhisperServer](https://github.com/briannippert/OpenScanner.WhisperServer) URL and picks a model **queried live from that server**; recordings are resampled locally (16 kHz mono with the existing radio voice-filter chain) and POSTed to the remote server, which returns the text. Local behavior is unchanged.

## Changes
- **`RemoteTranscriptionClient`** — HTTP client for the server's `/transcribe`, `/models`, and `/health` endpoints (configurable timeout, trailing-slash normalization, blank/`[...]` filtering).
- **`WhisperTranscriptionService`** — branches `TranscribeAudio` on the new `TranscriptionBackend` setting. The ffmpeg 16k-wav conversion is extracted into a shared helper used by both backends; local model download/bootstrap is skipped when remote.
- **`TranscriptionController`** — server-side proxy for remote `/models` and `/health` (keeps the browser same-origin; validates the URL, 400/502 on bad/unreachable).
- **`SettingsManager.tsx`** — Backend selector (Local/Remote); when Remote: server-URL field, a **Test** button (health probe), and a model dropdown populated from the server (debounced query).
- New settings keys (via the existing generic settings table): `TranscriptionBackend`, `RemoteTranscriptionUrl`, `RemoteTranscriptionModel`; `Transcription:RemoteTimeoutSeconds` config.
- Unit tests for the remote-client URL handling.

## Verification
- `dotnet test` — 184 passed; `npm run lint` + `tsc --noEmit` clean.
- End-to-end against a live WhisperServer: settings persist, `/remote/health` + `/remote/models` proxies return live data, and a backfill of a real clip ran the full path (ffmpeg → remote POST → text `"And so, my fellow Americans..."` persisted to the DB in ~2s). Blank clips correctly store no text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)