### PR TITLE
Fix self-update file ownership + add manual update check

### DIFF
--- a/client/src/components/AppHeader.tsx
+++ b/client/src/components/AppHeader.tsx
@@ -54,8 +54,12 @@ const AppHeader: React.FC<Props> = ({
   const hasFix = gps?.time && gps.fix >= 2;
 
   // The toolbar actions, shared between the desktop icon row and the mobile menu.
+  // Software Update is always listed: it's the only way into the update dialog,
+  // and gating it on updateAvailable meant you couldn't check on demand until the
+  // server's 30-minute poll had already found something. The UPDATE chip below
+  // stays gated — that's the "there's something waiting" nudge.
   const actions = [
-    ...(updateAvailable ? [{ label: 'Software Update', icon: <SystemUpdateIcon />, onClick: onOpenUpdate }] : []),
+    { label: 'Software Update', icon: <SystemUpdateIcon />, onClick: onOpenUpdate },
     { label: 'Fire Tone Outs', icon: <NotificationsActiveIcon />, onClick: onOpenFireTones },
     { label: 'Radio Aliases', icon: <BadgeIcon />, onClick: onOpenAliases },
     { label: 'Settings', icon: <SettingsIcon />, onClick: onOpenSettings },

--- a/client/src/components/UpdateManager.test.tsx
+++ b/client/src/components/UpdateManager.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import UpdateManager from './UpdateManager';
+import type { UpdateStatus } from '../types';
+
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const status = (over: Partial<UpdateStatus> = {}): UpdateStatus => ({
+    state: 'idle',
+    currentVersion: '0.1.70',
+    currentCommit: 'abcdef1234567890',
+    commitsBehind: 0,
+    updateAvailable: false,
+    log: [],
+    lastCheckedUtc: new Date(Date.now() - 25 * 60_000).toISOString(),
+    ...over,
+});
+
+const jsonOnce = (body: unknown) =>
+    fetchMock.mockResolvedValueOnce({ ok: true, json: async () => body });
+
+const renderDialog = (props: Partial<React.ComponentProps<typeof UpdateManager>> = {}) =>
+    render(
+        <UpdateManager
+            open
+            onClose={vi.fn()}
+            log={[]}
+            state="idle"
+            onSeed={vi.fn()}
+            {...props}
+        />,
+    );
+
+describe('UpdateManager — manual check', () => {
+    beforeEach(() => fetchMock.mockReset());
+
+    it('shows when the last check happened, so the 30-minute poll is visible', async () => {
+        jsonOnce(status());
+        renderDialog();
+        expect(await screen.findByText('Checked 25 minutes ago')).toBeDefined();
+    });
+
+    it('posts to /api/update/check and surfaces a newly-found release', async () => {
+        jsonOnce(status()); // initial GET /api/update/status
+        renderDialog();
+        await screen.findByText(/Up to date/);
+
+        // The forced check finds v0.2.0.
+        jsonOnce(status({
+            state: 'available',
+            updateAvailable: true,
+            latestTag: 'v0.2.0',
+            commitsBehind: 4,
+            lastCheckedUtc: new Date().toISOString(),
+        }));
+
+        fireEvent.click(screen.getByRole('button', { name: /Check now/ }));
+
+        await waitFor(() => {
+            const call = fetchMock.mock.calls.find(c => String(c[0]).includes('/api/update/check'));
+            expect(call).toBeDefined();
+            expect(call?.[1]?.method).toBe('POST');
+        });
+
+        // The primary action flips from "Up to date" to offering the new release.
+        expect(await screen.findByRole('button', { name: /Update to v0\.2\.0/ })).toBeDefined();
+        expect(screen.getByText(/latest v0\.2\.0 \(4 behind\)/)).toBeDefined();
+        expect(screen.getByText('Checked just now')).toBeDefined();
+    });
+
+    it('surfaces a failed check and re-enables the button', async () => {
+        jsonOnce(status());
+        renderDialog();
+        await screen.findByText(/Up to date/);
+
+        jsonOnce(status({ error: 'Update check failed: GitHub returned 503' }));
+        fireEvent.click(screen.getByRole('button', { name: /Check now/ }));
+
+        expect(await screen.findByText(/GitHub returned 503/)).toBeDefined();
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: /Check now/ }).hasAttribute('disabled')).toBe(false),
+        );
+    });
+
+    it('does not leave the button stuck spinning if the request throws', async () => {
+        jsonOnce(status());
+        renderDialog();
+        await screen.findByText(/Up to date/);
+
+        fetchMock.mockRejectedValueOnce(new Error('network down'));
+        fireEvent.click(screen.getByRole('button', { name: /Check now/ }));
+
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: /Check now/ }).hasAttribute('disabled')).toBe(false),
+        );
+    });
+
+    it('is disabled mid-update so a check cannot race the build', async () => {
+        jsonOnce(status());
+        renderDialog({ state: 'updating' });
+        await waitFor(() =>
+            expect(screen.getByRole('button', { name: /Check now/ }).hasAttribute('disabled')).toBe(true),
+        );
+    });
+});

--- a/client/src/components/UpdateManager.tsx
+++ b/client/src/components/UpdateManager.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Button, Typography, Alert, CircularProgress, Chip, Link } from '@mui/material';
 import SystemUpdateIcon from '@mui/icons-material/SystemUpdate';
 import CheckCircleIcon from '@mui/icons-material/CheckCircle';
+import RefreshIcon from '@mui/icons-material/Refresh';
 import FormDialog from './common/FormDialog';
 import { apiFetch, apiJson } from './common/apiBase';
 import type { UpdateStatus, UpdateState } from '../types';
@@ -21,9 +22,25 @@ const MONO = '"Roboto Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
 
 const shortCommit = (c?: string) => (c ? c.slice(0, 8) : '');
 
+/** "3 minutes ago" for the last-checked caption. The server only checks every 30
+ *  minutes, so minute precision is plenty. */
+const sinceText = (iso?: string): string => {
+  if (!iso) return 'never';
+  const secs = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+  if (!Number.isFinite(secs) || secs < 0) return 'just now';
+  if (secs < 60) return 'just now';
+  const mins = Math.floor(secs / 60);
+  if (mins < 60) return `${mins} minute${mins === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} ago`;
+};
+
 const UpdateManager: React.FC<Props> = ({ open, onClose, log, state, onSeed }) => {
   const [status, setStatus] = useState<UpdateStatus | null>(null);
   const [restarted, setRestarted] = useState(false);
+  const [checking, setChecking] = useState(false);
   const logBoxRef = useRef<HTMLDivElement>(null);
 
   // Seed from the authoritative snapshot whenever the dialog opens.
@@ -68,9 +85,23 @@ const UpdateManager: React.FC<Props> = ({ open, onClose, log, state, onSeed }) =
     await apiFetch('/api/update/start', { method: 'POST' });
   }, [onSeed]);
 
+  // Force a check now rather than waiting out the server's 30-minute poll. The
+  // response is the refreshed snapshot, so no follow-up GET is needed; a failed
+  // check comes back with `error` set and surfaces in the alert below.
+  const check = useCallback(async () => {
+    setChecking(true);
+    try {
+      const s = await apiJson<UpdateStatus>('/api/update/check', { method: 'POST' });
+      if (s) setStatus(s);
+    } finally {
+      setChecking(false);
+    }
+  }, []);
+
   const failed = state === 'failed';
   const updating = state === 'updating';
   const available = status?.updateAvailable ?? false;
+  const busyChecking = checking || state === 'checking';
 
   const actionButton = (() => {
     if (state === 'success') {
@@ -102,6 +133,13 @@ const UpdateManager: React.FC<Props> = ({ open, onClose, log, state, onSeed }) =
       actions={
         <>
           <Button onClick={onClose} color="inherit" disabled={updating}>Close</Button>
+          <Button
+            onClick={check}
+            disabled={updating || busyChecking || state === 'success'}
+            startIcon={busyChecking ? <CircularProgress size={16} /> : <RefreshIcon />}
+          >
+            {busyChecking ? 'Checking…' : 'Check now'}
+          </Button>
           {actionButton}
         </>
       }
@@ -124,8 +162,11 @@ const UpdateManager: React.FC<Props> = ({ open, onClose, log, state, onSeed }) =
             />
           </>
         )}
+        <Typography variant="caption" color="text.secondary" sx={{ ml: 'auto' }}>
+          {busyChecking ? 'Checking…' : `Checked ${sinceText(status?.lastCheckedUtc)}`}
+        </Typography>
         {status?.releaseUrl && (
-          <Link href={status.releaseUrl} target="_blank" rel="noopener" variant="caption" sx={{ ml: 'auto' }}>
+          <Link href={status.releaseUrl} target="_blank" rel="noopener" variant="caption">
             Release notes
           </Link>
         )}
@@ -146,7 +187,16 @@ const UpdateManager: React.FC<Props> = ({ open, onClose, log, state, onSeed }) =
           {status?.error || 'Update failed. The running version is unchanged — see the log below.'}
         </Alert>
       )}
-      {!status?.latestTag && !updating && state !== 'success' && (
+      {/* A failed *check* deliberately leaves the state alone (a network blip
+          shouldn't look like a failed update), so it reports through `error`
+          only — without this the Check now button would silently snap back to
+          "Up to date". */}
+      {!failed && !updating && status?.error && (
+        <Alert severity="warning" sx={{ mb: 2 }}>
+          {status.error}
+        </Alert>
+      )}
+      {!status?.latestTag && !status?.error && !updating && state !== 'success' && (
         <Alert severity="info" sx={{ mb: 2 }}>
           Checking for the latest release… If this persists, the server may be offline from GitHub.
         </Alert>

--- a/scripts/finalize_update.sh
+++ b/scripts/finalize_update.sh
@@ -15,11 +15,31 @@ STAGING="${1:?staging dir required}"
 PUBLISH="${2:?publish dir required}"
 UNIT="${3:-openscanner}"
 BACKUP="${PUBLISH%/}_backup"
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 
 log() { echo "[finalize] $*"; }
 
-# Whatever happens, never leave the service down: always try to start it on exit.
+# The service — and therefore the whole self-update — runs as root, while the
+# checkout belongs to the operator. Every step that writes into the repo (git
+# reset, npm build, the swap below) leaves root-owned files behind, which then
+# block the next update and any manual `install_service.sh` run. Hand the tree
+# back to whoever owns .git so the repo is never left half root-owned.
+restore_ownership() {
+    [ "$(id -u)" -eq 0 ] || return 0
+    local owner
+    owner=$(stat -c '%U:%G' "$REPO_ROOT/.git" 2>/dev/null) || return 0
+    case "$owner" in
+        ""|root:*) return 0 ;;
+    esac
+    log "Restoring ownership of $REPO_ROOT to $owner"
+    chown -R "$owner" "$REPO_ROOT" || log "WARN: chown failed"
+}
+
+# Whatever happens, never leave the service down or the repo root-owned: the
+# build steps have already run as root by the time we get here, so every exit
+# path — including the aborts below — needs the ownership fixup.
 cleanup() {
+    restore_ownership
     if ! systemctl is-active --quiet "$UNIT"; then
         log "Ensuring $UNIT is started"
         systemctl start "$UNIT" || true

--- a/scripts/install_service.sh
+++ b/scripts/install_service.sh
@@ -67,6 +67,34 @@ else
     log_info "Service was not running."
 fi
 
+# The service runs as root, so an older in-UI self-update can have left root-owned
+# files behind: the git reset rewrites tracked files, the build writes client/dist
+# and the publish dir. Those block the reset and build below, which run as the
+# regular user. Reclaim them first.
+#
+# Only the paths the update actually writes are checked — data/ (recordings) and
+# whisper.cpp/models are written by the root service by design, and chowning those
+# on every install would be pointless churn.
+log_step "Checking File Ownership..."
+RECLAIM_PATHS=(".git" "scripts" "client" "server" "version.json")
+NEEDS_RECLAIM=()
+for rel in "${RECLAIM_PATHS[@]}"; do
+    path="$PROJECT_ROOT/$rel"
+    [ -e "$path" ] || continue
+    if [ -n "$(find "$path" ! -user "$USER" -print -quit 2>/dev/null)" ]; then
+        NEEDS_RECLAIM+=("$path")
+    fi
+done
+
+if [ ${#NEEDS_RECLAIM[@]} -gt 0 ]; then
+    log_warn "Found files not owned by $USER (left by a root self-update):"
+    for p in "${NEEDS_RECLAIM[@]}"; do log_warn "  - ${p#"$PROJECT_ROOT/"}"; done
+    sudo chown -R "$USER:$(id -gn)" "${NEEDS_RECLAIM[@]}"
+    log_success "Ownership restored to $USER."
+else
+    log_success "Ownership looks correct."
+fi
+
 # ----------------------------------------------------------------
 # 2. Update Code
 # ----------------------------------------------------------------


### PR DESCRIPTION
Two updater fixes from the same support report.

---

## 1. Self-update left root-owned files in the checkout

Reported from the field:

> Had some problems updating. Had to change ownership of files in these paths from root to my "radio" user: `server/OpenScanner.Server/bin/Release/net10.0/publish`, `client/dist`, `scripts`. Couldn't get the built-in updater to work this time.

The systemd unit runs the server as `User=root`, so `UpdateService` — and every file-writing step of the update — runs as root inside an operator-owned checkout:

| Step | Writes as root |
|---|---|
| `git reset --hard <tag>` (`UpdateService.cs:301`) | `scripts/` and other tracked files |
| `dotnet build` → csproj npm step (`OpenScanner.Server.csproj:45-46`) | `client/dist` |
| `finalize_update.sh` rsync | `.../net10.0/publish` |

Exactly the three paths reported. Nothing handed ownership back, so the **first** self-update poisoned the tree and every later update failed: `install_service.sh` refuses to run as root, and as `radio` it can't `git reset --hard` over root-owned files or write into `publish`. The `-c safe.directory=*` shim in `UpdateService.cs:130` was already papering over the same mismatch at the git layer.

**Fix:**
- `finalize_update.sh` restores ownership to whoever owns `.git`, on every exit path (via the existing `EXIT` trap, so aborts are covered). No-ops when not root, when `.git` is missing, or when the repo is genuinely root-owned.
- `install_service.sh` detects and reclaims root-owned files *before* the `git reset --hard`, repairing installs already stuck in this state.

The installer check is scoped to `.git`/`scripts`/`client`/`server`/`version.json`. `data/` and `whisper.cpp/models` are root-owned **by design** (the root service writes recordings there); a full-tree check would fire on every install.

## 2. Manual "Check now" button

The server only polls GitHub every 30 minutes and the dialog just read the cached snapshot, so there was no way to check on demand. `POST /api/update/check` already forced a check and returned the refreshed snapshot — nothing on the client called it. Now there's a button that does, plus a "Checked N minutes ago" caption so the poll's staleness is visible. Disabled mid-update so a check can't race a running build.

Two things this turned up, both fixed here:

- **The dialog was unreachable.** The Software Update entry in `AppHeader` was gated on `updateAvailable`, and it's the only way in — so the button would have been unclickable until the poll had *already* found an update, i.e. exactly when you don't need it. The entry is now always listed; the UPDATE chip stays gated as the "something is waiting" nudge.
- **Failed checks were silent.** A failed check deliberately leaves `state` alone (a network blip shouldn't look like a failed update) and reports via `error` only, but the dialog rendered errors only when `state === 'failed'`. An unreachable GitHub would have snapped the button back to "Up to date" with no explanation. Check errors now surface as a warning alert.

---

## Testing

**Scripts** — exercised end-to-end with stubbed `systemctl`/`chown` on fixture repos:
- `restore_ownership` across all five branches: root + operator-owned (chowns), non-root (no-op), already root-owned (no-op), missing `.git` (no-op, no crash), differing user/group.
- Finalizer swap on success *and* abort paths — new build in, stale file removed via `--delete`, rollback backup kept, exec bit set, ownership restored on both.
- Installer guard against a tree poisoned like the report (catches the depth-6 publish dir, `client/dist`, `scripts`) and a clean tree with root-owned `data/` + models (correctly silent).

**Client** — 5 new tests in `UpdateManager.test.tsx` covering the last-checked caption, the POST + newly-found release flow, failed-check surfacing, a thrown request not leaving the button stuck spinning, and disabled-mid-update. Full suite 14/14, lint clean, `tsc --noEmit` clean, production build succeeds.

Two notes worth surfacing:
- My first draft of the installer guard used `-maxdepth 2`, which would have **silently missed the publish dir at depth 6** — the most important path in the report. Caught in testing; scoped by path instead.
- One script test looked alarming mid-way (a "successful" swap left `OLD-BUILD` in place). That was a fixture artifact, not a bug: `"OLD-BUILD\n"` and `"NEW-BUILD\n"` are both 10 bytes written in the same second, so `rsync -a`'s size+mtime quick-check correctly skipped them. Real builds never collide that way.

## Caveats

- Root-owned files are still created *during* an update — they just no longer survive it. If the finalizer is SIGKILLed mid-run the trap won't fire; the installer guard is the backstop. The deeper fixes (dropping privileges for build steps, or running the service non-root with `CAP_NET_BIND_SERVICE`) remain open if this recurs.
- Anyone already stuck needs one manual `chown` before the fixed installer can help — the pull that would deliver it is the thing their root-owned `scripts/` blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)