### PR TITLE
Compress live audio with Opus, and fix the receiver's selectivity and detection

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.6",
         "@mui/material": "^7.3.6",
+        "opus-decoder": "^0.7.11",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
       },
@@ -135,6 +136,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1590,6 +1592,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1633,37 +1636,15 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1721,6 +1702,7 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1758,6 +1740,7 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1794,6 +1777,12 @@
     "node_modules/@emotion/weak-memoize": {
       "version": "0.4.0",
       "license": "MIT"
+    },
+    "node_modules/@eshaz/web-worker": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@eshaz/web-worker/-/web-worker-1.2.2.tgz",
+      "integrity": "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -2088,6 +2077,7 @@
     "node_modules/@mui/material": {
       "version": "7.3.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.6",
@@ -2544,6 +2534,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -3172,8 +3196,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3244,6 +3267,7 @@
       "version": "24.10.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3259,6 +3283,7 @@
     "node_modules/@types/react": {
       "version": "19.2.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3267,6 +3292,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3329,6 +3355,7 @@
       "version": "8.51.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -3677,10 +3704,21 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@wasm-audio-decoders/common": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/common/-/common-9.0.7.tgz",
+      "integrity": "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag==",
+      "license": "MIT",
+      "dependencies": {
+        "@eshaz/web-worker": "1.2.2",
+        "simple-yenc": "^1.0.4"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3950,6 +3988,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4426,8 +4465,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4668,6 +4706,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6486,7 +6525,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6658,6 +6696,19 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/opus-decoder": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/opus-decoder/-/opus-decoder-0.7.11.tgz",
+      "integrity": "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A==",
+      "license": "MIT",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "9.0.7"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
       }
     },
     "node_modules/own-keys": {
@@ -6935,7 +6986,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6951,7 +7001,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6962,7 +7011,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6975,8 +7023,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7002,6 +7049,7 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7009,6 +7057,7 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7228,6 +7277,7 @@
       "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -7517,6 +7567,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-yenc": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-1.0.4.tgz",
+      "integrity": "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw==",
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
       }
     },
     "node_modules/smob": {
@@ -8091,6 +8151,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8252,6 +8313,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8693,6 +8755,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9008,6 +9071,7 @@
       "version": "4.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -136,6 +136,7 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1591,6 +1592,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1634,37 +1636,15 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1722,6 +1702,7 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1759,6 +1740,7 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2095,6 +2077,7 @@
     "node_modules/@mui/material": {
       "version": "7.3.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.6",
@@ -2551,6 +2534,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -3179,8 +3196,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3251,6 +3267,7 @@
       "version": "24.10.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3266,6 +3283,7 @@
     "node_modules/@types/react": {
       "version": "19.2.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3274,6 +3292,7 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3336,6 +3355,7 @@
       "version": "8.51.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -3698,6 +3718,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3967,6 +3988,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4443,8 +4465,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4685,6 +4706,7 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6503,7 +6525,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6965,7 +6986,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6981,7 +7001,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -6992,7 +7011,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7005,8 +7023,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7032,6 +7049,7 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7039,6 +7057,7 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7258,6 +7277,7 @@
       "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8131,6 +8151,7 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8292,6 +8313,7 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8733,6 +8755,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9048,6 +9071,7 @@
       "version": "4.2.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -136,7 +136,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1592,7 +1591,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1636,15 +1634,37 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1702,7 +1722,6 @@
     "node_modules/@emotion/react": {
       "version": "11.14.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1740,7 +1759,6 @@
     "node_modules/@emotion/styled": {
       "version": "11.14.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -2077,7 +2095,6 @@
     "node_modules/@mui/material": {
       "version": "7.3.6",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "@mui/core-downloads-tracker": "^7.3.6",
@@ -2534,40 +2551,6 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
@@ -3196,7 +3179,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3267,7 +3251,6 @@
       "version": "24.10.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3283,7 +3266,6 @@
     "node_modules/@types/react": {
       "version": "19.2.7",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3292,7 +3274,6 @@
       "version": "19.2.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3355,7 +3336,6 @@
       "version": "8.51.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -3718,7 +3698,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3988,7 +3967,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4465,7 +4443,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -4706,7 +4685,6 @@
       "version": "9.39.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6525,6 +6503,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6986,6 +6965,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7001,6 +6981,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -7011,6 +6992,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7023,7 +7005,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -7049,7 +7032,6 @@
     "node_modules/react": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7057,7 +7039,6 @@
     "node_modules/react-dom": {
       "version": "19.2.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7277,7 +7258,6 @@
       "integrity": "sha512-iZKH8BeoCwTCBTZBZWQQMreekd4mdomwdjIQ40GC1oZm6o+8PnNMIxFOiCsGMWeS8iDJ7KZcl7KwmKk/0HOQpA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -8151,7 +8131,6 @@
       "version": "5.9.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8313,7 +8292,6 @@
       "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -8755,7 +8733,6 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -9071,7 +9048,6 @@
       "version": "4.2.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "^7.3.6",
     "@mui/material": "^7.3.6",
+    "opus-decoder": "^0.7.11",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -316,6 +316,7 @@ function App() {
           open={isSettingsOpen}
           onClose={() => setIsSettingsOpen(false)}
           onRecordingsDeleted={() => scanner.setCallLog([])}
+          scannerState={scannerState}
         />
         <AliasManager
           open={isAliasManagerOpen}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
   const [debugGain, setDebugGain] = useState<number>(40);
 
   const audio = useAudioPipeline(volume);
-  const scanner = useScannerSocket({ onParallel: audio.setParallel });
+  const scanner = useScannerSocket();
   const { scannerState } = scanner;
   const manualHold = scannerState.manualHoldFrequency;
 

--- a/client/src/audio/opusStream.test.ts
+++ b/client/src/audio/opusStream.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  detectAudioCodec,
+  parseAudioFormat,
+  resetCodecDetection,
+  wasmDecoderLoadCount,
+} from './opusStream';
+
+vi.mock('opus-decoder', () => ({
+  OpusDecoder: class {
+    ready = Promise.resolve();
+    decodeFrame() {
+      return { channelData: [new Float32Array(960)], samplesDecoded: 960, sampleRate: 48000, errors: [] };
+    }
+    reset() { return Promise.resolve(); }
+    free() { /* noop */ }
+  },
+}));
+
+function stubAudioDecoder(supported: boolean | 'absent') {
+  if (supported === 'absent') {
+    vi.stubGlobal('AudioDecoder', undefined);
+    return;
+  }
+  vi.stubGlobal('AudioDecoder', {
+    isConfigSupported: vi.fn().mockResolvedValue({ supported }),
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  resetCodecDetection();
+});
+
+describe('parseAudioFormat', () => {
+  it('reads the opus announcement', () => {
+    const fmt = parseAudioFormat(
+      JSON.stringify({
+        type: 'AUDIO_FORMAT',
+        payload: { codec: 'opus', sampleRate: 48000, channels: 2, frameMs: 20, bitrate: 40000 },
+      }),
+    );
+    expect(fmt).toEqual({ codec: 'opus', sampleRate: 48000, channels: 2, frameMs: 20, bitrate: 40000 });
+  });
+
+  it('normalizes the server pcm codec name', () => {
+    const fmt = parseAudioFormat(
+      JSON.stringify({ type: 'AUDIO_FORMAT', payload: { codec: 'pcm_s16le', sampleRate: 48000, channels: 1 } }),
+    );
+    expect(fmt?.codec).toBe('pcm');
+    expect(fmt?.channels).toBe(1);
+  });
+
+  it('ignores other message types and malformed input', () => {
+    expect(parseAudioFormat(JSON.stringify({ type: 'STATE_UPDATE', payload: {} }))).toBeNull();
+    expect(parseAudioFormat('not json')).toBeNull();
+    expect(
+      parseAudioFormat(JSON.stringify({ type: 'AUDIO_FORMAT', payload: { codec: 'flac' } })),
+    ).toBeNull();
+  });
+});
+
+describe('detectAudioCodec', () => {
+  it('prefers WebCodecs and never downloads the wasm decoder', async () => {
+    stubAudioDecoder(true);
+
+    await expect(detectAudioCodec()).resolves.toBe('opus');
+    // The bundle-size guarantee: browsers on the native path must not pay for libopus.
+    expect(wasmDecoderLoadCount()).toBe(0);
+  });
+
+  it('falls back to the wasm decoder when WebCodecs is missing', async () => {
+    stubAudioDecoder('absent');
+
+    await expect(detectAudioCodec()).resolves.toBe('opus');
+    expect(wasmDecoderLoadCount()).toBe(1);
+  });
+
+  it('falls back to the wasm decoder when WebCodecs rejects opus', async () => {
+    stubAudioDecoder(false);
+
+    await expect(detectAudioCodec()).resolves.toBe('opus');
+    expect(wasmDecoderLoadCount()).toBe(1);
+  });
+
+  it('memoizes, so reconnects do not re-probe', async () => {
+    stubAudioDecoder(true);
+
+    await detectAudioCodec();
+    await detectAudioCodec();
+
+    const decoder = globalThis.AudioDecoder as unknown as { isConfigSupported: ReturnType<typeof vi.fn> };
+    expect(decoder.isConfigSupported).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/audio/opusStream.ts
+++ b/client/src/audio/opusStream.ts
@@ -1,0 +1,234 @@
+/**
+ * Opus decoding for the live audio WebSocket.
+ *
+ * The server streams raw s16le PCM at 48 kHz — 768 kbps mono, 1.5 Mbps stereo — which makes
+ * listening from outside the LAN impractical. It will instead send Opus (~24 kbps) to any client
+ * that asks for it, so this module answers two questions: can this browser decode Opus, and how.
+ *
+ * Three tiers, best first:
+ *   1. WebCodecs `AudioDecoder` — native, off the main thread, no download. Needs a secure context.
+ *   2. `opus-decoder` (libopus compiled to wasm) — works over plain http, which is how the Pi is
+ *      usually reached. Dynamically imported so browsers on tier 1 never download it.
+ *   3. Neither — the caller falls back to uncompressed PCM, exactly as before.
+ */
+
+export type LiveCodec = 'opus' | 'pcm';
+
+/** The `AUDIO_FORMAT` payload the server sends as a text frame on the audio socket. */
+export interface AudioFormat {
+  codec: LiveCodec;
+  sampleRate: number;
+  channels: number;
+  frameMs?: number;
+  bitrate?: number;
+}
+
+export interface StreamDecoder {
+  /** Fire-and-forget. Decoded samples arrive through the callback given at construction. */
+  decode(packet: ArrayBuffer): void;
+  reset(): void;
+  close(): void;
+}
+
+/** Planar Float32, one array per channel. Always backed by a plain (transferable) ArrayBuffer. */
+export type SamplesCallback = (channels: Float32Array<ArrayBuffer>[]) => void;
+
+const SAMPLE_RATE = 48000;
+/** Every packet the server sends is one 20 ms frame. */
+const FRAME_DURATION_US = 20000;
+
+/** Parses an `AUDIO_FORMAT` text frame, returning null for anything else. */
+export function parseAudioFormat(raw: string): AudioFormat | null {
+  try {
+    const msg = JSON.parse(raw);
+    if (msg?.type !== 'AUDIO_FORMAT' || !msg.payload) return null;
+    const { codec, sampleRate, channels } = msg.payload;
+    if (codec !== 'opus' && codec !== 'pcm_s16le') return null;
+    return {
+      codec: codec === 'opus' ? 'opus' : 'pcm',
+      sampleRate: typeof sampleRate === 'number' ? sampleRate : SAMPLE_RATE,
+      channels: channels === 2 ? 2 : 1,
+      frameMs: msg.payload.frameMs,
+      bitrate: msg.payload.bitrate,
+    };
+  } catch {
+    return null;
+  }
+}
+
+let probe: Promise<LiveCodec> | null = null;
+
+/**
+ * Resolves what this browser can decode. Memoized: the answer can't change within a page load, and
+ * reconnects must not re-run the wasm import.
+ */
+export function detectAudioCodec(): Promise<LiveCodec> {
+  probe ??= runProbe();
+  return probe;
+}
+
+/** Test seam — resets the memoized probe, the cached wasm module, and the load counter. */
+export function resetCodecDetection(): void {
+  probe = null;
+  wasmModule = null;
+  wasmLoads = 0;
+}
+
+/**
+ * Test seam — how many times the wasm decoder module has been imported. Guards the promise that
+ * browsers with native WebCodecs never download libopus.
+ */
+export function wasmDecoderLoadCount(): number {
+  return wasmLoads;
+}
+
+async function runProbe(): Promise<LiveCodec> {
+  if (await webCodecsSupportsOpus()) return 'opus';
+  // No WebCodecs (older browser, or a non-secure context like http://raspberrypi.local). Only
+  // claim Opus if the wasm decoder actually loads — promising it and failing later would leave
+  // the user with silence.
+  try {
+    await loadWasmDecoderModule();
+    return 'opus';
+  } catch {
+    return 'pcm';
+  }
+}
+
+async function webCodecsSupportsOpus(): Promise<boolean> {
+  if (typeof AudioDecoder === 'undefined') return false;
+  try {
+    const support = await AudioDecoder.isConfigSupported(opusConfig(1));
+    return !!support.supported;
+  } catch {
+    return false;
+  }
+}
+
+function opusConfig(channels: number): AudioDecoderConfig {
+  // No `description`: that tells WebCodecs the input is a raw Opus packet stream rather than
+  // Ogg-contained, which is exactly what the server sends.
+  return { codec: 'opus', sampleRate: SAMPLE_RATE, numberOfChannels: channels };
+}
+
+type WasmDecoderModule = typeof import('opus-decoder');
+let wasmModule: Promise<WasmDecoderModule> | null = null;
+let wasmLoads = 0;
+
+function loadWasmDecoderModule(): Promise<WasmDecoderModule> {
+  if (!wasmModule) {
+    wasmLoads++;
+    wasmModule = import('opus-decoder');
+  }
+  return wasmModule;
+}
+
+/**
+ * Builds a decoder for the given channel count, preferring WebCodecs. Returns null when neither
+ * tier is usable, which tells the caller to renegotiate as PCM.
+ */
+export async function createOpusDecoder(
+  channels: number,
+  onSamples: SamplesCallback,
+  onError?: (err: unknown) => void,
+): Promise<StreamDecoder | null> {
+  const native = await createWebCodecsDecoder(channels, onSamples, onError);
+  if (native) return native;
+  try {
+    return await createWasmDecoder(channels, onSamples);
+  } catch (err) {
+    onError?.(err);
+    return null;
+  }
+}
+
+async function createWebCodecsDecoder(
+  channels: number,
+  onSamples: SamplesCallback,
+  onError?: (err: unknown) => void,
+): Promise<StreamDecoder | null> {
+  if (typeof AudioDecoder === 'undefined') return null;
+
+  const config = opusConfig(channels);
+  try {
+    if (!(await AudioDecoder.isConfigSupported(config)).supported) return null;
+  } catch {
+    return null;
+  }
+
+  let timestamp = 0;
+  const decoder = new AudioDecoder({
+    output: (data) => {
+      try {
+        const out: Float32Array<ArrayBuffer>[] = [];
+        for (let ch = 0; ch < data.numberOfChannels; ch++) {
+          const buf = new Float32Array(data.numberOfFrames);
+          data.copyTo(buf, { planeIndex: ch, format: 'f32-planar' });
+          out.push(buf);
+        }
+        onSamples(out);
+      } finally {
+        // Mandatory: AudioData holds a slot in the decoder's pool. Leak these and playback
+        // silently stops a few hundred frames in.
+        data.close();
+      }
+    },
+    error: (err) => onError?.(err),
+  });
+  decoder.configure(config);
+
+  return {
+    decode(packet) {
+      // Every Opus packet is independently decodable, so every chunk is a key frame. Timestamps
+      // only label the output; the worklet's ring buffer owns real-time alignment.
+      decoder.decode(
+        new EncodedAudioChunk({ type: 'key', timestamp, duration: FRAME_DURATION_US, data: packet }),
+      );
+      timestamp += FRAME_DURATION_US;
+    },
+    reset() {
+      timestamp = 0;
+      try {
+        decoder.reset();
+        decoder.configure(config);
+      } catch (err) {
+        onError?.(err);
+      }
+    },
+    close() {
+      try {
+        if (decoder.state !== 'closed') decoder.close();
+      } catch {
+        /* already gone */
+      }
+    },
+  };
+}
+
+async function createWasmDecoder(channels: number, onSamples: SamplesCallback): Promise<StreamDecoder> {
+  const { OpusDecoder } = await loadWasmDecoderModule();
+  const decoder = new OpusDecoder({ channels });
+  await decoder.ready;
+
+  return {
+    decode(packet) {
+      const { channelData, samplesDecoded } = decoder.decodeFrame(new Uint8Array(packet));
+      if (samplesDecoded <= 0) return;
+      // slice() is load-bearing: opus-decoder reuses these output buffers between calls, and the
+      // playback path transfers them to the worklet. Handing over the originals would neuter the
+      // decoder's own memory and break every subsequent frame. It also allocates a fresh plain
+      // ArrayBuffer, which is what makes the cast safe.
+      onSamples(channelData.map((c) => c.slice(0, samplesDecoded) as Float32Array<ArrayBuffer>));
+    },
+    reset() {
+      void decoder.reset();
+    },
+    close() {
+      try {
+        decoder.free();
+      } catch {
+        /* already freed */
+      }
+    },
+  };
+}

--- a/client/src/components/SettingsManager.tsx
+++ b/client/src/components/SettingsManager.tsx
@@ -8,6 +8,7 @@ import SettingsIcon from '@mui/icons-material/Settings';
 import DeleteForeverIcon from '@mui/icons-material/DeleteForever';
 import FormDialog from './common/FormDialog';
 import { apiFetch } from './common/apiBase';
+import type { ScannerState } from '../types';
 
 interface StorageInfo {
     recordingsBytes: number;
@@ -28,7 +29,31 @@ interface Props {
     open: boolean;
     onClose: () => void;
     onRecordingsDeleted?: () => void;
+    /** Live scanner state, for the measured frequency offset shown beside the PPM setting. */
+    scannerState?: ScannerState;
 }
+
+/**
+ * Turns the live per-channel frequency error into a ppm figure the user can act on.
+ *
+ * Only parallel FastScan measures this — it comes from the channelizer's FM discriminator DC,
+ * and the single-channel path hands demodulation to rtl_fm instead. Picks the strongest active
+ * channel, since a weak one's discriminator reading is mostly noise.
+ */
+const measuredPpm = (state?: ScannerState): { offsetHz: number; ppm: number; label: string } | null => {
+    const active = (state?.parallelChannels ?? [])
+        .filter(pc => pc.isActive && pc.measuredOffsetHz != null && pc.channel.frequency > 0)
+        .sort((a, b) => b.signalStrength - a.signalStrength);
+    if (active.length === 0) return null;
+
+    const best = active[0];
+    const offsetHz = best.measuredOffsetHz!;
+    return {
+        offsetHz,
+        ppm: offsetHz / (best.channel.frequency * 1e6) * 1e6,
+        label: best.channel.alphaTag || `${best.channel.frequency} MHz`,
+    };
+};
 
 const formatBytes = (bytes: number): string => {
     if (!bytes || bytes < 0) return '0 B';
@@ -81,7 +106,7 @@ const Row: React.FC<{ label: string; description?: string; control: React.ReactN
     </Box>
 );
 
-const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }) => {
+const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted, scannerState }) => {
     const [settings, setSettings] = useState<Record<string, string>>({});
     const [systemInfo, setSystemInfo] = useState<Record<string, string>>({});
     const [loading, setLoading] = useState(false);
@@ -230,6 +255,33 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
             console.error("Failed to update setting", error);
         }
     };
+
+    /**
+     * SDR tuning goes through the scanner endpoints rather than /api/settings, because the
+     * device has to persist *and* apply the value — gain and ppm are baked into the rtl_sdr
+     * arguments, so the server restarts an active capture to pick them up.
+     */
+    const handleSdrChange = async (key: 'SdrGain' | 'SdrPpm', raw: string) => {
+        setSettings(prev => ({ ...prev, [key]: raw }));
+        const value = parseFloat(raw);
+        if (!Number.isFinite(value)) return;
+
+        const path = key === 'SdrGain' ? 'gain' : 'ppm';
+        try {
+            await apiFetch(`/api/scanner/${path}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ value })
+            });
+        } catch (error) {
+            console.error("Failed to update SDR tuning", error);
+        }
+    };
+
+    // The measured error is relative to how we are *currently* tuned, so applying it means
+    // adding it to the correction already in force, not replacing it.
+    const measured = measuredPpm(scannerState);
+    const currentPpm = parseFloat(settings['SdrPpm'] ?? '') || 0;
 
     // Define known settings with friendly names
     const knownSettings: { key: string; label: string; description: string }[] = [
@@ -387,6 +439,56 @@ const SettingsManager: React.FC<Props> = ({ open, onClose, onRecordingsDeleted }
                                     )}
                                 </>
                             )}
+                        </Section>
+
+                        <Section title="SDR Tuning">
+                            <Row
+                                label="Tuner Gain"
+                                description="RTL-SDR tuner gain in dB. 0 uses the tuner's own AGC, which suits most setups; raise it manually if weak signals are being missed, lower it if a strong local transmitter is desensitising the front end."
+                                control={
+                                    <TextField
+                                        type="number"
+                                        size="small"
+                                        variant="outlined"
+                                        style={{ width: '90px', minWidth: '90px' }}
+                                        value={settings['SdrGain'] ?? ''}
+                                        placeholder="0"
+                                        inputProps={{ min: 0, max: 50, step: 0.1 }}
+                                        onChange={(e) => handleSdrChange('SdrGain', e.target.value)}
+                                    />
+                                }
+                            />
+                            <Row
+                                label="Frequency Correction"
+                                description={
+                                    measured
+                                        ? `Measured on ${measured.label}: ${(measured.offsetHz / 1000).toFixed(2)} kHz off, about ${(currentPpm + measured.ppm).toFixed(1)} ppm. Apply it while a strong, known-accurate signal is up.`
+                                        : 'Crystal error in ppm. Dongles without a TCXO are commonly 20–60 ppm off, which at VHF is several kHz — enough to push a narrowband channel out of the passband and break digital decoding. Open this while a strong signal is being received in parallel scan and the measured value appears here.'
+                                }
+                                control={
+                                    <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+                                        {measured && (
+                                            <Button
+                                                size="small"
+                                                variant="outlined"
+                                                onClick={() => handleSdrChange('SdrPpm', (currentPpm + measured.ppm).toFixed(1))}
+                                            >
+                                                Apply
+                                            </Button>
+                                        )}
+                                        <TextField
+                                            type="number"
+                                            size="small"
+                                            variant="outlined"
+                                            style={{ width: '90px', minWidth: '90px' }}
+                                            value={settings['SdrPpm'] ?? ''}
+                                            placeholder="0"
+                                            inputProps={{ min: -200, max: 200, step: 0.1 }}
+                                            onChange={(e) => handleSdrChange('SdrPpm', e.target.value)}
+                                        />
+                                    </Box>
+                                }
+                            />
                         </Section>
 
                         <Section title="Integrations">

--- a/client/src/hooks/useAudioPipeline.ts
+++ b/client/src/hooks/useAudioPipeline.ts
@@ -1,4 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  createOpusDecoder,
+  detectAudioCodec,
+  parseAudioFormat,
+  type AudioFormat,
+  type StreamDecoder,
+} from '../audio/opusStream';
+
+/** Packets to hold while an Opus decoder is being constructed (~500 ms at 20 ms/packet). */
+const MAX_PENDING_PACKETS = 25;
 
 export interface NowPlaying {
   id: string;
@@ -56,8 +66,16 @@ export function useAudioPipeline(volume: number) {
   const workletSetupRef = useRef<Promise<AudioWorkletNode | null> | null>(null);
   const nextStartTime = useRef<number>(0); // fallback scheduler cursor
   const isPageHiddenRef = useRef(false);
-  const isParallelRef = useRef(false);
   const volumeRef = useRef(volume);
+
+  // Live-stream format, from the server's AUDIO_FORMAT frame on the audio socket itself. This
+  // used to be inferred from parallelChannels on the *control* socket, which had no ordering
+  // relationship to the samples — so a scan-mode switch could deinterleave stereo as mono.
+  const formatRef = useRef<AudioFormat | null>(null);
+  const decoderRef = useRef<StreamDecoder | null>(null);
+  const pendingPacketsRef = useRef<ArrayBuffer[]>([]);
+  /** Sticky once a decoder fails at runtime: reconnect asks for uncompressed PCM instead. */
+  const forcePcmRef = useRef(false);
 
   // Playback transport state.
   const sourceRef = useRef<AudioBufferSourceNode | null>(null);
@@ -79,8 +97,51 @@ export function useAudioPipeline(volume: number) {
 
   useEffect(() => { nowPlayingRef.current = nowPlaying; }, [nowPlaying]);
 
-  const setParallel = useCallback((parallel: boolean) => {
-    isParallelRef.current = parallel;
+  /**
+   * Hands decoded samples to the player: the ring-buffer worklet where available, otherwise
+   * scheduled buffer sources. Both the PCM and Opus paths funnel through here, so they share one
+   * analyser → filter → gain graph and the VU meter and spectrogram keep working unchanged.
+   */
+  const pushSamples = useCallback((left: Float32Array<ArrayBuffer>, right: Float32Array<ArrayBuffer>) => {
+    const ctx = window.audioCtx;
+    const analyser = audioAnalyserRef.current;
+    if (!ctx || !analyser) return;
+
+    const node = workletNodeRef.current;
+    if (node) {
+      // Preferred path: hand off to the ring-buffer worklet (contiguous
+      // playback, no per-frame boundary pops), transferring the buffers.
+      if (left === right) {
+        node.port.postMessage({ channels: [left] }, [left.buffer]);
+      } else {
+        node.port.postMessage({ channels: [left, right] }, [left.buffer, right.buffer]);
+      }
+      return;
+    }
+
+    // Fallback (no AudioWorklet, e.g. http://): schedule a buffer source
+    // into the analyser with a jitter buffer.
+    const frames = left.length;
+    const stereo = left !== right;
+    // Buffer rate is the source PCM rate (48000), not ctx.sampleRate:
+    // this declares the samples' true rate so the engine resamples
+    // correctly if the device context runs at a different rate.
+    const audioBuffer = ctx.createBuffer(stereo ? 2 : 1, frames, 48000);
+    audioBuffer.copyToChannel(left, 0);
+    if (stereo) audioBuffer.copyToChannel(right, 1);
+
+    const source = ctx.createBufferSource();
+    source.buffer = audioBuffer;
+    source.connect(analyser);
+
+    const currentTime = ctx.currentTime;
+    const JITTER_BUFFER = 0.2;
+    const MAX_DRIFT = 0.6;
+    if (nextStartTime.current < currentTime || nextStartTime.current > currentTime + MAX_DRIFT) {
+      nextStartTime.current = currentTime + JITTER_BUFFER;
+    }
+    source.start(nextStartTime.current);
+    nextStartTime.current += audioBuffer.duration;
   }, []);
 
   const ensureCtx = useCallback(async (): Promise<AudioContext | null> => {
@@ -168,9 +229,11 @@ export function useAudioPipeline(volume: number) {
   useEffect(() => {
     const onVisibilityChange = () => {
       isPageHiddenRef.current = document.visibilityState === 'hidden';
-      // Clear any stale buffered audio so we resume live, not behind.
+      // Clear any stale buffered audio so we resume live, not behind. Packets were dropped while
+      // hidden, so the Opus decoder needs its prediction state cleared too.
       if (document.visibilityState === 'visible') {
         workletNodeRef.current?.port.postMessage({ type: 'reset' });
+        decoderRef.current?.reset();
       }
     };
     document.addEventListener('visibilitychange', onVisibilityChange);
@@ -334,105 +397,156 @@ export function useAudioPipeline(volume: number) {
     }
   }, [isPaused, currentPosition]);
 
-  // Live audio WebSocket: streams raw Int16 PCM frames, scheduled to avoid gaps.
+  // Live audio WebSocket. The server sends whichever codec we ask for: Opus (~24 kbps) where the
+  // browser can decode it, raw Int16 PCM (768 kbps) otherwise.
   useEffect(() => {
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-    const wsAudioUrl = `${wsProtocol}//${window.location.host}/ws/audio`;
+    const wsAudioBase = `${wsProtocol}//${window.location.host}/ws/audio`;
     let closed = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    // Guards against a slow decoder construction resolving after the format moved on again.
+    let decoderGeneration = 0;
 
-    const connectAudioWs = () => {
-      wsAudio.current = new WebSocket(wsAudioUrl);
+    const closeDecoder = () => {
+      decoderRef.current?.close();
+      decoderRef.current = null;
+      pendingPacketsRef.current = [];
+    };
+
+    const onDecoded = (channels: Float32Array<ArrayBuffer>[]) => {
+      if (channels.length === 0) return;
+      pushSamples(channels[0], channels.length > 1 ? channels[1] : channels[0]);
+    };
+
+    const onDecoderError = (err: unknown) => {
+      console.error('[Audio] Opus decoding failed; falling back to PCM:', err);
+      forcePcmRef.current = true;
+      closeDecoder();
+      wsAudio.current?.close(); // the reconnect below comes back asking for PCM
+    };
+
+    const applyFormat = (fmt: AudioFormat) => {
+      const prev = formatRef.current;
+      formatRef.current = fmt;
+      if (prev && prev.codec === fmt.codec && prev.channels === fmt.channels) return;
+
+      // Anything buffered describes the old format.
+      workletNodeRef.current?.port.postMessage({ type: 'reset' });
+      closeDecoder();
+      if (fmt.codec !== 'opus') return;
+
+      const generation = ++decoderGeneration;
+      void createOpusDecoder(fmt.channels, onDecoded, onDecoderError).then((decoder) => {
+        if (closed || generation !== decoderGeneration) {
+          decoder?.close();
+          return;
+        }
+        if (!decoder) {
+          onDecoderError(new Error('no Opus decoder available'));
+          return;
+        }
+        decoderRef.current = decoder;
+        // Packets that arrived while we were constructing, replayed in order.
+        for (const packet of pendingPacketsRef.current) decoder.decode(packet);
+        pendingPacketsRef.current = [];
+      });
+    };
+
+    const handlePcm = (data: ArrayBuffer) => {
+      const int16Array = new Int16Array(data);
+      const isStereo = formatRef.current?.channels === 2;
+
+      // Deinterleave Int16 → Float32.
+      let left: Float32Array<ArrayBuffer>;
+      let right: Float32Array<ArrayBuffer>;
+      if (isStereo && int16Array.length >= 2) {
+        const frameSamples = Math.floor(int16Array.length / 2);
+        left = new Float32Array(frameSamples);
+        right = new Float32Array(frameSamples);
+        for (let i = 0; i < frameSamples; i++) {
+          left[i] = int16Array[i * 2] / 32768;
+          right[i] = int16Array[i * 2 + 1] / 32768;
+        }
+      } else {
+        left = new Float32Array(int16Array.length);
+        for (let i = 0; i < int16Array.length; i++) left[i] = int16Array[i] / 32768;
+        right = left;
+      }
+
+      pushSamples(left, right);
+    };
+
+    const connectAudioWs = async () => {
+      const codec = forcePcmRef.current ? 'pcm' : await detectAudioCodec();
+      if (closed) return;
+      // The server treats a missing ?codec= as a pre-negotiation client, so always send one.
+      const ws = new WebSocket(`${wsAudioBase}?codec=${codec === 'opus' ? 'opus,pcm' : 'pcm'}`);
+      wsAudio.current = ws;
       // Receive frames as ArrayBuffer, not Blob. Blob forces a per-frame
       // `await event.data.arrayBuffer()` in the handler below, and that async
       // yield lets concurrently-arriving frames resolve out of order — which
       // reorders PCM and produces high-frequency popping. ArrayBuffer frames
       // are available synchronously, so enqueue order matches arrival order.
-      wsAudio.current.binaryType = 'arraybuffer';
-      wsAudio.current.onclose = () => { if (!closed) setTimeout(connectAudioWs, 3000); };
-      wsAudio.current.onmessage = async (event) => {
+      ws.binaryType = 'arraybuffer';
+      ws.onclose = () => {
+        closeDecoder();
+        formatRef.current = null;
+        if (!closed) reconnectTimer = setTimeout(() => { void connectAudioWs(); }, 3000);
+      };
+      ws.onmessage = (event) => {
+        if (typeof event.data === 'string') {
+          const fmt = parseAudioFormat(event.data);
+          if (fmt) applyFormat(fmt);
+          return;
+        }
         if (!(event.data instanceof ArrayBuffer)) return;
         if (isPageHiddenRef.current) return;
 
         try {
-          const ctx = await ensureCtx();
-          if (!ctx) return;
-          const node = await ensureLiveGraph(ctx);
-          const analyser = audioAnalyserRef.current;
-          if (!analyser) return;
-
-          const int16Array = new Int16Array(event.data);
-          const isStereo = isParallelRef.current;
-
-          // Deinterleave Int16 → Float32.
-          let left: Float32Array<ArrayBuffer>;
-          let right: Float32Array<ArrayBuffer>;
-          if (isStereo && int16Array.length >= 2) {
-            const frameSamples = Math.floor(int16Array.length / 2);
-            left = new Float32Array(frameSamples);
-            right = new Float32Array(frameSamples);
-            for (let i = 0; i < frameSamples; i++) {
-              left[i] = int16Array[i * 2] / 32768;
-              right[i] = int16Array[i * 2 + 1] / 32768;
+          if (formatRef.current?.codec === 'opus') {
+            // Dispatch synchronously: Opus frames carry prediction state, so reordering them
+            // corrupts the decoder rather than just producing a click. The decoder's own output
+            // callback is where samples meet the (possibly not-yet-built) audio graph.
+            void ensureGraphReady();
+            const decoder = decoderRef.current;
+            if (decoder) decoder.decode(event.data);
+            else if (pendingPacketsRef.current.length < MAX_PENDING_PACKETS) {
+              pendingPacketsRef.current.push(event.data);
             }
-          } else {
-            left = new Float32Array(int16Array.length);
-            for (let i = 0; i < int16Array.length; i++) left[i] = int16Array[i] / 32768;
-            right = left;
+            return;
           }
 
-          if (node) {
-            // Preferred path: hand off to the ring-buffer worklet (contiguous
-            // playback, no per-frame boundary pops), transferring the buffers.
-            if (left === right) {
-              node.port.postMessage({ channels: [left] }, [left.buffer]);
-            } else {
-              node.port.postMessage({ channels: [left, right] }, [left.buffer, right.buffer]);
-            }
-          } else {
-            // Fallback (no AudioWorklet, e.g. http://): schedule a buffer source
-            // into the analyser with a jitter buffer.
-            const frames = left.length;
-            const stereo = left !== right;
-            // Buffer rate is the source PCM rate (48000), not ctx.sampleRate:
-            // this declares the samples' true rate so the engine resamples
-            // correctly if the device context runs at a different rate.
-            const audioBuffer = ctx.createBuffer(stereo ? 2 : 1, frames, 48000);
-            audioBuffer.copyToChannel(left, 0);
-            if (stereo) audioBuffer.copyToChannel(right, 1);
-
-            const source = ctx.createBufferSource();
-            source.buffer = audioBuffer;
-            source.connect(analyser);
-
-            const currentTime = ctx.currentTime;
-            const JITTER_BUFFER = 0.2;
-            const MAX_DRIFT = 0.6;
-            if (nextStartTime.current < currentTime || nextStartTime.current > currentTime + MAX_DRIFT) {
-              nextStartTime.current = currentTime + JITTER_BUFFER;
-            }
-            source.start(nextStartTime.current);
-            nextStartTime.current += audioBuffer.duration;
-          }
+          const data = event.data;
+          void ensureGraphReady().then((ready) => { if (ready) handlePcm(data); });
         } catch (err) {
           console.error('[Audio] Processing error:', err);
         }
       };
     };
 
+    const ensureGraphReady = async (): Promise<boolean> => {
+      const ctx = await ensureCtx();
+      if (!ctx) return false;
+      await ensureLiveGraph(ctx);
+      return audioAnalyserRef.current !== null;
+    };
+
     const resumeAudio = () => {
       if (window.audioCtx && window.audioCtx.state === 'suspended') window.audioCtx.resume();
     };
     window.addEventListener('click', resumeAudio);
-    connectAudioWs();
+    void connectAudioWs();
 
     return () => {
       closed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
       window.removeEventListener('click', resumeAudio);
+      closeDecoder();
       wsAudio.current?.close();
     };
-    // ensureCtx/ensureLiveGraph are stable (memoized with empty deps); listed to
+    // ensureCtx/ensureLiveGraph/pushSamples are stable (memoized with empty deps); listed to
     // satisfy exhaustive-deps without re-running the socket setup.
-  }, [ensureCtx, ensureLiveGraph]);
+  }, [ensureCtx, ensureLiveGraph, pushSamples]);
 
   return {
     isAudioInitialized,
@@ -448,6 +562,5 @@ export function useAudioPipeline(volume: number) {
     seek,
     setRate,
     stop,
-    setParallel,
   };
 }

--- a/client/src/hooks/useScannerSocket.ts
+++ b/client/src/hooks/useScannerSocket.ts
@@ -52,6 +52,8 @@ export function useScannerSocket() {
       case 'start': return scannerApi('power', 'PUT', { enabled: true });
       case 'stop': return scannerApi('power', 'PUT', { enabled: false });
       case 'set_squelch': return scannerApi('squelch', 'PUT', { value });
+      case 'set_gain': return scannerApi('gain', 'PUT', { value });
+      case 'set_ppm': return scannerApi('ppm', 'PUT', { value });
       case 'debug_spectrum': return scannerApi('debug-spectrum', 'POST', { frequency, gain: value });
       default: console.error('Unknown command:', action);
     }

--- a/client/src/hooks/useScannerSocket.ts
+++ b/client/src/hooks/useScannerSocket.ts
@@ -6,17 +6,12 @@ import type { NameFor } from '../lib/aliasLabels';
 const aliasKey = (kind: string, value: number, alphaTag: string, frequency: number) =>
   `${alphaTag}|${frequency.toFixed(4)}|${kind}|${value}`;
 
-interface Options {
-  /** Called when a state update indicates whether the live stream is stereo. */
-  onParallel?: (parallel: boolean) => void;
-}
-
 /**
  * Owns the control WebSocket, initial REST loads, live scanner/channel/log/event
  * state, and the command + CRUD helpers. Extracted from App so the component is a
  * thin composition root over this hook and useAudioPipeline.
  */
-export function useScannerSocket({ onParallel }: Options = {}) {
+export function useScannerSocket() {
   const [scannerState, setScannerState] = useState<ScannerState>({ status: 'IDLE', signalStrength: 0 });
   const [channels, setChannels] = useState<Channel[]>([]);
   const [fireTones, setFireTones] = useState<FireToneSet[]>([]);
@@ -40,8 +35,6 @@ export function useScannerSocket({ onParallel }: Options = {}) {
   const [logLoaded, setLogLoaded] = useState(false);
 
   const wsControl = useRef<WebSocket | null>(null);
-  const onParallelRef = useRef(onParallel);
-  useEffect(() => { onParallelRef.current = onParallel; }, [onParallel]);
 
   // Low-level REST helper for scanner control endpoints.
   const scannerApi = useCallback((path: string, method: string, body?: object) =>
@@ -239,7 +232,6 @@ export function useScannerSocket({ onParallel }: Options = {}) {
           const message = JSON.parse(event.data);
           if (message.type === 'STATE_UPDATE') {
             const newState = message.payload as ScannerState;
-            onParallelRef.current?.(!!(newState.parallelChannels && newState.parallelChannels.length > 0));
             setScannerState(newState);
           } else if (message.type === 'NEW_LOG') {
             const newEntry = message.payload as CallLog;

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -23,6 +23,11 @@ export interface ParallelChannelState {
     targetID?: number;
     speakerChain?: string;
     currentTone?: string;
+    /**
+     * Measured frequency error of the received carrier, in Hz, or absent when idle. Over a
+     * transmitter known to be on-frequency this is the dongle's crystal error.
+     */
+    measuredOffsetHz?: number;
 }
 
 export interface ScannerState {
@@ -37,6 +42,7 @@ export interface ScannerState {
     isAudioStreaming?: boolean;
     squelch?: number;
     gain?: number;
+    ppm?: number;
     rfSpectrum?: { frequency: number, db: number }[];
     gps?: {
         lat: number;

--- a/server/OpenScanner.Server/Audio/AudioChunk.cs
+++ b/server/OpenScanner.Server/Audio/AudioChunk.cs
@@ -1,0 +1,21 @@
+namespace OpenScanner.Server.Audio;
+
+/// <summary>
+/// A chunk of live audio leaving a radio source, carrying its own format.
+///
+/// The channel count used to be inferred by the browser from <c>parallelChannels</c> on the
+/// *control* WebSocket — a different connection with no ordering relationship to the audio, so a
+/// scan-mode switch could deinterleave stereo as mono until the two sockets caught up. Attaching
+/// the format to the samples at the point they are produced removes the guesswork.
+/// </summary>
+/// <param name="Pcm">Interleaved little-endian signed 16-bit PCM.</param>
+/// <param name="Channels">1 for mono, 2 for interleaved stereo.</param>
+/// <param name="SampleRate">Sample rate in Hz.</param>
+public readonly record struct AudioChunk(byte[] Pcm, int Channels, int SampleRate)
+{
+    /// <summary>Mono 48 kHz — the single-channel decoder path.</summary>
+    public static AudioChunk Mono48k(byte[] pcm) => new(pcm, 1, 48000);
+
+    /// <summary>Interleaved stereo 48 kHz — the parallel FastScan mixer.</summary>
+    public static AudioChunk Stereo48k(byte[] pcm) => new(pcm, 2, 48000);
+}

--- a/server/OpenScanner.Server/Audio/AudioNegotiation.cs
+++ b/server/OpenScanner.Server/Audio/AudioNegotiation.cs
@@ -1,0 +1,53 @@
+namespace OpenScanner.Server.Audio;
+
+/// <summary>
+/// What a given <c>/ws/audio</c> session is being sent.
+/// </summary>
+public enum LiveAudioCodec
+{
+    /// <summary>
+    /// No <c>?codec=</c> parameter at all. The client is from before codec negotiation existed, so
+    /// it gets exactly what it always got: raw s16le PCM binary frames and no text frames.
+    /// </summary>
+    LegacyPcm,
+
+    /// <summary>Raw s16le PCM, but with <c>AUDIO_FORMAT</c> announcements.</summary>
+    Pcm,
+
+    /// <summary>One Opus packet per binary frame, with <c>AUDIO_FORMAT</c> announcements.</summary>
+    Opus,
+}
+
+/// <summary>
+/// Resolves the <c>?codec=</c> query parameter on the audio WebSocket.
+/// </summary>
+public static class AudioNegotiation
+{
+    /// <summary>
+    /// Picks a codec from the client's ordered preference list.
+    /// </summary>
+    /// <param name="codecParam">Raw <c>?codec=</c> value (comma-separated, most preferred first),
+    /// or null when the parameter is absent.</param>
+    /// <param name="opusAvailable">False when the server can't encode Opus, which downgrades an
+    /// Opus request to PCM rather than failing the connection.</param>
+    public static LiveAudioCodec Negotiate(string? codecParam, bool opusAvailable)
+    {
+        if (codecParam is null) return LiveAudioCodec.LegacyPcm;
+
+        foreach (var raw in codecParam.Split(','))
+        {
+            switch (raw.Trim().ToLowerInvariant())
+            {
+                case "opus" when opusAvailable:
+                    return LiveAudioCodec.Opus;
+                case "pcm":
+                case "pcm_s16le":
+                    return LiveAudioCodec.Pcm;
+            }
+        }
+
+        // The parameter was present but named nothing we support (including "opus" when Opus is
+        // unavailable). The client still speaks the negotiated protocol, so it gets AUDIO_FORMAT.
+        return LiveAudioCodec.Pcm;
+    }
+}

--- a/server/OpenScanner.Server/Audio/OpusStreamEncoder.cs
+++ b/server/OpenScanner.Server/Audio/OpusStreamEncoder.cs
@@ -1,0 +1,176 @@
+using Concentus;
+using Concentus.Enums;
+
+namespace OpenScanner.Server.Audio;
+
+/// <summary>
+/// Encodes a stream of arbitrary-length s16le PCM chunks into Opus packets.
+///
+/// Opus only accepts exact frame sizes, but the audio chunks reaching the broadcaster don't
+/// align to one: the single-channel decoder path flushes whenever it has 4096 bytes *or* 40 ms
+/// have elapsed (<see cref="Decoders.DSDBase"/>), while the parallel mixer emits exactly 20 ms.
+/// This class buffers whatever it is handed and emits one packet per complete 20 ms frame,
+/// carrying the remainder to the next push.
+///
+/// Not thread-safe — the underlying Concentus encoder holds mutable state and must have a single
+/// caller. Callers broadcasting from more than one producer thread must serialize their pushes.
+/// </summary>
+public sealed class OpusStreamEncoder : IDisposable
+{
+    /// <summary>Samples per channel in one Opus frame: 20 ms at 48 kHz.</summary>
+    public const int FrameSamplesPerChannel = 960;
+
+    /// <summary>Largest possible Opus packet for a single frame.</summary>
+    private const int MaxPacketBytes = 1275;
+
+    private readonly IOpusEncoder _encoder;
+    private readonly short[] _frame;
+    private readonly byte[] _packetScratch = new byte[MaxPacketBytes];
+
+    /// <summary>Interleaved samples buffered so far toward the next frame.</summary>
+    private int _filled;
+
+    /// <summary>
+    /// Low byte of a sample whose high byte hasn't arrived yet, or -1. Chunks really can end
+    /// mid-sample: <c>DSDBase.ProcessAudioStream</c> passes a trailing odd byte through unchanged,
+    /// so a 40 ms flush can land on an odd boundary. Dropping the byte instead of carrying it
+    /// would swap the endianness of every subsequent sample.
+    /// </summary>
+    private int _pendingByte = -1;
+
+    private bool _disposed;
+
+    /// <summary>Channel count this encoder was created for (1 = mono, 2 = interleaved stereo).</summary>
+    public int Channels { get; }
+
+    /// <summary>Sample rate in Hz.</summary>
+    public int SampleRate { get; }
+
+    /// <summary>Target bitrate in bits per second.</summary>
+    public int Bitrate { get; }
+
+    /// <summary>Samples per channel currently buffered toward the next frame.</summary>
+    public int PendingSamples => _filled / Channels;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OpusStreamEncoder"/> class.
+    /// </summary>
+    /// <param name="channels">1 for mono, 2 for interleaved stereo.</param>
+    /// <param name="bitrate">Target bitrate in bits per second.</param>
+    /// <param name="complexity">Opus complexity 0-10. Concentus is managed and slower than native
+    /// libopus, so this defaults low enough to stay cheap on a Pi.</param>
+    /// <param name="sampleRate">Input sample rate in Hz.</param>
+    public OpusStreamEncoder(int channels, int bitrate, int complexity = 5, int sampleRate = 48000)
+    {
+        if (channels is not (1 or 2)) throw new ArgumentOutOfRangeException(nameof(channels));
+
+        Channels = channels;
+        SampleRate = sampleRate;
+        Bitrate = bitrate;
+
+        _encoder = OpusCodecFactory.CreateEncoder(sampleRate, channels, OpusApplication.OPUS_APPLICATION_VOIP);
+        _encoder.Bitrate = bitrate;
+        _encoder.Complexity = complexity;
+        // The source is vocoder output that the client already lowpasses at 3400 Hz, so tell the
+        // encoder it's speech and stop it spending bits above the voice band.
+        _encoder.SignalType = OpusSignal.OPUS_SIGNAL_VOICE;
+        _encoder.MaxBandwidth = OpusBandwidth.OPUS_BANDWIDTH_WIDEBAND;
+        _encoder.UseVBR = true;
+        _encoder.UseConstrainedVBR = false;
+        // FEC exists for lossy datagram transports. WebSockets ride TCP, which doesn't drop
+        // packets — it stalls — so every FEC bit would be waste.
+        _encoder.UseInbandFEC = false;
+        _encoder.PacketLossPercent = 0;
+        // Silence is already suppressed upstream: the mixer skips broadcasting when every channel
+        // is quiet, and the decoder path simply stops producing. DTX would add nothing.
+        _encoder.UseDTX = false;
+
+        _frame = new short[FrameSamplesPerChannel * channels];
+    }
+
+    /// <summary>
+    /// Appends s16le PCM and returns zero or more complete Opus packets, in order.
+    /// </summary>
+    /// <param name="pcm">Interleaved little-endian 16-bit PCM. May be any length, including odd.</param>
+    /// <returns>One packet per complete 20 ms frame the push completed.</returns>
+    public IReadOnlyList<byte[]> Push(ReadOnlySpan<byte> pcm)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        List<byte[]>? packets = null;
+        int i = 0;
+
+        while (i < pcm.Length)
+        {
+            short sample;
+            if (_pendingByte >= 0)
+            {
+                sample = (short)((pcm[i] << 8) | _pendingByte);
+                _pendingByte = -1;
+                i += 1;
+            }
+            else if (i + 1 < pcm.Length)
+            {
+                sample = (short)((pcm[i + 1] << 8) | pcm[i]);
+                i += 2;
+            }
+            else
+            {
+                _pendingByte = pcm[i];
+                break;
+            }
+
+            _frame[_filled++] = sample;
+            if (_filled == _frame.Length)
+            {
+                (packets ??= new List<byte[]>()).Add(EncodeFrame());
+                _filled = 0;
+            }
+        }
+
+        return packets ?? (IReadOnlyList<byte[]>)Array.Empty<byte[]>();
+    }
+
+    /// <summary>
+    /// Zero-pads a partial frame to a full one and encodes it, so a finite buffer (the pre-roll
+    /// replay) doesn't lose its last few milliseconds.
+    /// </summary>
+    /// <returns>The final packet, or null when nothing was buffered.</returns>
+    public byte[]? FlushWithSilence()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_filled == 0 && _pendingByte < 0) return null;
+
+        // A dangling half-sample can't be completed; discarding one byte is the only option.
+        _pendingByte = -1;
+        Array.Clear(_frame, _filled, _frame.Length - _filled);
+        _filled = 0;
+        return EncodeFrame();
+    }
+
+    /// <summary>
+    /// Discards the partial frame and resets encoder state. Used across stream gaps so the
+    /// encoder doesn't carry prediction state from one transmission into the next.
+    /// </summary>
+    public void Reset()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        _filled = 0;
+        _pendingByte = -1;
+        _encoder.ResetState();
+    }
+
+    private byte[] EncodeFrame()
+    {
+        int len = _encoder.Encode(_frame, FrameSamplesPerChannel, _packetScratch, _packetScratch.Length);
+        return _packetScratch.AsSpan(0, len).ToArray();
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        (_encoder as IDisposable)?.Dispose();
+    }
+}

--- a/server/OpenScanner.Server/Controllers/ScannerController.cs
+++ b/server/OpenScanner.Server/Controllers/ScannerController.cs
@@ -134,12 +134,36 @@ public class ScannerController : ControllerBase
     /// <summary>
     /// Sets the squelch threshold.
     /// </summary>
-    /// <param name="request">The squelch threshold, in dB.</param>
+    /// <param name="request">The squelch threshold, in dB of SNR above the noise floor.</param>
     [HttpPut("scanner/squelch")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public IActionResult SetSquelch([FromBody] SquelchRequest request)
     {
         _radio.SetSquelch(request.Value);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Sets the RTL-SDR tuner gain.
+    /// </summary>
+    /// <param name="request">The tuner gain, in dB (0 = AUTO/AGC).</param>
+    [HttpPut("scanner/gain")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult SetGain([FromBody] GainRequest request)
+    {
+        _radio.SetGain(request.Value);
+        return Ok();
+    }
+
+    /// <summary>
+    /// Sets the crystal frequency error correction.
+    /// </summary>
+    /// <param name="request">The correction, in parts per million.</param>
+    [HttpPut("scanner/ppm")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public IActionResult SetPpm([FromBody] PpmRequest request)
+    {
+        _radio.SetPpm(request.Value);
         return Ok();
     }
 
@@ -188,6 +212,22 @@ public class ScannerController : ControllerBase
     {
         _radio.StartDebugSpectrum(request.Frequency, request.Gain);
         return Ok();
+    }
+
+    /// <summary>
+    /// Reads a numeric "value" from a loose-typed command body, accepting either a JSON
+    /// number or a numeric string (older clients send the latter).
+    /// </summary>
+    private static bool TryReadValue(JsonElement body, out double value)
+    {
+        value = 0;
+        if (!body.TryGetProperty("value", out var prop)) return false;
+        if (prop.ValueKind == JsonValueKind.Number)
+        {
+            value = prop.GetDouble();
+            return true;
+        }
+        return double.TryParse(prop.GetString(), out value);
     }
 
     /// <summary>
@@ -268,10 +308,13 @@ public class ScannerController : ControllerBase
                 }
                 break;
             case "set_squelch":
-                 if (body.TryGetProperty("value", out var v) && v.ValueKind == JsonValueKind.Number)
-                    _radio.SetSquelch(v.GetDouble());
-                 else if (body.TryGetProperty("value", out var vs) && double.TryParse(vs.GetString(), out var vd))
-                    _radio.SetSquelch(vd);
+                if (TryReadValue(body, out var squelchValue)) _radio.SetSquelch(squelchValue);
+                break;
+            case "set_gain":
+                if (TryReadValue(body, out var gainValue)) _radio.SetGain(gainValue);
+                break;
+            case "set_ppm":
+                if (TryReadValue(body, out var ppmValue)) _radio.SetPpm(ppmValue);
                 break;
             case "start_dump":
                 if (body.TryGetProperty("label", out var labelProp))
@@ -314,8 +357,14 @@ public record PowerRequest(bool Enabled);
 /// <summary>Request to hold the scanner on a frequency (MHz).</summary>
 public record HoldRequest(double Frequency);
 
-/// <summary>Request to set the squelch threshold (dB).</summary>
+/// <summary>Request to set the squelch threshold (dB of SNR above the noise floor).</summary>
 public record SquelchRequest(double Value);
+
+/// <summary>Request to set the RTL-SDR tuner gain (dB; 0 = AUTO/AGC).</summary>
+public record GainRequest(double Value);
+
+/// <summary>Request to set the crystal frequency error correction (ppm).</summary>
+public record PpmRequest(double Value);
 
 /// <summary>Request to temporarily avoid a frequency (MHz) for a duration (seconds).</summary>
 public record AvoidRequest(double Frequency, double Duration = 10);

--- a/server/OpenScanner.Server/DSP/Channelizer.cs
+++ b/server/OpenScanner.Server/DSP/Channelizer.cs
@@ -2,8 +2,14 @@ namespace OpenScanner.Server.DSP;
 
 /// <summary>
 /// Isolates a single narrowband channel from a wideband IQ stream.
-/// Pipeline: NCO frequency shift -> two-stage FIR decimation -> FM/AM demodulation.
-/// Produces 48 kHz s16le PCM audio suitable for feeding to decoders.
+/// Pipeline: DC block -> NCO frequency shift -> two-stage FIR decimation -> channel filter
+/// -> FM/AM demodulation. Produces 48 kHz s16le PCM audio suitable for feeding to decoders.
+///
+/// The three filters have distinct jobs and are sized independently:
+/// stages 1 and 2 exist only to prevent aliasing as the rate comes down, while the channel
+/// filter at the output rate provides all of the selectivity. Sizing the decimation filters by
+/// their decimation factor (as this did before 2026) is unrelated to the selectivity a channel
+/// actually needs, and left a 12.5 kHz-spaced neighbour sitting inside the passband.
 /// </summary>
 public class Channelizer
 {
@@ -12,9 +18,24 @@ public class Channelizer
     private readonly double _offsetHz;
     private readonly bool _amMode;
 
-    // NCO (Numerically Controlled Oscillator)
-    private double _ncoPhase;
-    private readonly double _ncoPhaseInc;
+    // NCO, as a recursive complex rotator. Multiplying by a fixed unit phasor each sample costs
+    // one complex multiply instead of a Math.Cos/Math.Sin pair — at 2.4 Msps that pair was
+    // 4.8M transcendental calls per second per channel and dominated the whole pipeline.
+    private double _ncoRe = 1.0;
+    private double _ncoIm;
+    private readonly double _ncoStepRe;
+    private readonly double _ncoStepIm;
+    private int _ncoSinceNormalize;
+    /// <summary>Repeated complex multiplies let the rotator's magnitude creep; renormalize periodically.</summary>
+    private const int NcoNormalizeInterval = 1024;
+
+    // Input DC removal. RTL-SDR dongles put a large spike at the tuner centre; without this it
+    // lands inside whichever channel sits at the centre frequency.
+    private double _dcI;
+    private double _dcQ;
+    private readonly double _dcAlpha;
+    /// <summary>Corner frequency of the input DC blocker. Low enough to touch nothing but the spike.</summary>
+    private const double DcBlockerCornerHz = 500.0;
 
     // Stage 1 decimation
     private readonly int _decim1;
@@ -32,6 +53,13 @@ public class Channelizer
     private int _writePtr2;
     private int _decimCount2;
 
+    // Channel filter: runs at the output rate on complex baseband and provides all of the
+    // selectivity. Empty when the caller asks for no channel shaping.
+    private readonly double[] _filter3;
+    private readonly double[] _delayI3;
+    private readonly double[] _delayQ3;
+    private int _writePtr3;
+
     // FM demodulator state (previous IQ sample for phase differencing)
     private double _prevI;
     private double _prevQ;
@@ -43,18 +71,31 @@ public class Channelizer
     // FM scaling: convert phase-diff to normalized audio
     private readonly double _fmScale;
 
-    // Signal power metering (IQ magnitude before demodulation)
+    // Signal metering, accumulated over the same window: in-channel power and discriminator DC.
     private double _iqPowerAccum;
+    private double _phaseDiffAccum;
     private int _iqPowerCount;
     private double _signalPowerDb = -90.0;
+    private double _frequencyOffsetHz;
     private const int IqPowerWindow = 4800; // ~100ms at 48kHz output rate
 
     /// <summary>
-    /// Latest measured RF signal power in dB (IQ magnitude before demodulation).
-    /// Updated every ~100ms. Useful for signal strength metering.
-    /// Noise floor is typically around -30 to -40 dB; a carrier reads -5 to 0 dB.
+    /// Latest measured signal power in dB, taken on the complex baseband after the channel
+    /// filter and before demodulation. Measuring it post-filter makes it genuine in-channel
+    /// power rather than everything the decimation chain happened to let through, which is
+    /// what makes it usable as a squelch metric.
+    /// Updated every ~100ms. Noise floor typically sits around -30 to -40 dB; a carrier
+    /// reads -5 to 0 dB.
     /// </summary>
     public double SignalPowerDb => _signalPowerDb;
+
+    /// <summary>
+    /// Mean FM discriminator output over the last measurement window, in Hz. For a signal
+    /// centred in the passband this is zero; a non-zero reading is the frequency error between
+    /// the transmitter and where we tuned, which over a known-accurate reference signal is the
+    /// dongle's crystal error. Meaningless in AM mode or with no signal present.
+    /// </summary>
+    public double FrequencyOffsetHz => _frequencyOffsetHz;
 
     /// <summary>
     /// Maximum output bytes for a given input length (for buffer pre-allocation).
@@ -74,7 +115,23 @@ public class Channelizer
     /// <param name="outputRate">Desired audio output rate in Hz (typically 48000)</param>
     /// <param name="offsetHz">Frequency offset of target channel from SDR center, in Hz</param>
     /// <param name="amMode">True for AM demodulation, false for FM</param>
-    public Channelizer(int inputRate, int outputRate, double offsetHz, bool amMode = false)
+    /// <param name="channelCutoffHz">
+    /// One-sided bandwidth of the wanted channel, in Hz — 6250 for a 12.5 kHz channel, 12500 for
+    /// a 25 kHz one. Zero disables the channel filter, leaving only the anti-alias stages
+    /// (the pre-2026 behaviour).
+    /// </param>
+    /// <param name="deviationHz">
+    /// Peak frequency deviation the transmitter uses, which sets the audio scaling. 5000 suits
+    /// analog voice; P25 C4FM peaks at 1800 and DMR 4FSK at 1944, and scaling those as if they
+    /// were 5 kHz leaves the decoder ~11 dB of unused headroom.
+    /// </param>
+    public Channelizer(
+        int inputRate,
+        int outputRate,
+        double offsetHz,
+        bool amMode = false,
+        double channelCutoffHz = 0,
+        double deviationHz = 5000.0)
     {
         _inputRate = inputRate;
         _outputRate = outputRate;
@@ -110,22 +167,33 @@ public class Channelizer
 
         int intermediateRate = inputRate / _decim1;
 
-        // NCO phase increment per input sample (negative for downconversion)
-        _ncoPhaseInc = -2.0 * Math.PI * offsetHz / inputRate;
+        // NCO as a fixed unit phasor, applied by repeated complex multiply.
+        // Negative angle for downconversion, matching the old phase increment.
+        double ncoStep = -2.0 * Math.PI * offsetHz / inputRate;
+        _ncoStepRe = Math.Cos(ncoStep);
+        _ncoStepIm = Math.Sin(ncoStep);
 
-        // Design decimation filters using windowed sinc method.
-        // Cutoff at 80% of the output Nyquist to provide transition band.
-        double cutoff1Normalized = 0.8 * (intermediateRate / 2.0) / inputRate;
-        int taps1 = Math.Max(4 * _decim1, 32) | 1; // Ensure odd number of taps
-        _filter1 = DesignLowPass(cutoff1Normalized, taps1);
+        _dcAlpha = 2.0 * Math.PI * DcBlockerCornerHz / inputRate;
+
+        // Everything the channel filter will ultimately keep. Used to size the anti-alias
+        // stages: they only have to stop what would fold *into this band*, not everything
+        // above their own cutoff, which is what keeps them cheap.
+        double keepHz = channelCutoffHz > 0 ? channelCutoffHz : outputRate / 2.0;
+
+        // Stage 1: decimating to intermediateRate folds content near multiples of
+        // intermediateRate down onto us, so the stopband has to start at intermediateRate - keep.
+        double cutoff1 = 0.8 * (intermediateRate / 2.0);
+        int taps1 = BlackmanTaps(inputRate, transitionHz: intermediateRate - keepHz - cutoff1, minimum: 33);
+        _filter1 = DesignLowPass(cutoff1 / inputRate, taps1);
         _delayI1 = new double[taps1];
         _delayQ1 = new double[taps1];
 
         if (_decim2 > 1)
         {
-            double cutoff2Normalized = 0.8 * (outputRate / 2.0) / intermediateRate;
-            int taps2 = Math.Max(4 * _decim2, 16) | 1;
-            _filter2 = DesignLowPass(cutoff2Normalized, taps2);
+            // Stage 2: same argument one rate down — stop by outputRate - keep.
+            double cutoff2 = 0.8 * (outputRate / 2.0);
+            int taps2 = BlackmanTaps(intermediateRate, transitionHz: outputRate - keepHz - cutoff2, minimum: 21);
+            _filter2 = DesignLowPass(cutoff2 / intermediateRate, taps2);
             _delayI2 = new double[taps2];
             _delayQ2 = new double[taps2];
         }
@@ -136,11 +204,39 @@ public class Channelizer
             _delayQ2 = Array.Empty<double>();
         }
 
-        // FM gain: scale atan2 output (radians) so ~5 kHz deviation maps to ~80% of s16le range.
-        // atan2 output for 5 kHz deviation at outputRate: 2*pi*5000/outputRate radians
-        // We want that to map to ~0.8, so: scale = 0.8 / (2*pi*5000/outputRate)
-        double typicalDeviation = 5000.0; // 5 kHz for NFM / P25
-        _fmScale = 0.8 * outputRate / (2.0 * Math.PI * typicalDeviation);
+        // Stage 3: the actual channel filter, and the only one sized for selectivity. A 2 kHz
+        // transition puts the adjacent 12.5 kHz channel well inside the stopband while leaving
+        // the wanted signal untouched.
+        if (channelCutoffHz > 0 && channelCutoffHz < outputRate / 2.0)
+        {
+            int taps3 = BlackmanTaps(outputRate, transitionHz: 2000, minimum: 31);
+            _filter3 = DesignLowPass(channelCutoffHz / outputRate, taps3);
+            _delayI3 = new double[taps3];
+            _delayQ3 = new double[taps3];
+        }
+        else
+        {
+            _filter3 = Array.Empty<double>();
+            _delayI3 = Array.Empty<double>();
+            _delayQ3 = Array.Empty<double>();
+        }
+
+        // FM gain: scale atan2 output (radians) so peak deviation maps to ~80% of s16le range.
+        // atan2 output at peak deviation is 2*pi*deviation/outputRate radians.
+        _fmScale = 0.8 * outputRate / (2.0 * Math.PI * deviationHz);
+    }
+
+    /// <summary>
+    /// Tap count for a Blackman-windowed FIR with the given transition width. The Blackman
+    /// window's transition is about 5.5/N of the sample rate for ~74 dB of stopband, so the
+    /// count follows from how sharp the filter has to be — not, as this used to assume, from
+    /// the decimation factor, which says nothing about the required selectivity.
+    /// </summary>
+    internal static int BlackmanTaps(double sampleRate, double transitionHz, int minimum)
+    {
+        if (transitionHz <= 0) return minimum | 1;
+        int taps = (int)Math.Ceiling(5.5 * sampleRate / transitionHz);
+        return Math.Max(taps, minimum) | 1; // odd, for a symmetric linear-phase filter
     }
 
     /// <summary>
@@ -161,14 +257,29 @@ public class Channelizer
             double rawI = (iq[i] - 127.5) * (1.0 / 127.5);
             double rawQ = (iq[i + 1] - 127.5) * (1.0 / 127.5);
 
-            // NCO frequency shift (complex multiply by e^(j*phase))
-            double cosP = Math.Cos(_ncoPhase);
-            double sinP = Math.Sin(_ncoPhase);
-            double sI = rawI * cosP - rawQ * sinP;
-            double sQ = rawI * sinP + rawQ * cosP;
-            _ncoPhase += _ncoPhaseInc;
-            if (_ncoPhase > Math.PI) _ncoPhase -= 2.0 * Math.PI;
-            else if (_ncoPhase < -Math.PI) _ncoPhase += 2.0 * Math.PI;
+            // Track and subtract the input DC offset. 127.5 is only the nominal centre; the
+            // real one moves with gain and temperature, and whatever is left of it is the
+            // dongle's centre spike.
+            _dcI += _dcAlpha * (rawI - _dcI);
+            _dcQ += _dcAlpha * (rawQ - _dcQ);
+            rawI -= _dcI;
+            rawQ -= _dcQ;
+
+            // NCO frequency shift: complex multiply by the current phasor, then advance the
+            // phasor by one fixed step. Identical to multiplying by e^(j*phase) each sample.
+            double sI = rawI * _ncoRe - rawQ * _ncoIm;
+            double sQ = rawI * _ncoIm + rawQ * _ncoRe;
+
+            double nextRe = _ncoRe * _ncoStepRe - _ncoIm * _ncoStepIm;
+            _ncoIm = _ncoRe * _ncoStepIm + _ncoIm * _ncoStepRe;
+            _ncoRe = nextRe;
+
+            if (++_ncoSinceNormalize >= NcoNormalizeInterval)
+            {
+                _ncoSinceNormalize = 0;
+                double mag = Math.Sqrt(_ncoRe * _ncoRe + _ncoIm * _ncoIm);
+                if (mag > 1e-12) { _ncoRe /= mag; _ncoIm /= mag; }
+            }
 
             // Stage 1: push into delay line
             _delayI1[_writePtr1] = sI;
@@ -218,17 +329,29 @@ public class Channelizer
                 fQ = fQ1;
             }
 
-            // Measure IQ power before demodulation (true RF signal strength)
-            double mag2 = fI * fI + fQ * fQ;
-            _iqPowerAccum += mag2;
-            _iqPowerCount++;
-            if (_iqPowerCount >= IqPowerWindow)
+            // Stage 3: the channel filter. No decimation here — it runs at the output rate,
+            // which is what makes a sharp filter affordable.
+            if (_filter3.Length > 0)
             {
-                double rmsMag = Math.Sqrt(_iqPowerAccum / _iqPowerCount);
-                _signalPowerDb = 20.0 * Math.Log10(rmsMag + 1e-12);
-                _iqPowerAccum = 0;
-                _iqPowerCount = 0;
+                _delayI3[_writePtr3] = fI;
+                _delayQ3[_writePtr3] = fQ;
+                _writePtr3 = (_writePtr3 + 1) % _filter3.Length;
+
+                fI = 0; fQ = 0;
+                int rp3 = _writePtr3;
+                for (int k = 0; k < _filter3.Length; k++)
+                {
+                    rp3--;
+                    if (rp3 < 0) rp3 += _filter3.Length;
+                    fI += _filter3[k] * _delayI3[rp3];
+                    fQ += _filter3[k] * _delayQ3[rp3];
+                }
             }
+
+            // Meter after the channel filter, so this reads in-channel power rather than
+            // everything the decimation chain let through.
+            _iqPowerAccum += fI * fI + fQ * fQ;
+            _iqPowerCount++;
 
             // Demodulate
             double sample;
@@ -245,10 +368,23 @@ public class Channelizer
                 double dot = fI * _prevI + fQ * _prevQ;
                 double cross = fQ * _prevI - fI * _prevQ;
                 double phaseD = Math.Atan2(cross, dot);
+                // Its mean is the carrier's offset from where we tuned; voice modulation
+                // averages out over the window, leaving the frequency error behind.
+                _phaseDiffAccum += phaseD;
                 sample = phaseD * _fmScale;
             }
             _prevI = fI;
             _prevQ = fQ;
+
+            if (_iqPowerCount >= IqPowerWindow)
+            {
+                double rmsMag = Math.Sqrt(_iqPowerAccum / _iqPowerCount);
+                _signalPowerDb = 20.0 * Math.Log10(rmsMag + 1e-12);
+                _frequencyOffsetHz = _phaseDiffAccum / _iqPowerCount * _outputRate / (2.0 * Math.PI);
+                _iqPowerAccum = 0;
+                _phaseDiffAccum = 0;
+                _iqPowerCount = 0;
+            }
 
             // Clamp and convert to s16le
             if (sample > 1.0) sample = 1.0;
@@ -267,12 +403,15 @@ public class Channelizer
     /// </summary>
     public void Reset()
     {
-        _ncoPhase = 0;
+        _ncoRe = 1.0; _ncoIm = 0; _ncoSinceNormalize = 0;
+        _dcI = 0; _dcQ = 0;
         Array.Clear(_delayI1); Array.Clear(_delayQ1); _writePtr1 = 0; _decimCount1 = 0;
         Array.Clear(_delayI2); Array.Clear(_delayQ2); _writePtr2 = 0; _decimCount2 = 0;
+        Array.Clear(_delayI3); Array.Clear(_delayQ3); _writePtr3 = 0;
         _prevI = 0; _prevQ = 0;
         _amDcEstimate = 0;
-        _iqPowerAccum = 0; _iqPowerCount = 0; _signalPowerDb = -90.0;
+        _iqPowerAccum = 0; _phaseDiffAccum = 0; _iqPowerCount = 0;
+        _signalPowerDb = -90.0; _frequencyOffsetHz = 0;
     }
 
     /// <summary>

--- a/server/OpenScanner.Server/DSP/SpectrumEstimator.cs
+++ b/server/OpenScanner.Server/DSP/SpectrumEstimator.cs
@@ -1,0 +1,171 @@
+using System.Numerics;
+
+namespace OpenScanner.Server.DSP;
+
+/// <summary>
+/// A power spectrum of one IQ buffer, plus the statistics carrier detection needs from it.
+///
+/// Levels are normalized so that a full-scale complex carrier reads 0 dB regardless of FFT
+/// size. That matters because the previous implementation subtracted an empirical constant
+/// ("Normalize (Empirical)", -20 dB) from raw FFT magnitudes, which made the squelch setting
+/// depend on the FFT size and on nothing the user could see.
+/// </summary>
+public sealed class SpectrumEstimate
+{
+    /// <summary>Linear power per bin, DC-centred (index <c>FftSize/2</c> is the tuner frequency).</summary>
+    private readonly double[] _power;
+
+    /// <summary>Number of bins.</summary>
+    public int FftSize => _power.Length;
+
+    /// <summary>Hz per bin.</summary>
+    public double BinWidthHz { get; }
+
+    /// <summary>
+    /// Median bin power, in dB. The median rather than the mean: a single strong carrier — or
+    /// the dongle's DC spike — drags a mean upward and suppresses the computed SNR of every
+    /// other channel, which is exactly when detection matters most.
+    /// </summary>
+    public double NoiseFloorDb { get; }
+
+    /// <summary>Median bin power, linear.</summary>
+    private readonly double _noiseFloor;
+
+    internal SpectrumEstimate(double[] power, double binWidthHz)
+    {
+        _power = power;
+        BinWidthHz = binWidthHz;
+
+        var sorted = (double[])power.Clone();
+        Array.Sort(sorted);
+        _noiseFloor = sorted[sorted.Length / 2];
+        NoiseFloorDb = ToDb(_noiseFloor);
+    }
+
+    /// <summary>Power spectrum in dB, DC-centred, for display.</summary>
+    public double[] ToDbArray()
+    {
+        var db = new double[_power.Length];
+        for (int i = 0; i < _power.Length; i++) db[i] = ToDb(_power[i]);
+        return db;
+    }
+
+    /// <summary>Bin index for a frequency offset from the tuner centre, or -1 if out of range.</summary>
+    public int BinForOffset(double offsetHz)
+    {
+        int bin = (int)Math.Round(offsetHz / BinWidthHz + _power.Length / 2.0);
+        return bin >= 0 && bin < _power.Length ? bin : -1;
+    }
+
+    /// <summary>How many bins each side of centre a channel of the given width occupies.</summary>
+    public int HalfWidthBins(double channelBandwidthHz) =>
+        Math.Max(0, (int)Math.Round(channelBandwidthHz / 2.0 / BinWidthHz));
+
+    /// <summary>
+    /// Signal-to-noise ratio of a channel, in dB: total power across the bins the channel
+    /// occupies, against the same number of bins' worth of noise floor.
+    ///
+    /// Integrating the channel rather than sampling its centre bin is what removes scalloping
+    /// loss — a carrier landing between bin centres splits its energy across neighbours and a
+    /// single-bin reading under-reports it by up to ~3.9 dB, which is the difference between
+    /// detecting a weak signal and walking past it.
+    /// </summary>
+    public double ChannelSnrDb(int centerBin, int halfWidthBins)
+    {
+        double sum = 0;
+        int counted = 0;
+        for (int b = centerBin - halfWidthBins; b <= centerBin + halfWidthBins; b++)
+        {
+            if (b < 0 || b >= _power.Length) continue;
+            sum += _power[b];
+            counted++;
+        }
+        if (counted == 0) return double.NegativeInfinity;
+        return ToDb(sum / (counted * _noiseFloor));
+    }
+
+    /// <summary>Absolute power of a channel, in dB relative to a full-scale carrier.</summary>
+    public double ChannelPowerDb(int centerBin, int halfWidthBins)
+    {
+        double sum = 0;
+        for (int b = centerBin - halfWidthBins; b <= centerBin + halfWidthBins; b++)
+        {
+            if (b < 0 || b >= _power.Length) continue;
+            sum += _power[b];
+        }
+        return ToDb(sum);
+    }
+
+    private static double ToDb(double linearPower) => 10.0 * Math.Log10(linearPower + 1e-20);
+}
+
+/// <summary>
+/// Welch-averaged power spectrum estimation over an RTL-SDR IQ buffer.
+/// </summary>
+public static class SpectrumEstimator
+{
+    /// <summary>Hann window coherent gain, needed to normalize levels back to full scale.</summary>
+    private const double HannCoherentGain = 0.5;
+
+    /// <summary>
+    /// Estimates the power spectrum by averaging FFTs of successive segments of the buffer.
+    ///
+    /// Averaging is the whole point. A single FFT of one segment has ~5.6 dB of standard
+    /// deviation per bin, so weak carriers disappear into the variance and the detector has to
+    /// be told to wait for repeat hits before believing anything. Averaging N segments divides
+    /// that variance by N: 16 segments is a 4x reduction in standard deviation, roughly 6 dB of
+    /// usable detection margin, recovered from data that was already in the buffer and being
+    /// thrown away — the previous code used 256 of the 32768 samples it was handed.
+    /// </summary>
+    /// <param name="iq">Unsigned 8-bit interleaved IQ, as rtl_sdr emits.</param>
+    /// <param name="length">Valid bytes in <paramref name="iq"/>.</param>
+    /// <param name="sampleRate">Capture rate in Hz.</param>
+    /// <param name="fftSize">Bins per FFT; must be a power of two.</param>
+    /// <param name="maxSegments">Upper bound on segments to average.</param>
+    /// <returns>The estimate, or null when the buffer is too short for even one segment.</returns>
+    public static SpectrumEstimate? Estimate(
+        byte[] iq, int length, int sampleRate, int fftSize = 1024, int maxSegments = 16)
+    {
+        int availableSamples = length / 2;
+        int segments = Math.Min(maxSegments, availableSamples / fftSize);
+        if (segments < 1) return null;
+
+        var window = BuildHannWindow(fftSize);
+        var accumulated = new double[fftSize];
+        var scratch = new Complex[fftSize];
+
+        // Normalizes an FFT bin so a full-scale complex carrier reads 1.0 (0 dB).
+        double scale = 1.0 / (fftSize * HannCoherentGain);
+
+        for (int s = 0; s < segments; s++)
+        {
+            int baseByte = s * fftSize * 2;
+            for (int i = 0; i < fftSize; i++)
+            {
+                double iSample = (iq[baseByte + i * 2] - 127.5) / 127.5;
+                double qSample = (iq[baseByte + i * 2 + 1] - 127.5) / 127.5;
+                scratch[i] = new Complex(iSample * window[i], qSample * window[i]);
+            }
+
+            FftSharp.FFT.Forward(scratch);
+
+            // Accumulate DC-centred, so the caller never has to think about FFT ordering.
+            for (int i = 0; i < fftSize; i++)
+            {
+                double magnitude = scratch[i].Magnitude * scale;
+                accumulated[(i + fftSize / 2) % fftSize] += magnitude * magnitude;
+            }
+        }
+
+        for (int i = 0; i < fftSize; i++) accumulated[i] /= segments;
+        return new SpectrumEstimate(accumulated, sampleRate / (double)fftSize);
+    }
+
+    private static double[] BuildHannWindow(int size)
+    {
+        var window = new double[size];
+        for (int i = 0; i < size; i++)
+            window[i] = 0.5 * (1 - Math.Cos(2 * Math.PI * i / (size - 1)));
+        return window;
+    }
+}

--- a/server/OpenScanner.Server/Decoders/AM.cs
+++ b/server/OpenScanner.Server/Decoders/AM.cs
@@ -15,7 +15,7 @@ public class AM : DSDBase
         int captureRate = 24000;
 
         // AM Pipeline with moderate squelch and increased gain for better signal handling
-        return $"{PlatformTools.Stdbuf("-o0")}{PlatformTools.RtlFm} -f {channel.Frequency}M -M am -s {captureRate} -r {captureRate} -g 42 -p 0 -l 50 -t 30 - | {PlatformTools.Ffmpeg} -f s16le -ar {captureRate} -ac 1 -i - -af 'highpass=f=300,lowpass=f=4000,volume=5.0' -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
+        return $"{PlatformTools.Stdbuf("-o0")}{PlatformTools.RtlFm} -f {channel.Frequency}M -M am -s {captureRate} -r {captureRate} {Tuning.RtlFmArgs()} -l 50 -t 30 - |{PlatformTools.Ffmpeg} -f s16le -ar {captureRate} -ac 1 -i - -af 'highpass=f=300,lowpass=f=4000,volume=5.0' -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }
 
     protected override Task OnStarted(CancellationToken token)

--- a/server/OpenScanner.Server/Decoders/DMR.cs
+++ b/server/OpenScanner.Server/Decoders/DMR.cs
@@ -32,7 +32,10 @@ public class DMR : DSDBase
         string rtlMode = "fm";
         string dsdArgs = "-fs -ma -V 1"; // DMR TDMA Simplex, auto modulation, slot 1
 
-        string source = InputSource ?? $"{PlatformTools.RtlFm} -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 45 -p 0 -M {rtlMode} -";
+        // -l 0: no squelch, for the same reason as P25 — dsd-fme needs an unbroken sample
+        // stream to hold TDMA sync. This was already implicit (rtl_fm defaults to 0); it is
+        // now explicit so it cannot be "tidied" back into a squelched pipeline.
+        string source = InputSource ?? $"{PlatformTools.RtlFm} -f {channel.Frequency}M -s {captureRate} -r {outputRate} {Tuning.RtlFmArgs()} -l 0 -M {rtlMode} -";
 
         return $"{PlatformTools.Stdbuf("-o0")}{source} | {PlatformTools.Stdbuf("-i0 -o0")}{PlatformTools.DsdFme} {dsdArgs} -i - -o - -s {outputRate} | {PlatformTools.Stdbuf("-o0")}{PlatformTools.Ffmpeg} -f s16le -ar {dsdOutputRate} -ac 2 -probesize 32 -analyzeduration 0 -i - -af volume=2.0 -f s16le -ar 48000 -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }

--- a/server/OpenScanner.Server/Decoders/DSDBase.cs
+++ b/server/OpenScanner.Server/Decoders/DSDBase.cs
@@ -21,6 +21,9 @@ public abstract class DSDBase : IDecoder
     public string? InputSource { get; set; }
 
     /// <inheritdoc />
+    public SdrTuning Tuning { get; set; } = new();
+
+    /// <inheritdoc />
     public bool CanFeedInput => InputSource != null;
 
     protected DSDBase(ILogger logger)

--- a/server/OpenScanner.Server/Decoders/NFM.cs
+++ b/server/OpenScanner.Server/Decoders/NFM.cs
@@ -16,10 +16,11 @@ public class NFM : DSDBase
     {
         int captureRate = 48000;
         int outputRate = 48000;
-        
-        // NFM decoder with optimized squelch and gain settings
+
+        // Analog voice keeps rtl_fm's squelch: it saves CPU and there is no decoder downstream
+        // whose sync it could break.
         // Simplified pipeline: no parallel MDC processing to avoid audio artifacts
-        return $"{PlatformTools.Stdbuf("-o0")}{PlatformTools.RtlFm} -f {channel.Frequency}M -M fm -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -";
+        return $"{PlatformTools.Stdbuf("-o0")}{PlatformTools.RtlFm} -f {channel.Frequency}M -M fm -s {captureRate} -r {outputRate} {Tuning.RtlFmArgs()} -l 50 -t 30 -";
     }
 
     protected override Task OnStarted(CancellationToken token)

--- a/server/OpenScanner.Server/Decoders/P25.cs
+++ b/server/OpenScanner.Server/Decoders/P25.cs
@@ -30,7 +30,10 @@ public class P25 : DSDBase
         string rtlMode = "fm";
         string dsdArgs = "-f1"; // P25 Phase 1
 
-        string source = InputSource ?? $"{PlatformTools.RtlFm} -f {channel.Frequency}M -s {captureRate} -r {outputRate} -g 42 -p 0 -l 50 -t 30 -M {rtlMode} -";
+        // -l 0: no squelch. rtl_fm's squelch gates the sample stream, and dsd-fme needs a
+        // continuous one to hold C4FM symbol sync — chopping it costs the opening syllables of
+        // every call and breaks marginal signals outright.
+        string source = InputSource ?? $"{PlatformTools.RtlFm} -f {channel.Frequency}M -s {captureRate} -r {outputRate} {Tuning.RtlFmArgs()} -l 0 -M {rtlMode} -";
 
         return $"{PlatformTools.Stdbuf("-o0")}{source} | {PlatformTools.Stdbuf("-i0 -o0")}{PlatformTools.DsdFme} {dsdArgs} -i - -o - -s {outputRate} | {PlatformTools.Stdbuf("-o0")}{PlatformTools.Ffmpeg} -f s16le -ar {dsdOutputRate} -ac 1 -probesize 32 -analyzeduration 0 -i - -f s16le -ar {outputRate} -ac 1 -fflags nobuffer -flags low_delay -flush_packets 1 - -loglevel quiet";
     }

--- a/server/OpenScanner.Server/Devices/ChannelPipeline.cs
+++ b/server/OpenScanner.Server/Devices/ChannelPipeline.cs
@@ -37,10 +37,17 @@ public class ChannelPipeline : IDisposable
     private bool _isActive;
     private DateTime _lastActivityTime = DateTime.MinValue;
 
-    // Analog squelch uses pre-demod IQ power from the channelizer.
-    // The threshold is calibrated against the IQ magnitude dB scale where
-    // noise floor sits around -35 to -45 dB and a carrier reads -5 to -15 dB.
-    private const double AnalogSquelchThresholdDb = -28.0;
+    // Analog squelch runs off the channelizer's in-channel power (post channel filter,
+    // pre-demodulation), measured as SNR against a self-calibrating noise floor. The
+    // configured threshold arrives via the constructor; before 2026 it was stored and then
+    // ignored in favour of a hardcoded absolute constant, so the squelch setting had no
+    // effect in parallel FastScan at all — and an absolute threshold could not have worked
+    // across gain settings anyway.
+    private double? _noiseFloorDb;
+    // Adapt quickly while the channel is quiet, barely at all while a signal is up, so a long
+    // transmission cannot drag its own floor up and squelch itself off.
+    private const double NoiseFloorAttackQuiet = 0.05;
+    private const double NoiseFloorAttackActive = 0.002;
 
     // Digital channels are marked inactive after this long without voice audio.
     private const double DigitalHangSeconds = 2.0;
@@ -64,8 +71,15 @@ public class ChannelPipeline : IDisposable
     /// <summary>Whether this channel currently has active audio/voice.</summary>
     public bool IsActive => _isActive;
 
-    /// <summary>Latest measured signal level in dB (IQ power before demod, updated every ~100ms).</summary>
+    /// <summary>Latest measured signal level in dB (in-channel power before demod, updated every ~100ms).</summary>
     public double SignalLevelDb => _channelizer.SignalPowerDb;
+
+    /// <summary>
+    /// Measured frequency error of the received carrier, in Hz. Over a transmitter known to be
+    /// on-frequency this is the dongle's crystal error, which is what makes ppm calibratable
+    /// from the UI instead of guessed. Null until a signal has been present.
+    /// </summary>
+    public double? MeasuredOffsetHz => _isActive ? _channelizer.FrequencyOffsetHz : null;
 
     /// <summary>The channel this pipeline is assigned to.</summary>
     public Channel Channel => _channel;
@@ -79,7 +93,8 @@ public class ChannelPipeline : IDisposable
     /// <param name="centerFreqMhz">SDR center frequency in MHz</param>
     /// <param name="decoderFactory">Factory for creating decoders</param>
     /// <param name="logger">Logger instance</param>
-    /// <param name="squelchDb">Squelch threshold in dB (for analog modes)</param>
+    /// <param name="loggerFactory">Factory for per-channel sub-loggers (MDC1200 decoder)</param>
+    /// <param name="squelchDb">Squelch threshold, in dB of SNR above the noise floor (analog modes)</param>
     public ChannelPipeline(
         Channel channel,
         int inputSampleRate,
@@ -100,7 +115,9 @@ public class ChannelPipeline : IDisposable
         double offsetHz = (channel.Frequency - centerFreqMhz) * 1e6;
 
         bool isAm = channel.Mode?.ToUpper() == "AM";
-        _channelizer = new Channelizer(inputSampleRate, outputSampleRate, offsetHz, isAm);
+        var (channelCutoffHz, deviationHz) = FilterProfile(channel.Mode);
+        _channelizer = new Channelizer(
+            inputSampleRate, outputSampleRate, offsetHz, isAm, channelCutoffHz, deviationHz);
 
         // Pre-allocate audio buffer (generous size for typical IQ chunk of 65536 bytes)
         _audioBuffer = new byte[_channelizer.MaxOutputBytes(65536 * 2)];
@@ -176,7 +193,11 @@ public class ChannelPipeline : IDisposable
         {
             // Analog mode: channelizer output IS the audio.
             // Use pre-demod IQ power for squelch (post-demod FM noise is always loud).
-            bool hasSignal = _channelizer.SignalPowerDb > AnalogSquelchThresholdDb;
+            double powerDb = _channelizer.SignalPowerDb;
+            _noiseFloorDb ??= powerDb;
+            bool hasSignal = powerDb - _noiseFloorDb.Value > _squelchDb;
+            _noiseFloorDb += (hasSignal ? NoiseFloorAttackActive : NoiseFloorAttackQuiet)
+                             * (powerDb - _noiseFloorDb.Value);
 
             if (hasSignal)
             {
@@ -235,6 +256,25 @@ public class ChannelPipeline : IDisposable
         }
         return false;
     }
+
+    /// <summary>
+    /// Channel filter cutoff (one-sided, Hz) and peak transmitter deviation for a mode.
+    ///
+    /// The digital modes are pinned by standard: P25 and DMR are 12.5 kHz channels, so 6.25 kHz
+    /// of cutoff, with C4FM peaking at 1800 Hz and DMR 4FSK at 1944 Hz. Analog FM is deliberately
+    /// left at 12.5 kHz / 5 kHz rather than assuming a narrowbanded system — over-narrowing a
+    /// 25 kHz channel would clip the audio, which is a worse failure than passing extra noise.
+    /// Anything unrecognised gets no channel filter, preserving the pre-2026 behaviour.
+    /// </summary>
+    private static (double CutoffHz, double DeviationHz) FilterProfile(string? mode) =>
+        mode?.ToUpperInvariant() switch
+        {
+            "P25" => (6250, 1800),
+            "DMR" => (6250, 1944),
+            "NFM" or "FM" => (12500, 5000),
+            "AM" => (5000, 5000),
+            _ => (0, 5000),
+        };
 
     /// <summary>
     /// Whether this mode requires a decoder process (dsd-fme).

--- a/server/OpenScanner.Server/Devices/MockRadioSource.cs
+++ b/server/OpenScanner.Server/Devices/MockRadioSource.cs
@@ -130,6 +130,10 @@ public class MockRadioSource : BackgroundService, IRadioSource
 
     public void SetSquelch(double db) => UpdateState(_state with { Squelch = db });
 
+    public void SetGain(double db) => UpdateState(_state with { Gain = db });
+
+    public void SetPpm(double ppm) => UpdateState(_state with { Ppm = ppm });
+
     public void Start()
     {
         if (_isRunning) return;

--- a/server/OpenScanner.Server/Devices/MockRadioSource.cs
+++ b/server/OpenScanner.Server/Devices/MockRadioSource.cs
@@ -1,3 +1,4 @@
+using OpenScanner.Server.Audio;
 using OpenScanner.Server.Interfaces;
 using OpenScanner.Server.Models;
 using OpenScanner.Server.Services;
@@ -31,7 +32,7 @@ public class MockRadioSource : BackgroundService, IRadioSource
 
     public event Action<ScannerState>? OnStateChanged;
     public event Action<CallLog>? OnNewLog;
-    public event Action<byte[]>? OnAudio;
+    public event Action<AudioChunk>? OnAudio;
     public event Action<RadioEvent>? OnNewEvent;
 
     private ScannerState _state = new("IDLE", 0);
@@ -370,7 +371,7 @@ public class MockRadioSource : BackgroundService, IRadioSource
 
     private void HandleAudioChunk(byte[] chunk)
     {
-        OnAudio?.Invoke(chunk);
+        OnAudio?.Invoke(AudioChunk.Mono48k(chunk));
         _recordingService.ProcessAudio(chunk);
         _toneDetector.ProcessAudio(chunk);
         _mdc.ProcessAudio(chunk);

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Globalization;
 using System.Numerics;
 using OpenScanner.Server.Audio;
 using OpenScanner.Server.DSP;
@@ -52,6 +53,14 @@ public class RtlDevice : BackgroundService, IRadioSource
     // the tone and the voice that follows stay one recording.
     private const int ActivityTimeoutMs = 2000;
     private const int ToneHoldMs = 6000;
+
+    /// <summary>
+    /// Default squelch, in dB of SNR above the measured noise floor. Squelch used to be an
+    /// absolute dB level, which meant it silently changed meaning with the gain setting and
+    /// with the FFT size. It is not persisted, so there is no stored value on the old scale
+    /// to migrate.
+    /// </summary>
+    private const double DefaultSquelchSnrDb = 10.0;
 
     private DateTime _recordingLockoutUntil = DateTime.MinValue;
     private CancellationTokenSource? _scanCts;
@@ -120,8 +129,16 @@ public class RtlDevice : BackgroundService, IRadioSource
         _recordingService = recordingService;
         _channelService = channelService;
         _state = new ScannerState("IDLE", 0);
-        
-        _gps.OnGpsUpdate += (data) => 
+
+        // Restore the persisted SDR tuning. Gain: dB, or 0/absent = AUTO (tuner AGC).
+        // Ppm: crystal error correction; 0/absent = uncorrected.
+        _state = _state with
+        {
+            Gain = ReadNumericSetting("SdrGain"),
+            Ppm = ReadNumericSetting("SdrPpm"),
+        };
+
+        _gps.OnGpsUpdate += (data) =>
         {
             UpdateState(_state with { Gps = data });
             _channelService.CheckGeoRefresh(data.Lat, data.Lon);
@@ -194,8 +211,57 @@ public class RtlDevice : BackgroundService, IRadioSource
     public void SetSquelch(double db)
     {
         UpdateState(_state with { Squelch = db });
-        _logger.LogInformation($"Squelch set to {db}dB");
+        _logger.LogInformation($"Squelch set to {db}dB SNR");
     }
+
+    /// <inheritdoc />
+    public void SetGain(double db)
+    {
+        UpdateState(_state with { Gain = db });
+        _ = _db.SetSettingAsync("SdrGain", Num(db));
+        _logger.LogInformation($"SDR gain set to {(db == 0 ? "AUTO (tuner AGC)" : $"{db}dB")}");
+        RestartScanToApplyTuning();
+    }
+
+    /// <inheritdoc />
+    public void SetPpm(double ppm)
+    {
+        UpdateState(_state with { Ppm = ppm });
+        _ = _db.SetSettingAsync("SdrPpm", Num(ppm));
+        _logger.LogInformation($"SDR frequency correction set to {ppm} ppm");
+        RestartScanToApplyTuning();
+    }
+
+    /// <summary>
+    /// Gain and ppm are baked into the rtl_sdr/rtl_fm arguments at launch, so a running
+    /// capture has to be restarted to pick up a change (mirrors <see cref="ReloadChannels"/>).
+    /// </summary>
+    private void RestartScanToApplyTuning()
+    {
+        if (_state.Status != "SCANNING") return;
+        StopScanning();
+        Task.Delay(250).ContinueWith(_ => StartScanning());
+    }
+
+    private double? ReadNumericSetting(string key)
+    {
+        var raw = _db.GetSettingAsync(key).GetAwaiter().GetResult();
+        return double.TryParse(raw, NumberStyles.Any, CultureInfo.InvariantCulture, out var value)
+            ? value
+            : null;
+    }
+
+    /// <summary>Formats a number for a command-line argument, immune to the host locale.</summary>
+    private static string Num(double value) => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The rtl_sdr/rtl_fm tuning arguments shared by every capture: tuner gain and crystal
+    /// error correction. Both tools spell these the same way and both treat "-g 0" as AUTO.
+    /// </summary>
+    private string TuningArgs() => $"-g {Num(_state.Gain ?? 0)} -p {Num(_state.Ppm ?? 0)}";
+
+    /// <summary>The configured front-end settings, for handing to a decoder's own rtl_fm.</summary>
+    private SdrTuning CurrentTuning() => new(_state.Gain ?? 0, _state.Ppm ?? 0);
 
     /// <inheritdoc />
     public void Start()
@@ -249,7 +315,9 @@ public class RtlDevice : BackgroundService, IRadioSource
         StopScanning();
         StopDecoding();
 
-        UpdateState(_state with { Status = "DEBUG", CurrentFrequency = freq, ManualHoldFrequency = freq, RfSpectrum = null, Gain = targetGain });
+        // Deliberately does not touch _state.Gain: that field is the *configured* tuner gain
+        // and drives every capture's -g. The debug sweep's gain is a transient argument.
+        UpdateState(_state with { Status = "DEBUG", CurrentFrequency = freq, ManualHoldFrequency = freq, RfSpectrum = null });
 
         _scanCts = new CancellationTokenSource();
         var token = _scanCts.Token;
@@ -273,7 +341,9 @@ public class RtlDevice : BackgroundService, IRadioSource
 
         int sampleRate = 2400000; 
         var binPath = PlatformTools.RtlSdr;
-        var args = $"-f {freq}M -s {sampleRate} -g {gain} -b 1 -";
+        // Debug spectrum takes an explicit gain (it sweeps to find one), but still needs the
+        // configured ppm or the displayed spectrum sits offset from the real frequencies.
+        var args = $"-f {freq}M -s {sampleRate} -g {Num(gain)} -p {Num(_state.Ppm ?? 0)} -b 1 -";
 
         _logger.LogInformation($"Debug Spectrum HW: {binPath} {args}");
 
@@ -372,8 +442,7 @@ public class RtlDevice : BackgroundService, IRadioSource
             CurrentChannel = null, 
             SignalStrength = 0,
             ManualHoldFrequency = null,
-            ParallelChannels = null,
-            Gain = null
+            ParallelChannels = null
         });
         
         // Small delay to let hardware settle before restarting the scan
@@ -622,7 +691,7 @@ public class RtlDevice : BackgroundService, IRadioSource
 
             var pipeline = new ChannelPipeline(
                 ch, sampleRate, outputRate, bank.CenterFrequency,
-                _decoderFactory, _logger, _loggerFactory, _state.Squelch ?? -55.0);
+                _decoderFactory, _logger, _loggerFactory, _state.Squelch ?? DefaultSquelchSnrDb);
 
             // Wire up events
             pipeline.OnAudio += HandleParallelAudio;
@@ -672,7 +741,7 @@ public class RtlDevice : BackgroundService, IRadioSource
         await Task.Delay(250, token); // USB settle time
 
         var binPath = PlatformTools.RtlSdr;
-        var args = $"-f {bank.CenterFrequency:F3}M -s {sampleRate} -g 20 -b 1 -";
+        var args = $"-f {bank.CenterFrequency:F3}M -s {sampleRate} {TuningArgs()} -b 1 -";
         _logger.LogInformation($"Parallel Scanner: {binPath} {args}");
 
         var psi = new ProcessStartInfo(binPath, args)
@@ -810,46 +879,14 @@ public class RtlDevice : BackgroundService, IRadioSource
     /// <summary>
     /// FFT spectrum calculation for UI display only (no carrier detection in parallel mode).
     /// </summary>
-    private void ProcessSamplesForSpectrum(byte[] buffer, int length, double centerFreq, int sampleRate, int fftSize = 256)
+    private void ProcessSamplesForSpectrum(byte[] buffer, int length, double centerFreq, int sampleRate, int fftSize = DetectionFftSize)
     {
-        if (length < fftSize * 2) return;
+        // Fewer segments than the detection path: this only feeds the waterfall, and it runs at
+        // ~50 Hz on top of every channel pipeline's own filtering.
+        var spectrum = SpectrumEstimator.Estimate(buffer, length, sampleRate, fftSize, maxSegments: 4);
+        if (spectrum == null) return;
 
-        int bytesNeeded = fftSize * 2;
-        int offset = length - bytesNeeded;
-        if (offset < 0) return;
-
-        var complexSamples = new Complex[fftSize];
-        for (int i = 0; i < fftSize; i++)
-        {
-            double iSample = (buffer[offset + i * 2] - 127.5) / 127.5;
-            double qSample = (buffer[offset + i * 2 + 1] - 127.5) / 127.5;
-            double window = 0.5 * (1 - Math.Cos(2 * Math.PI * i / (fftSize - 1)));
-            complexSamples[i] = new Complex(iSample * window, qSample * window);
-        }
-
-        FftSharp.FFT.Forward(complexSamples);
-
-        var fftDb = new double[fftSize];
-        for (int i = 0; i < fftSize; i++)
-        {
-            var power = complexSamples[i].Magnitude * complexSamples[i].Magnitude;
-            fftDb[i] = 10 * Math.Log10(power + 1e-9);
-        }
-
-        var shiftedDb = new double[fftSize];
-        Array.Copy(fftDb, fftSize / 2, shiftedDb, 0, fftSize / 2);
-        Array.Copy(fftDb, 0, shiftedDb, fftSize / 2, fftSize / 2);
-
-        for (int i = 0; i < fftSize; i++) shiftedDb[i] -= 20;
-
-        var spectrumPoints = new SpectrumPoint[fftSize];
-        for (int i = 0; i < fftSize; i++)
-        {
-            double freqOffset = (i - fftSize / 2.0) * (sampleRate / (double)fftSize);
-            spectrumPoints[i] = new SpectrumPoint((centerFreq * 1000000 + freqOffset) / 1000000, shiftedDb[i]);
-        }
-
-        UpdateState(_state with { RfSpectrum = spectrumPoints });
+        PublishSpectrum(spectrum, centerFreq, sampleRate);
     }
 
     /// <summary>
@@ -1049,7 +1086,8 @@ public class RtlDevice : BackgroundService, IRadioSource
             SourceID: null,
             TargetID: null,
             SpeakerChain: null,
-            CurrentTone: _parallelLastTones.GetValueOrDefault(p.Channel.Frequency)
+            CurrentTone: _parallelLastTones.GetValueOrDefault(p.Channel.Frequency),
+            MeasuredOffsetHz: p.MeasuredOffsetHz
         )).ToArray();
 
         UpdateState(_state with { ParallelChannels = states });
@@ -1064,7 +1102,7 @@ public class RtlDevice : BackgroundService, IRadioSource
         int scanRate = 1024000; 
         var binPath = PlatformTools.RtlSdr;
         // -b 1: Use 1 buffer to reduce latency and improve startup reliability
-        var args = $"-f {centerFreqMhz:F3}M -s {scanRate} -g 20 -b 1 -";
+        var args = $"-f {centerFreqMhz:F3}M -s {scanRate} {TuningArgs()} -b 1 -";
 
         _logger.LogInformation($"Starting Scanner: {centerFreqMhz:F3} MHz (Cmd: {binPath} {args})");
 
@@ -1190,6 +1228,38 @@ public class RtlDevice : BackgroundService, IRadioSource
         }
     }
 
+    /// <summary>
+    /// Shifts a proposed tuner centre until no channel sits within <see cref="DcGuardMHz"/> of
+    /// it, while keeping every channel inside the capture window. Returns the original centre
+    /// if no clear offset exists — the window is the harder constraint, and losing one channel
+    /// to the DC spike beats losing several off the edge.
+    /// </summary>
+    internal static double NudgeOffChannels(double center, List<Channel> sorted, double spreadMHz)
+    {
+        // How much the centre may move before a channel falls outside the 2.4 MHz window.
+        double slack = (2.4 - spreadMHz) / 2.0;
+        if (slack <= 0) return center;
+
+        bool IsClear(double candidate) =>
+            sorted.All(c => Math.Abs(c.Frequency - candidate) > DcGuardMHz);
+
+        if (IsClear(center)) return center;
+
+        // Try progressively larger nudges either side, staying inside the window.
+        for (double step = DcGuardMHz; step <= slack; step += DcGuardMHz)
+        {
+            if (IsClear(center + step)) return center + step;
+            if (IsClear(center - step)) return center - step;
+        }
+        return center;
+    }
+
+    /// <summary>
+    /// Keep-out radius around the tuner centre, in MHz. One detection FFT bin at the 1.024 MHz
+    /// scan rate is 1 kHz, so 10 kHz is comfortably clear of the residual DC bin.
+    /// </summary>
+    private const double DcGuardMHz = 0.01;
+
     private List<double> CalculateScanCenters(List<Channel> channels)
     {
         if (!channels.Any()) return new List<double>();
@@ -1251,13 +1321,14 @@ public class RtlDevice : BackgroundService, IRadioSource
         if (spread <= 2.4 + 1e-9)
         {
             // FastScan: all channels fit in a single 2.4 MHz SDR window — no hopping needed.
-            // For single-channel, offset center by +0.25 MHz so the signal doesn't land on the
-            // DC spike bin (bin fftSize/2). Multi-channel midpoint is already offset from DC.
-            double center;
-            if (sorted.Count == 1)
-                center = sorted[0].Frequency + 0.25;
-            else
-                center = (minFreq + maxFreq) / 2.0;
+            // The centre must not land on a channel, or that channel sits on the DC spike and
+            // is the one channel the scanner can never hear. A single channel is offset by a
+            // fixed 0.25 MHz; the multi-channel midpoint was previously assumed to be clear of
+            // any channel, which is false whenever the set is symmetric about one of its own
+            // members (three channels evenly spaced, say).
+            double center = sorted.Count == 1
+                ? sorted[0].Frequency + 0.25
+                : NudgeOffChannels((minFreq + maxFreq) / 2.0, sorted, spread);
 
             _logger.LogInformation($"ScanBank FastScan: {minFreq:F3}-{maxFreq:F3} MHz (spread: {spread:F2} MHz)");
             banks.Add(new ScanBank
@@ -1290,70 +1361,45 @@ public class RtlDevice : BackgroundService, IRadioSource
         return banks;
     }
 
+    /// <summary>
+    /// Bins per detection FFT. At the 1.024 MHz scan rate this is 1 kHz per bin, fine enough
+    /// to resolve a 12.5 kHz channel across ~13 bins rather than guessing from one.
+    /// </summary>
+    private const int DetectionFftSize = 1024;
+
+    /// <summary>Segments averaged per buffer. See <see cref="SpectrumEstimator.Estimate"/>.</summary>
+    private const int DetectionSegments = 16;
+
     private void ProcessSamples(byte[] buffer, int length, double centerFreq, int sampleRate)
     {
-        if (length < 1024) return;
-        
-        // Use last 512 samples (1024 bytes) for lowest latency
-        int fftSize = 256;
-        int bytesNeeded = fftSize * 2;
-        int offset = length - bytesNeeded;
-        if (offset < 0) return;
+        var spectrum = SpectrumEstimator.Estimate(
+            buffer, length, sampleRate, DetectionFftSize, DetectionSegments);
+        if (spectrum == null) return;
 
-        var complexSamples = new Complex[fftSize];
-        for (int i = 0; i < fftSize; i++)
-        {
-            // Normalize 0-255 to -1.0 to 1.0
-            double iSample = (buffer[offset + i * 2] - 127.5) / 127.5;
-            double qSample = (buffer[offset + i * 2 + 1] - 127.5) / 127.5;
-            
-            // Hanning Window
-            double window = 0.5 * (1 - Math.Cos(2 * Math.PI * i / (fftSize - 1)));
-            complexSamples[i] = new Complex(iSample * window, qSample * window);
-        }
-
-        // FFT
-        FftSharp.FFT.Forward(complexSamples);
-        
-        // Power in dB
-        var fftDb = new double[fftSize];
-        for (int i = 0; i < fftSize; i++)
-        {
-            var power = complexSamples[i].Magnitude * complexSamples[i].Magnitude;
-            fftDb[i] = 10 * Math.Log10(power + 1e-9);
-        }
-
-        // FFT Shift (Swap halves)
-        var shiftedDb = new double[fftSize];
-        Array.Copy(fftDb, fftSize / 2, shiftedDb, 0, fftSize / 2);
-        Array.Copy(fftDb, 0, shiftedDb, fftSize / 2, fftSize / 2);
-
-        // Normalize (Empirical)
-        for(int i=0; i<fftSize; i++) shiftedDb[i] -= 20;
-
-        // Map to SpectrumPoint objects
-        var spectrumPoints = new SpectrumPoint[fftSize];
-        for (int i = 0; i < fftSize; i++)
-        {
-            double freqOffset = (i - fftSize / 2.0) * (sampleRate / (double)fftSize);
-            spectrumPoints[i] = new SpectrumPoint((centerFreq * 1000000 + freqOffset) / 1000000, shiftedDb[i]);
-        }
-
-        UpdateState(_state with { RfSpectrum = spectrumPoints });
-
-        // Check Channels
-        CheckChannels(shiftedDb, centerFreq, sampleRate, fftSize);
+        PublishSpectrum(spectrum, centerFreq, sampleRate);
+        CheckChannels(spectrum, centerFreq);
     }
 
-    private void CheckChannels(double[] fftDb, double centerFreq, int sampleRate, int fftSize)
+    /// <summary>Pushes a spectrum estimate to the UI waterfall.</summary>
+    private void PublishSpectrum(SpectrumEstimate spectrum, double centerFreq, int sampleRate)
+    {
+        var db = spectrum.ToDbArray();
+        var spectrumPoints = new SpectrumPoint[db.Length];
+        for (int i = 0; i < db.Length; i++)
+        {
+            double freqOffset = (i - db.Length / 2.0) * spectrum.BinWidthHz;
+            spectrumPoints[i] = new SpectrumPoint((centerFreq * 1e6 + freqOffset) / 1e6, db[i]);
+        }
+        UpdateState(_state with { RfSpectrum = spectrumPoints });
+    }
+
+        // Normalize (Empirical)
+    private void CheckChannels(SpectrumEstimate spectrum, double centerFreq)
     {
         Channel? bestChannel = null;
+        double bestSnr = double.NegativeInfinity;
         double maxDetectedDb = -100;
-        
-        // Calculate average noise floor
-        double sum = 0;
-        for (int i = 0; i < fftSize; i++) sum += fftDb[i];
-        double avgNoise = sum / fftSize;
+        double squelchSnr = _state.Squelch ?? DefaultSquelchSnrDb;
 
         // Clean up old lockouts to prevent memory leak
         if (!_channelLockouts.IsEmpty)
@@ -1382,55 +1428,43 @@ public class RtlDevice : BackgroundService, IRadioSource
                 continue;
             }
 
-            double freqDiff = (channel.Frequency - centerFreq) * 1000000;
-            int binIndex = (int)((freqDiff / sampleRate) * fftSize + fftSize / 2.0);
+            int binIndex = spectrum.BinForOffset((channel.Frequency - centerFreq) * 1e6);
+            if (binIndex < 0) continue;
 
-            if (binIndex >= 0 && binIndex < fftSize)
+            // The residual DC spike is a single bin wide once the capture has been DC-blocked,
+            // so only that bin is skipped. The old guard blanked three bins, and at the FFT
+            // size in use that blinded a ~28 kHz window around the tuner centre — enough to
+            // hide a channel outright when a FastScan bank happened to centre on one.
+            if (binIndex == spectrum.FftSize / 2)
             {
-                // DC Filter: Ignore center 3 bins (approx 24kHz spread)
-                int centerBin = fftSize / 2;
-                if (binIndex >= centerBin - 1 && binIndex <= centerBin + 1)
-                {
-                    // If we have a strong signal in the center bin, warn that it might be getting filtered
-                    if (fftDb[binIndex] > -40) 
-                    {
-                        _logger.LogDebug($"Strong signal detected in center bin ({channel.Frequency} MHz). DC filter is rejecting it.");
-                    }
-                    continue;
-                }
+                _logger.LogDebug(
+                    $"{channel.AlphaTag} ({channel.Frequency} MHz) sits on the tuner centre; " +
+                    "skipping its DC bin.");
+                continue;
+            }
 
-                double db = fftDb[binIndex];
-                if (db > maxDetectedDb) maxDetectedDb = db;
+            int halfWidth = spectrum.HalfWidthBins(ChannelBandwidthHz(channel.Mode));
+            double snr = spectrum.ChannelSnrDb(binIndex, halfWidth);
+            double db = spectrum.ChannelPowerDb(binIndex, halfWidth);
+            if (db > maxDetectedDb) maxDetectedDb = db;
 
-                // SNR Requirement: Signal must be at least 15dB above average noise
-                // AND above absolute threshold
-                double snr = db - avgNoise;
-                double threshold = _state.Squelch ?? -55;
+            if (snr <= squelchSnr)
+            {
+                _channelHits[channel.Frequency] = 0;
+                continue;
+            }
 
-                if (db > threshold)
-                {
-                    if (snr > 15)
-                    {
-                        _channelHits[channel.Frequency] = _channelHits.GetValueOrDefault(channel.Frequency, 0) + 1;
-                        
-                        // Instant lock for strong signals (>20dB SNR), otherwise require 3 hits
-                        int hitsNeeded = snr > 20 ? 1 : 3;
-                        
-                        if (_channelHits[channel.Frequency] >= hitsNeeded && (bestChannel == null || db > maxDetectedDb))
-                        {
-                            bestChannel = channel;
-                        }
-                    }
-                    else
-                    {
-                        _channelHits[channel.Frequency] = 0;
-                        _logger.LogDebug($"Signal detected on {channel.AlphaTag} but SNR too low: {snr:F1}dB (Need 15dB)");
-                    }
-                }
-                else
-                {
-                    _channelHits[channel.Frequency] = 0;
-                }
+            _channelHits[channel.Frequency] = _channelHits.GetValueOrDefault(channel.Frequency, 0) + 1;
+
+            // Averaging 16 segments cut the per-bin variance by 16x, so a single reading is
+            // now trustworthy on its own for anything comfortably above threshold. Only
+            // marginal signals still wait for a second look.
+            int hitsNeeded = snr > squelchSnr + 10 ? 1 : 2;
+
+            if (_channelHits[channel.Frequency] >= hitsNeeded && snr > bestSnr)
+            {
+                bestSnr = snr;
+                bestChannel = channel;
             }
         }
 
@@ -1440,12 +1474,27 @@ public class RtlDevice : BackgroundService, IRadioSource
 
         if (bestChannel != null)
         {
-            _logger.LogInformation($"Detected carrier on {bestChannel.AlphaTag} (SNR: {(maxDetectedDb - avgNoise):F1}dB)");
+            _logger.LogInformation(
+                $"Detected carrier on {bestChannel.AlphaTag} (SNR: {bestSnr:F1}dB over a " +
+                $"{spectrum.NoiseFloorDb:F1}dB floor)");
             StopScanning();
             _recordingLockoutUntil = DateTime.UtcNow.AddSeconds(3);
             LockOn(bestChannel);
         }
     }
+
+    /// <summary>
+    /// Occupied bandwidth of a channel by mode, used to decide how many FFT bins its energy
+    /// is spread across. Analog FM stays at 25 kHz rather than assuming a narrowbanded system:
+    /// integrating a slightly too-wide window costs a little noise, whereas integrating too
+    /// narrow a one misses signal.
+    /// </summary>
+    private static double ChannelBandwidthHz(string? mode) => mode?.ToUpperInvariant() switch
+    {
+        "P25" or "DMR" => 12500,
+        "AM" => 10000,
+        _ => 25000,
+    };
 
     private void LockOn(Channel channel)
     {
@@ -1534,6 +1583,10 @@ public class RtlDevice : BackgroundService, IRadioSource
         try 
         {
             _currentDecoder = _decoderFactory.GetDecoder(channel.Mode);
+            // The decoder runs its own rtl_fm, so it needs the same front-end settings as the
+            // wideband scan that found the signal — otherwise the scanner detects at one gain
+            // and listens at another.
+            _currentDecoder.Tuning = CurrentTuning();
             
             _currentDecoder.OnAudio += (chunk) => 
             {

--- a/server/OpenScanner.Server/Devices/RtlDevice.cs
+++ b/server/OpenScanner.Server/Devices/RtlDevice.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Numerics;
+using OpenScanner.Server.Audio;
 using OpenScanner.Server.DSP;
 using OpenScanner.Server.Models;
 using OpenScanner.Server.Interfaces;
@@ -31,7 +32,7 @@ public class RtlDevice : BackgroundService, IRadioSource
     public event Action<CallLog>? OnNewLog;
     
     /// <inheritdoc />
-    public event Action<byte[]>? OnAudio;
+    public event Action<AudioChunk>? OnAudio;
 
     /// <inheritdoc />
     public event Action<RadioEvent>? OnNewEvent;
@@ -951,7 +952,7 @@ public class RtlDevice : BackgroundService, IRadioSource
             stereo[outIdx + 3] = (byte)((right >> 8) & 0xFF);
         }
 
-        OnAudio?.Invoke(stereo);
+        OnAudio?.Invoke(AudioChunk.Stereo48k(stereo));
     }
 
     /// <summary>
@@ -1552,7 +1553,7 @@ public class RtlDevice : BackgroundService, IRadioSource
                 // Analyze for Fire Tone Outs and MDC1200 signaling
                 _toneDetector.ProcessAudio(chunk);
                 _mdc.ProcessAudio(chunk);
-                OnAudio?.Invoke(chunk);
+                OnAudio?.Invoke(AudioChunk.Mono48k(chunk));
 
                 _recordingService.ProcessAudio(chunk);
                 

--- a/server/OpenScanner.Server/Interfaces/IDecoder.cs
+++ b/server/OpenScanner.Server/Interfaces/IDecoder.cs
@@ -11,6 +11,12 @@ public interface IDecoder
     string? InputSource { get; set; }
 
     /// <summary>
+    /// SDR tuning applied to the decoder's own rtl_fm capture. Ignored when
+    /// <see cref="InputSource"/> is set, since the caller is then supplying samples itself.
+    /// </summary>
+    SdrTuning Tuning { get; set; }
+
+    /// <summary>
     /// Whether this decoder supports being fed audio via <see cref="FeedInput"/>.
     /// True when InputSource is set (stdin-based feeding mode).
     /// </summary>

--- a/server/OpenScanner.Server/Interfaces/IRadioSource.cs
+++ b/server/OpenScanner.Server/Interfaces/IRadioSource.cs
@@ -1,3 +1,4 @@
+using OpenScanner.Server.Audio;
 using OpenScanner.Server.Models;
 
 namespace OpenScanner.Server.Interfaces;
@@ -20,7 +21,7 @@ public interface IRadioSource
     /// <summary>
     /// Event triggered when new audio data is available.
     /// </summary>
-    event Action<byte[]>? OnAudio;
+    event Action<AudioChunk>? OnAudio;
 
     /// <summary>
     /// Event triggered when a signaling event (fire tone-out or MDC1200) is detected.

--- a/server/OpenScanner.Server/Interfaces/IRadioSource.cs
+++ b/server/OpenScanner.Server/Interfaces/IRadioSource.cs
@@ -45,10 +45,25 @@ public interface IRadioSource
     void ReloadChannels();
 
     /// <summary>
-    /// Sets the squelch threshold.
+    /// Sets the squelch threshold, in dB of SNR above the measured noise floor.
     /// </summary>
-    /// <param name="db">The threshold in dB.</param>
+    /// <param name="db">The threshold in dB above the noise floor.</param>
     void SetSquelch(double db);
+
+    /// <summary>
+    /// Sets the RTL-SDR tuner gain, in dB. A value of 0 selects the tuner's automatic gain (AGC).
+    /// The setting is persisted and applied to subsequent captures.
+    /// </summary>
+    /// <param name="db">The tuner gain in dB, or 0 for AUTO.</param>
+    void SetGain(double db);
+
+    /// <summary>
+    /// Sets the crystal frequency error correction, in parts per million. Generic (non-TCXO)
+    /// dongles are commonly 20-60 ppm off, which at VHF is several kHz — enough to push a
+    /// narrowband channel out of the passband. Persisted and applied to subsequent captures.
+    /// </summary>
+    /// <param name="ppm">The correction in ppm; 0 for none.</param>
+    void SetPpm(double ppm);
 
     /// <summary>
     /// Starts the radio source scanning process.

--- a/server/OpenScanner.Server/Models/Models.cs
+++ b/server/OpenScanner.Server/Models/Models.cs
@@ -417,7 +417,13 @@ public record ParallelChannelState(
     int? SourceID = null,
     int? TargetID = null,
     string? SpeakerChain = null,
-    string? CurrentTone = null
+    string? CurrentTone = null,
+    /// <summary>
+    /// Measured frequency error of the received carrier, in Hz, or null when the channel is
+    /// idle. Over a transmitter known to be on-frequency this is the dongle's crystal error,
+    /// which is what makes the ppm setting calibratable instead of guesswork.
+    /// </summary>
+    double? MeasuredOffsetHz = null
 );
 
 /// <summary>
@@ -539,6 +545,7 @@ public record ScannerState(
     bool IsAudioStreaming = false,
     double? Squelch = null,
     double? Gain = null,
+    double? Ppm = null,
     string? DeviceName = null,
     string? DevicePort = null,
     SpectrumPoint[]? RfSpectrum = null,

--- a/server/OpenScanner.Server/Models/SdrTuning.cs
+++ b/server/OpenScanner.Server/Models/SdrTuning.cs
@@ -1,0 +1,29 @@
+using System.Globalization;
+
+namespace OpenScanner.Server.Models;
+
+/// <summary>
+/// The RTL-SDR front-end settings shared by every capture, and the rtl_fm flags that carry
+/// them. Kept in one place because the decoders used to hardcode their own values — gain was
+/// 42 in three of them and 45 in the fourth, ppm was pinned at 0 everywhere, and the wideband
+/// scan ran at a completely different gain from the decoders it handed off to.
+/// </summary>
+/// <param name="GainDb">Tuner gain in dB; 0 selects the tuner's own AGC.</param>
+/// <param name="Ppm">Crystal frequency error correction, in parts per million.</param>
+public readonly record struct SdrTuning(double GainDb = 0, double Ppm = 0)
+{
+    private static string Num(double value) => value.ToString("0.##", CultureInfo.InvariantCulture);
+
+    /// <summary>
+    /// The rtl_fm front-end flags. Beyond gain and ppm these carry two corrections that were
+    /// missing entirely:
+    ///
+    /// <c>-F 9</c> enables rtl_fm's low-leakage downsample filter. Its own help text describes
+    /// the default as having "bad roll off", and for narrowband work that roll-off is the
+    /// difference between hearing the wanted channel and hearing it plus its neighbours.
+    ///
+    /// <c>-E dc</c> removes the DC offset that would otherwise sit in the middle of the
+    /// demodulated audio as a constant bias.
+    /// </summary>
+    public string RtlFmArgs() => $"-g {Num(GainDb)} -p {Num(Ppm)} -F 9 -E dc";
+}

--- a/server/OpenScanner.Server/OpenScanner.Server.csproj
+++ b/server/OpenScanner.Server/OpenScanner.Server.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Concentus" Version="2.2.2" />
     <PackageReference Include="Dapper" Version="2.1.66" />
     <PackageReference Include="FftSharp" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0-rc.2.25502.107" />

--- a/server/OpenScanner.Server/Program.cs
+++ b/server/OpenScanner.Server/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.FileProviders;
 using OpenScanner.Server;
+using OpenScanner.Server.Audio;
 using OpenScanner.Server.Services;
 using OpenScanner.Server.Interfaces;
 using OpenScanner.Server.Devices;
@@ -144,8 +145,11 @@ app.Map("/ws/audio", async (HttpContext context) =>
 {
     if (context.WebSockets.IsWebSocketRequest)
     {
+        // No ?codec= at all means a pre-negotiation client, which keeps getting raw PCM.
+        var codecParam = context.Request.Query.TryGetValue("codec", out var v) ? v.ToString() : null;
+        var codec = AudioNegotiation.Negotiate(codecParam, wsBroadcaster.OpusAvailable);
         using var ws = await context.WebSockets.AcceptWebSocketAsync();
-        await wsBroadcaster.HandleAudioConnection(ws);
+        await wsBroadcaster.HandleAudioConnection(ws, codec);
     }
     else
     {

--- a/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
+++ b/server/OpenScanner.Server/Services/WebSocketBroadcaster.cs
@@ -3,6 +3,7 @@ using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.Logging;
+using OpenScanner.Server.Audio;
 using OpenScanner.Server.Models;
 using OpenScanner.Server.Interfaces;
 
@@ -30,11 +31,47 @@ public class WebSocketBroadcaster
         public WebSocket Socket { get; }
         public SemaphoreSlim Lock { get; } = new(1, 1);
 
-        public SocketSession(WebSocket socket)
+        /// <summary>What this session negotiated. Control sessions are always <see cref="LiveAudioCodec.LegacyPcm"/>.</summary>
+        public LiveAudioCodec Codec { get; }
+
+        /// <summary>
+        /// The format most recently announced to this session, so a client joining mid-stream and a
+        /// client present across a mono/stereo switch are both told before the samples arrive.
+        /// </summary>
+        public (int Channels, int SampleRate)? AnnouncedFormat { get; set; }
+
+        public SocketSession(WebSocket socket, LiveAudioCodec codec = LiveAudioCodec.LegacyPcm)
         {
             Socket = socket;
+            Codec = codec;
         }
     }
+
+    /// <summary>Bitrate for mono Opus streams (the single-channel scan path).</summary>
+    private const int OpusMonoBitrate = 24000;
+
+    /// <summary>Bitrate for stereo Opus streams (parallel FastScan). The two panned talkers are
+    /// distinct sources, so joint-stereo coding saves less than it would on real stereo.</summary>
+    private const int OpusStereoBitrate = 40000;
+
+    /// <summary>
+    /// A gap this long means a transmission ended. The encoder is reset so it doesn't carry
+    /// prediction state — or a stranded partial frame — from one transmission into the next.
+    /// </summary>
+    private static readonly TimeSpan EncoderGapReset = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// Shared encoder for the live stream: encode once, send the same bytes to every Opus session.
+    /// Guarded by <see cref="_encoderLock"/> because <see cref="OpusStreamEncoder"/> is not
+    /// thread-safe and audio arrives from two producer threads (the decoder's stdout reader and
+    /// the parallel mixer's timer).
+    /// </summary>
+    private OpusStreamEncoder? _liveEncoder;
+    private readonly object _encoderLock = new();
+    private DateTime _lastAudioAt = DateTime.MinValue;
+
+    /// <summary>Whether the server can encode Opus. False disables negotiation of it.</summary>
+    public bool OpusAvailable { get; private set; } = true;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WebSocketBroadcaster"/> class.
@@ -73,35 +110,76 @@ public class WebSocketBroadcaster
     /// Handles a new WebSocket connection for streaming audio data.
     /// </summary>
     /// <param name="socket">The WebSocket connection.</param>
-    public async Task HandleAudioConnection(WebSocket socket)
+    /// <param name="codec">The codec negotiated from the <c>?codec=</c> query parameter.</param>
+    public async Task HandleAudioConnection(WebSocket socket, LiveAudioCodec codec = LiveAudioCodec.LegacyPcm)
     {
         var id = Guid.NewGuid().ToString();
-        var session = new SocketSession(socket);
-        _audioSessions.TryAdd(id, session);
-        _logger.LogInformation($"New Audio WebSocket connection: {id}");
+        var session = new SocketSession(socket, codec);
+        _logger.LogInformation("New Audio WebSocket connection: {Id} ({Codec})", id, codec);
 
-        // Send pre-roll buffer to catch up new clients with the beginning of the transmission
+        // The pre-roll only ever holds mono: it is fed by the single-channel decoder path and
+        // cleared when decoding starts, so the parallel mixer never contributes to it.
         var preRollData = _radio.GetPreRollBuffer();
-        foreach (var chunk in preRollData)
+
+        if (codec == LiveAudioCodec.LegacyPcm)
         {
-            try
+            // Pre-negotiation clients get exactly the old behaviour, including the old ordering:
+            // registered first, so live frames can interleave into the pre-roll replay. Preserving
+            // that quirk is what makes "byte-identical for existing clients" literally true.
+            _audioSessions.TryAdd(id, session);
+            foreach (var chunk in preRollData)
             {
-                await session.Lock.WaitAsync();
-                if (socket.State == WebSocketState.Open)
-                {
-                    var segment = new ArraySegment<byte>(chunk);
-                    await socket.SendAsync(segment, WebSocketMessageType.Binary, true, CancellationToken.None);
-                }
-                session.Lock.Release();
+                await SendFramesAsync(session, id, new[] { (chunk, WebSocketMessageType.Binary) });
             }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to send pre-roll audio chunk to WebSocket {Id}", id);
-                session.Lock.Release();
-            }
+        }
+        else
+        {
+            // Negotiated clients are registered only after the pre-roll has been flushed, so the
+            // replay is contiguous — two interleaved Opus streams would be audibly broken.
+            await AnnounceFormatAsync(session, id, channels: 1, sampleRate: 48000);
+            var frames = BuildPreRollFrames(session, preRollData, id);
+            if (frames.Count > 0) await SendFramesAsync(session, id, frames);
+            _audioSessions.TryAdd(id, session);
         }
 
         await HandleSessionLoop(socket, id, _audioSessions);
+    }
+
+    /// <summary>
+    /// Renders the pre-roll into frames for a negotiated session. Opus sessions get the buffer
+    /// re-encoded by a throwaway encoder — the seam where it hands off to the shared live encoder
+    /// looks like a single lost packet to the decoder, which costs at most one 20 ms frame of
+    /// smearing.
+    /// </summary>
+    private List<(byte[] Data, WebSocketMessageType Type)> BuildPreRollFrames(
+        SocketSession session, byte[][] preRollData, string id)
+    {
+        var frames = new List<(byte[], WebSocketMessageType)>();
+        if (preRollData.Length == 0) return frames;
+
+        if (session.Codec != LiveAudioCodec.Opus)
+        {
+            foreach (var chunk in preRollData) frames.Add((chunk, WebSocketMessageType.Binary));
+            return frames;
+        }
+
+        try
+        {
+            using var encoder = new OpusStreamEncoder(channels: 1, bitrate: OpusMonoBitrate);
+            foreach (var chunk in preRollData)
+            {
+                foreach (var packet in encoder.Push(chunk)) frames.Add((packet, WebSocketMessageType.Binary));
+            }
+            var tail = encoder.FlushWithSilence();
+            if (tail != null) frames.Add((tail, WebSocketMessageType.Binary));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to encode pre-roll for WebSocket {Id}; skipping it", id);
+            frames.Clear();
+        }
+
+        return frames;
     }
 
     private async Task HandleSessionLoop(WebSocket socket, string id, ConcurrentDictionary<string, SocketSession> sessions)
@@ -195,22 +273,104 @@ public class WebSocketBroadcaster
         _ = BroadcastJson(msg);
     }
 
-    private void BroadcastAudio(byte[] audioData)
+    private void BroadcastAudio(AudioChunk chunk)
     {
-        // _logger.LogInformation($"Broadcasting audio: {audioData.Length} bytes to {_audioSessions.Count} clients");
-        if (_audioSessions.IsEmpty) 
+        if (_audioSessions.IsEmpty)
         {
-            // _logger.LogWarning("Audio generated but no clients connected.");
+            // Nobody is listening, so don't spend CPU encoding. The encoder is reset lazily on the
+            // next chunk via the gap check below.
             return;
         }
-        
+
         // Log occasionally to confirm flow
         if (DateTime.UtcNow.Second % 5 == 0 && DateTime.UtcNow.Millisecond < 100)
         {
-             _logger.LogInformation($"[WebSocket] Sending {audioData.Length} bytes to {_audioSessions.Count} clients");
+            _logger.LogInformation($"[WebSocket] Sending {chunk.Pcm.Length} bytes to {_audioSessions.Count} clients");
         }
 
-        _ = BroadcastBinary(audioData);
+        var packets = EncodeForOpusSessions(chunk);
+
+        var tasks = _audioSessions
+            .Select(kvp => SendAudioChunkAsync(kvp.Value, kvp.Key, chunk, packets))
+            .ToList();
+        _ = Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Encodes a chunk for the shared live Opus stream, or returns null when no session wants it.
+    /// </summary>
+    private IReadOnlyList<byte[]>? EncodeForOpusSessions(AudioChunk chunk)
+    {
+        bool anyOpus = false;
+        foreach (var session in _audioSessions.Values)
+        {
+            if (session.Codec == LiveAudioCodec.Opus) { anyOpus = true; break; }
+        }
+        if (!anyOpus) return null;
+
+        lock (_encoderLock)
+        {
+            try
+            {
+                var now = DateTime.UtcNow;
+                bool gap = now - _lastAudioAt > EncoderGapReset;
+                _lastAudioAt = now;
+
+                if (_liveEncoder == null || _liveEncoder.Channels != chunk.Channels)
+                {
+                    _liveEncoder?.Dispose();
+                    _liveEncoder = new OpusStreamEncoder(
+                        chunk.Channels,
+                        chunk.Channels == 1 ? OpusMonoBitrate : OpusStereoBitrate);
+                }
+                else if (gap)
+                {
+                    _liveEncoder.Reset();
+                }
+
+                return _liveEncoder.Push(chunk.Pcm);
+            }
+            catch (Exception ex)
+            {
+                // Never let an encoder fault take down live audio; drop to PCM for everyone.
+                _logger.LogError(ex, "Opus encoding failed; disabling Opus for new connections");
+                _liveEncoder?.Dispose();
+                _liveEncoder = null;
+                OpusAvailable = false;
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Sends one chunk's worth of frames to a session, holding its lock for the whole group so a
+    /// format announcement can never be reordered after the samples it describes.
+    /// </summary>
+    private async Task SendAudioChunkAsync(
+        SocketSession session, string id, AudioChunk chunk, IReadOnlyList<byte[]>? packets)
+    {
+        var frames = new List<(byte[], WebSocketMessageType)>();
+
+        if (session.Codec != LiveAudioCodec.LegacyPcm &&
+            session.AnnouncedFormat != (chunk.Channels, chunk.SampleRate))
+        {
+            frames.Add((FormatMessageBytes(session.Codec, chunk.Channels, chunk.SampleRate), WebSocketMessageType.Text));
+            session.AnnouncedFormat = (chunk.Channels, chunk.SampleRate);
+        }
+
+        if (session.Codec == LiveAudioCodec.Opus)
+        {
+            if (packets != null)
+            {
+                foreach (var packet in packets) frames.Add((packet, WebSocketMessageType.Binary));
+            }
+        }
+        else
+        {
+            frames.Add((chunk.Pcm, WebSocketMessageType.Binary));
+        }
+
+        if (frames.Count > 0) await SendFramesAsync(session, id, frames);
     }
 
     private async Task BroadcastJson(object data)
@@ -242,29 +402,59 @@ public class WebSocketBroadcaster
         await Task.WhenAll(tasks);
     }
 
-    private async Task BroadcastBinary(byte[] data)
+    /// <summary>
+    /// Sends a group of frames to one session atomically with respect to other senders.
+    /// </summary>
+    private async Task SendFramesAsync(
+        SocketSession session, string id, IReadOnlyList<(byte[] Data, WebSocketMessageType Type)> frames)
     {
-        var segment = new ArraySegment<byte>(data);
-        var tasks = _audioSessions.Values.Select(async session =>
+        await session.Lock.WaitAsync();
+        try
         {
-            await session.Lock.WaitAsync();
-            try
+            foreach (var (data, type) in frames)
             {
-                if (session.Socket.State == WebSocketState.Open)
-                {
-                    await session.Socket.SendAsync(segment, WebSocketMessageType.Binary, true, CancellationToken.None);
-                }
+                if (session.Socket.State != WebSocketState.Open) return;
+                await session.Socket.SendAsync(new ArraySegment<byte>(data), type, true, CancellationToken.None);
             }
-            catch (Exception ex)
-            {
-                _logger.LogDebug(ex, "Failed to send binary to a WebSocket session");
-            }
-            finally
-            {
-                session.Lock.Release();
-            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to send audio frames to WebSocket {Id}", id);
+        }
+        finally
+        {
+            session.Lock.Release();
+        }
+    }
+
+    private async Task AnnounceFormatAsync(SocketSession session, string id, int channels, int sampleRate)
+    {
+        session.AnnouncedFormat = (channels, sampleRate);
+        await SendFramesAsync(session, id, new[]
+        {
+            (FormatMessageBytes(session.Codec, channels, sampleRate), WebSocketMessageType.Text),
         });
-        
-        await Task.WhenAll(tasks);
+    }
+
+    /// <summary>
+    /// Builds the <c>AUDIO_FORMAT</c> text frame. Unlike the control socket's state updates, this
+    /// travels on the audio socket itself, so it is strictly ordered against the samples it
+    /// describes — which is what makes the channel count trustworthy across a scan-mode switch.
+    /// </summary>
+    private byte[] FormatMessageBytes(LiveAudioCodec codec, int channels, int sampleRate)
+    {
+        var payload = codec == LiveAudioCodec.Opus
+            ? (object)new
+            {
+                codec = "opus",
+                sampleRate,
+                channels,
+                frameMs = 20,
+                bitrate = channels == 1 ? OpusMonoBitrate : OpusStereoBitrate,
+            }
+            : new { codec = "pcm_s16le", sampleRate, channels };
+
+        var json = JsonSerializer.Serialize(new { type = "AUDIO_FORMAT", payload }, _jsonOptions);
+        return Encoding.UTF8.GetBytes(json);
     }
 }

--- a/server/OpenScanner.Tests/Audio/AudioNegotiationTests.cs
+++ b/server/OpenScanner.Tests/Audio/AudioNegotiationTests.cs
@@ -1,0 +1,51 @@
+using OpenScanner.Server.Audio;
+using Xunit;
+
+namespace OpenScanner.Tests.Audio;
+
+public class AudioNegotiationTests
+{
+    /// <summary>
+    /// The compatibility hinge: a client that never heard of codec negotiation sends no parameter
+    /// and must land in legacy mode, where it gets raw PCM and no text frames.
+    /// </summary>
+    [Fact]
+    public void MissingParameter_IsLegacyPcm()
+    {
+        Assert.Equal(LiveAudioCodec.LegacyPcm, AudioNegotiation.Negotiate(null, opusAvailable: true));
+    }
+
+    [Theory]
+    [InlineData("opus")]
+    [InlineData("opus,pcm")]
+    [InlineData(" OPUS , pcm ")]
+    public void OpusPreferred_SelectsOpus(string param)
+    {
+        Assert.Equal(LiveAudioCodec.Opus, AudioNegotiation.Negotiate(param, opusAvailable: true));
+    }
+
+    [Theory]
+    [InlineData("pcm")]
+    [InlineData("pcm_s16le")]
+    [InlineData("pcm,opus")]
+    public void PcmPreferred_SelectsPcm(string param)
+    {
+        Assert.Equal(LiveAudioCodec.Pcm, AudioNegotiation.Negotiate(param, opusAvailable: true));
+    }
+
+    [Fact]
+    public void OpusRequested_ButUnavailable_FallsBackToNegotiatedPcm()
+    {
+        Assert.Equal(LiveAudioCodec.Pcm, AudioNegotiation.Negotiate("opus", opusAvailable: false));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("flac")]
+    [InlineData("mp3,aac")]
+    public void UnknownCodecs_FallBackToNegotiatedPcm(string param)
+    {
+        // Not legacy: the client did send the parameter, so it speaks the negotiated protocol.
+        Assert.Equal(LiveAudioCodec.Pcm, AudioNegotiation.Negotiate(param, opusAvailable: true));
+    }
+}

--- a/server/OpenScanner.Tests/Audio/OpusStreamEncoderTests.cs
+++ b/server/OpenScanner.Tests/Audio/OpusStreamEncoderTests.cs
@@ -1,0 +1,234 @@
+using Concentus;
+using OpenScanner.Server.Audio;
+using Xunit;
+
+namespace OpenScanner.Tests.Audio;
+
+public class OpusStreamEncoderTests
+{
+    private const int FrameSamples = OpusStreamEncoder.FrameSamplesPerChannel; // 960
+
+    private static byte[] Pcm(params short[] samples)
+    {
+        var bytes = new byte[samples.Length * 2];
+        Buffer.BlockCopy(samples, 0, bytes, 0, bytes.Length);
+        return bytes;
+    }
+
+    /// <summary>Energy at a single frequency, via one Goertzel bin.</summary>
+    private static double GoertzelPower(double[] samples, double hz, int sampleRate = 48000)
+    {
+        double coeff = 2 * Math.Cos(2 * Math.PI * hz / sampleRate);
+        double s1 = 0, s2 = 0;
+        foreach (var x in samples)
+        {
+            double s0 = x + coeff * s1 - s2;
+            s2 = s1;
+            s1 = s0;
+        }
+        return s1 * s1 + s2 * s2 - coeff * s1 * s2;
+    }
+
+    private static byte[] Sine(int samples, double hz, int sampleRate = 48000, double amplitude = 0.5)
+    {
+        var pcm = new short[samples];
+        for (int i = 0; i < samples; i++)
+            pcm[i] = (short)(Math.Sin(2 * Math.PI * hz * i / sampleRate) * amplitude * short.MaxValue);
+        return Pcm(pcm);
+    }
+
+    /// <summary>
+    /// A 4096-byte mono chunk is 2048 samples: two complete 960-sample frames with 128 left over.
+    /// This is the shape the single-channel decoder path actually emits.
+    /// </summary>
+    [Fact]
+    public void Push_MonoChunk_EmitsCompleteFramesAndCarriesRemainder()
+    {
+        using var enc = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+
+        var packets = enc.Push(Sine(2048, 440));
+
+        Assert.Equal(2, packets.Count);
+        Assert.Equal(128, enc.PendingSamples);
+        Assert.All(packets, p => Assert.NotEmpty(p));
+    }
+
+    /// <summary>
+    /// The parallel mixer emits exactly 3840 bytes (960 stereo frames) per tick, which is exactly
+    /// one Opus frame — no remainder should ever accumulate in parallel mode.
+    /// </summary>
+    [Fact]
+    public void Push_StereoMixerChunk_EmitsExactlyOneFrameWithNoRemainder()
+    {
+        using var enc = new OpusStreamEncoder(channels: 2, bitrate: 40000);
+
+        var packets = enc.Push(new byte[FrameSamples * 4]);
+
+        Assert.Single(packets);
+        Assert.Equal(0, enc.PendingSamples);
+    }
+
+    [Fact]
+    public void Push_AccumulatesAcrossChunksUntilAFrameIsComplete()
+    {
+        using var enc = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+
+        Assert.Empty(enc.Push(Sine(500, 440)));
+        Assert.Empty(enc.Push(Sine(459, 440)));
+        Assert.Single(enc.Push(Sine(1, 440)));
+        Assert.Equal(0, enc.PendingSamples);
+    }
+
+    /// <summary>
+    /// DSDBase passes a trailing odd byte through unchanged, so chunks can end mid-sample. The
+    /// low byte must be carried into the next push; dropping it would swap the byte order of every
+    /// subsequent sample. Decode the result and compare against a reference encode of the same
+    /// samples fed in one piece — identical framing means the split was handled correctly.
+    /// </summary>
+    [Fact]
+    public void Push_OddLengthChunk_CarriesTheHalfSampleIntoTheNextPush()
+    {
+        var full = Sine(FrameSamples, 440);
+
+        using var split = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        var a = split.Push(full.AsSpan(0, 101).ToArray());  // ends mid-sample
+        var b = split.Push(full.AsSpan(101).ToArray());
+
+        using var whole = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        var reference = whole.Push(full);
+
+        Assert.Empty(a);
+        Assert.Single(b);
+        Assert.Single(reference);
+        Assert.Equal(reference[0], b[0]);
+    }
+
+    [Fact]
+    public void Push_EmptyInput_ProducesNothingAndKeepsState()
+    {
+        using var enc = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        enc.Push(Sine(100, 440));
+
+        Assert.Empty(enc.Push(ReadOnlySpan<byte>.Empty));
+        Assert.Equal(100, enc.PendingSamples);
+    }
+
+    /// <summary>
+    /// Feeding randomly-sized chunks (including odd ones) must reconstruct the same sample stream
+    /// as feeding it all at once — the accumulator must never desync.
+    /// </summary>
+    [Fact]
+    public void Push_RandomlyChunkedInput_MatchesUnchunkedEncoding()
+    {
+        var pcm = Sine(FrameSamples * 5, 700);
+
+        using var whole = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        var reference = whole.Push(pcm);
+
+        using var chunked = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        var rng = new Random(1234);
+        var got = new List<byte[]>();
+        for (int offset = 0; offset < pcm.Length;)
+        {
+            int take = Math.Min(rng.Next(1, 997), pcm.Length - offset);
+            got.AddRange(chunked.Push(pcm.AsSpan(offset, take)));
+            offset += take;
+        }
+
+        Assert.Equal(5, reference.Count);
+        Assert.Equal(reference.Count, got.Count);
+        for (int i = 0; i < reference.Count; i++)
+            Assert.Equal(reference[i], got[i]);
+    }
+
+    [Fact]
+    public void FlushWithSilence_EmitsThePartialFrameThenNothing()
+    {
+        using var enc = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        enc.Push(Sine(400, 440));
+
+        var tail = enc.FlushWithSilence();
+
+        Assert.NotNull(tail);
+        Assert.Equal(0, enc.PendingSamples);
+        Assert.Null(enc.FlushWithSilence());
+    }
+
+    [Fact]
+    public void Reset_DiscardsThePartialFrame()
+    {
+        using var enc = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        enc.Push(Sine(400, 440));
+
+        enc.Reset();
+
+        Assert.Equal(0, enc.PendingSamples);
+        Assert.Empty(enc.Push(Sine(959, 440)));
+        Assert.Single(enc.Push(Sine(1, 440)));
+    }
+
+    /// <summary>
+    /// Round-trip a 440 Hz tone through a real Opus decoder. Opus is lossy, so compare energy and
+    /// dominant frequency rather than samples.
+    /// </summary>
+    [Fact]
+    public void EncodedAudio_RoundTripsThroughAnOpusDecoder()
+    {
+        const int frames = 25; // 500 ms
+        var pcm = Sine(FrameSamples * frames, 440);
+
+        using var enc = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        var packets = enc.Push(pcm);
+        Assert.Equal(frames, packets.Count);
+
+        var decoder = OpusCodecFactory.CreateDecoder(48000, 1);
+        var decoded = new List<short>();
+        var scratch = new short[FrameSamples];
+        foreach (var packet in packets)
+        {
+            int n = decoder.Decode(packet, scratch, FrameSamples, false);
+            decoded.AddRange(scratch.AsSpan(0, n).ToArray());
+        }
+
+        Assert.Equal(FrameSamples * frames, decoded.Count);
+
+        // Skip the encoder's warm-up (~6.5 ms of algorithmic delay) before comparing energy.
+        double Rms(IEnumerable<short> s) => Math.Sqrt(s.Select(v => (double)v * v).Average());
+        var inputSamples = new short[pcm.Length / 2];
+        Buffer.BlockCopy(pcm, 0, inputSamples, 0, pcm.Length);
+
+        double inRms = Rms(inputSamples.Skip(FrameSamples));
+        double outRms = Rms(decoded.Skip(FrameSamples));
+        Assert.InRange(outRms / inRms, 0.7, 1.3);
+
+        // The tone should still be at 440 Hz: far more energy there than at an unrelated bin.
+        var window = decoded.Skip(FrameSamples).Take(8192).Select(v => (double)v).ToArray();
+        Assert.True(GoertzelPower(window, 440) > GoertzelPower(window, 1500) * 10,
+            "decoded audio lost its 440 Hz fundamental");
+    }
+
+    /// <summary>
+    /// Guards the bitrate settings: at 24 kbps a 20 ms packet averages ~60 bytes. If someone drops
+    /// the configuration and Concentus falls back to its default, packets balloon and this fails.
+    /// </summary>
+    [Fact]
+    public void MonoPacketsStayWithinTheExpectedBitrateBudget()
+    {
+        using var enc = new OpusStreamEncoder(channels: 1, bitrate: 24000);
+        var packets = enc.Push(Sine(FrameSamples * 50, 440)); // 1 second
+
+        double meanBytes = packets.Average(p => p.Length);
+        Assert.InRange(meanBytes, 10, 120);
+
+        // The whole point of the change: a second of mono audio is 96000 bytes as raw PCM.
+        int total = packets.Sum(p => p.Length);
+        Assert.True(total < 96000 / 15, $"expected >15x compression, got {96000.0 / total:F1}x");
+    }
+
+    [Fact]
+    public void Constructor_RejectsUnsupportedChannelCounts()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OpusStreamEncoder(channels: 0, bitrate: 24000));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new OpusStreamEncoder(channels: 3, bitrate: 24000));
+    }
+}

--- a/server/OpenScanner.Tests/Audio/WebSocketBroadcasterAudioTests.cs
+++ b/server/OpenScanner.Tests/Audio/WebSocketBroadcasterAudioTests.cs
@@ -1,0 +1,235 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using OpenScanner.Server.Audio;
+using OpenScanner.Server.Interfaces;
+using OpenScanner.Server.Services;
+using Xunit;
+
+namespace OpenScanner.Tests.Audio;
+
+/// <summary>
+/// Covers the <c>/ws/audio</c> wire protocol, which had no test coverage before Opus negotiation.
+/// </summary>
+public class WebSocketBroadcasterAudioTests
+{
+    /// <summary>A WebSocket that records everything sent to it and blocks in ReceiveAsync.</summary>
+    private sealed class FakeWebSocket : WebSocket
+    {
+        private readonly TaskCompletionSource<WebSocketReceiveResult> _receive = new();
+        private volatile WebSocketState _state = WebSocketState.Open;
+        public List<(byte[] Data, WebSocketMessageType Type)> Sent { get; } = new();
+
+        public override WebSocketCloseStatus? CloseStatus => null;
+        public override string? CloseStatusDescription => null;
+        public override WebSocketState State => _state;
+        public override string? SubProtocol => null;
+
+        public override void Abort() { }
+        public override void Dispose() { }
+
+        public override Task CloseAsync(WebSocketCloseStatus s, string? d, CancellationToken t) => Task.CompletedTask;
+        public override Task CloseOutputAsync(WebSocketCloseStatus s, string? d, CancellationToken t) => Task.CompletedTask;
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken token)
+            => _receive.Task;
+
+        public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType type, bool end, CancellationToken token)
+        {
+            lock (Sent) Sent.Add((buffer.ToArray(), type));
+            return Task.CompletedTask;
+        }
+
+        public void EndSession()
+        {
+            _state = WebSocketState.Closed;
+            _receive.TrySetResult(new WebSocketReceiveResult(0, WebSocketMessageType.Close, true));
+        }
+
+        public IReadOnlyList<(byte[] Data, WebSocketMessageType Type)> Snapshot()
+        {
+            lock (Sent) return Sent.ToList();
+        }
+    }
+
+    private static (WebSocketBroadcaster Broadcaster, Mock<IRadioSource> Radio) Create(
+        byte[][]? preRoll = null)
+    {
+        var radio = new Mock<IRadioSource>();
+        radio.Setup(r => r.GetPreRollBuffer()).Returns(preRoll ?? Array.Empty<byte[]>());
+        var broadcaster = new WebSocketBroadcaster(radio.Object, NullLogger<WebSocketBroadcaster>.Instance);
+        return (broadcaster, radio);
+    }
+
+    /// <summary>Connects a session and waits until the broadcaster has registered it.</summary>
+    private static async Task<(FakeWebSocket Socket, Task Session)> Connect(
+        WebSocketBroadcaster broadcaster, LiveAudioCodec codec)
+    {
+        var socket = new FakeWebSocket();
+        var session = broadcaster.HandleAudioConnection(socket, codec);
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (broadcaster.AudioClientCount == 0 && DateTime.UtcNow < deadline) await Task.Delay(5);
+        Assert.Equal(1, broadcaster.AudioClientCount);
+        return (socket, session);
+    }
+
+    private static async Task Drain(FakeWebSocket socket, Task session)
+    {
+        socket.EndSession();
+        await session.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    private static void RaiseAudio(Mock<IRadioSource> radio, AudioChunk chunk) =>
+        radio.Raise(r => r.OnAudio += null, chunk);
+
+    private static byte[] Pcm(int bytes) => Enumerable.Range(0, bytes).Select(i => (byte)(i % 251)).ToArray();
+
+    private static JsonElement ParseText((byte[] Data, WebSocketMessageType Type) frame)
+    {
+        Assert.Equal(WebSocketMessageType.Text, frame.Type);
+        return JsonDocument.Parse(Encoding.UTF8.GetString(frame.Data)).RootElement;
+    }
+
+    /// <summary>
+    /// The compatibility guarantee, asserted mechanically: a client that sends no ?codec= gets the
+    /// exact bytes it got before this feature existed, and zero text frames.
+    /// </summary>
+    [Fact]
+    public async Task LegacySession_ReceivesByteIdenticalPcmAndNoTextFrames()
+    {
+        var preRoll = new[] { Pcm(64), Pcm(96) };
+        var (broadcaster, radio) = Create(preRoll);
+        var (socket, session) = await Connect(broadcaster, LiveAudioCodec.LegacyPcm);
+
+        var live = Pcm(4096);
+        RaiseAudio(radio, AudioChunk.Mono48k(live));
+        await Task.Delay(50);
+        await Drain(socket, session);
+
+        var frames = socket.Snapshot();
+        Assert.All(frames, f => Assert.Equal(WebSocketMessageType.Binary, f.Type));
+        Assert.Equal(new[] { preRoll[0], preRoll[1], live }, frames.Select(f => f.Data));
+    }
+
+    [Fact]
+    public async Task NegotiatedPcmSession_GetsAudioFormatBeforeSamples()
+    {
+        var (broadcaster, radio) = Create();
+        var (socket, session) = await Connect(broadcaster, LiveAudioCodec.Pcm);
+
+        var live = Pcm(4096);
+        RaiseAudio(radio, AudioChunk.Mono48k(live));
+        await Task.Delay(50);
+        await Drain(socket, session);
+
+        var frames = socket.Snapshot();
+        var format = ParseText(frames[0]);
+        Assert.Equal("AUDIO_FORMAT", format.GetProperty("type").GetString());
+        Assert.Equal("pcm_s16le", format.GetProperty("payload").GetProperty("codec").GetString());
+        Assert.Equal(1, format.GetProperty("payload").GetProperty("channels").GetInt32());
+        Assert.Equal(48000, format.GetProperty("payload").GetProperty("sampleRate").GetInt32());
+
+        // Samples themselves are untouched — only the metadata is new.
+        Assert.Equal(live, frames.Last().Data);
+    }
+
+    [Fact]
+    public async Task OpusSession_GetsOpusFormatThenCompressedBinaryFrames()
+    {
+        var (broadcaster, radio) = Create();
+        var (socket, session) = await Connect(broadcaster, LiveAudioCodec.Opus);
+
+        // 10 chunks of 4096 bytes = 20480 samples = 21 complete 960-sample frames.
+        for (int i = 0; i < 10; i++) RaiseAudio(radio, AudioChunk.Mono48k(Pcm(4096)));
+        await Task.Delay(100);
+        await Drain(socket, session);
+
+        var frames = socket.Snapshot();
+        var format = ParseText(frames[0]);
+        Assert.Equal("opus", format.GetProperty("payload").GetProperty("codec").GetString());
+        Assert.Equal(20, format.GetProperty("payload").GetProperty("frameMs").GetInt32());
+
+        var packets = frames.Skip(1).ToList();
+        Assert.All(packets, p => Assert.Equal(WebSocketMessageType.Binary, p.Type));
+        Assert.Equal(21, packets.Count);
+
+        // The whole point: 40960 bytes of PCM in, a fraction of that out.
+        int encoded = packets.Sum(p => p.Data.Length);
+        Assert.True(encoded < 40960 / 10, $"expected >10x compression, got {40960.0 / encoded:F1}x");
+    }
+
+    /// <summary>
+    /// The mono/stereo race fix: switching scan modes re-announces the format on the audio socket,
+    /// strictly before the first frame that uses it.
+    /// </summary>
+    [Fact]
+    public async Task ChannelCountChange_ReAnnouncesFormatBeforeTheNewSamples()
+    {
+        var (broadcaster, radio) = Create();
+        var (socket, session) = await Connect(broadcaster, LiveAudioCodec.Pcm);
+
+        RaiseAudio(radio, AudioChunk.Mono48k(Pcm(3840)));
+        await Task.Delay(30);
+        int beforeSwitch = socket.Snapshot().Count;
+        RaiseAudio(radio, AudioChunk.Stereo48k(Pcm(3840)));
+        await Task.Delay(30);
+        await Drain(socket, session);
+
+        var frames = socket.Snapshot();
+        var announcement = ParseText(frames[beforeSwitch]);
+        Assert.Equal("AUDIO_FORMAT", announcement.GetProperty("type").GetString());
+        Assert.Equal(2, announcement.GetProperty("payload").GetProperty("channels").GetInt32());
+        Assert.Equal(WebSocketMessageType.Binary, frames[beforeSwitch + 1].Type);
+    }
+
+    [Fact]
+    public async Task OpusSession_ReceivesThePreRollReEncoded()
+    {
+        // 5 chunks of 4096 bytes = 10240 samples = 10 frames plus a padded tail.
+        var preRoll = Enumerable.Range(0, 5).Select(_ => Pcm(4096)).ToArray();
+        var (broadcaster, radio) = Create(preRoll);
+        var (socket, session) = await Connect(broadcaster, LiveAudioCodec.Opus);
+        await Drain(socket, session);
+
+        var frames = socket.Snapshot();
+        Assert.Equal(WebSocketMessageType.Text, frames[0].Type);
+        var packets = frames.Skip(1).ToList();
+        Assert.Equal(11, packets.Count);
+        Assert.All(packets, p => Assert.Equal(WebSocketMessageType.Binary, p.Type));
+    }
+
+    /// <summary>
+    /// PCM and Opus listeners at the same time each get their own representation of one chunk.
+    /// </summary>
+    [Fact]
+    public async Task MixedSessions_EachGetTheirNegotiatedFormat()
+    {
+        var (broadcaster, radio) = Create();
+        var pcmSocket = new FakeWebSocket();
+        var pcmSession = broadcaster.HandleAudioConnection(pcmSocket, LiveAudioCodec.LegacyPcm);
+        var opusSocket = new FakeWebSocket();
+        var opusSession = broadcaster.HandleAudioConnection(opusSocket, LiveAudioCodec.Opus);
+        var deadline = DateTime.UtcNow.AddSeconds(5);
+        while (broadcaster.AudioClientCount < 2 && DateTime.UtcNow < deadline) await Task.Delay(5);
+
+        var live = Pcm(3840);
+        RaiseAudio(radio, AudioChunk.Mono48k(live));
+        await Task.Delay(50);
+        await Drain(pcmSocket, pcmSession);
+        await Drain(opusSocket, opusSession);
+
+        Assert.Equal(new[] { live }, pcmSocket.Snapshot().Select(f => f.Data));
+
+        var opusFrames = opusSocket.Snapshot();
+        Assert.Equal(WebSocketMessageType.Text, opusFrames[0].Type);
+        // 3840 bytes of mono is 1920 samples: two 20 ms frames.
+        Assert.Equal(3, opusFrames.Count);
+        Assert.All(opusFrames.Skip(1), f =>
+        {
+            Assert.Equal(WebSocketMessageType.Binary, f.Type);
+            Assert.True(f.Data.Length < 200, $"packet was {f.Data.Length} bytes");
+        });
+    }
+}

--- a/server/OpenScanner.Tests/DSP/ChannelizerSelectivityTests.cs
+++ b/server/OpenScanner.Tests/DSP/ChannelizerSelectivityTests.cs
@@ -1,0 +1,226 @@
+using OpenScanner.Server.DSP;
+using Xunit;
+
+namespace OpenScanner.Tests.DSP;
+
+/// <summary>
+/// Measures what the channelizer actually rejects. Adjacent-channel rejection is the property
+/// that decides whether dsd-fme sees clean C4FM symbols or a neighbouring transmitter's, and it
+/// is measured on <see cref="Channelizer.SignalPowerDb"/> — pre-demodulation complex power —
+/// because the FM discriminator is amplitude-blind. Feeding it a lone attenuated carrier would
+/// produce full-scale audio no matter how far down the carrier was, so a post-demod measurement
+/// cannot see a filter at all.
+/// </summary>
+public class ChannelizerSelectivityTests
+{
+    private const int InputRate = 960000;
+    private const int OutputRate = 48000;
+
+    /// <summary>P25 and DMR both use 12.5 kHz channel spacing.</summary>
+    private const double AdjacentChannelHz = 12500;
+
+    /// <summary>
+    /// Generates a constant-amplitude carrier at <paramref name="toneOffsetHz"/> from the SDR
+    /// centre, as unsigned 8-bit interleaved IQ (what rtl_sdr emits).
+    /// </summary>
+    private static byte[] Carrier(double toneOffsetHz, int samples, double amplitude = 100)
+    {
+        var iq = new byte[samples * 2];
+        double phase = 0;
+        double inc = 2.0 * Math.PI * toneOffsetHz / InputRate;
+        for (int i = 0; i < samples; i++)
+        {
+            iq[i * 2] = (byte)Math.Clamp(127.5 + amplitude * Math.Cos(phase), 0, 255);
+            iq[i * 2 + 1] = (byte)Math.Clamp(127.5 + amplitude * Math.Sin(phase), 0, 255);
+            phase += inc;
+            if (phase > Math.PI) phase -= 2.0 * Math.PI;
+        }
+        return iq;
+    }
+
+    /// <summary>
+    /// Runs a carrier through a channelizer tuned to <paramref name="tunedOffsetHz"/> and returns
+    /// the settled in-channel power. Uses a full second so the ~100 ms power window is filled
+    /// several times over and filter start-up transients have washed out.
+    /// </summary>
+    private static double PowerDbOf(double tunedOffsetHz, double carrierOffsetHz, double channelCutoffHz)
+    {
+        var ch = new Channelizer(InputRate, OutputRate, tunedOffsetHz, channelCutoffHz: channelCutoffHz);
+        var iq = Carrier(carrierOffsetHz, InputRate);
+        var output = new byte[ch.MaxOutputBytes(iq.Length)];
+        ch.ProcessIQ(iq, iq.Length, output);
+        return ch.SignalPowerDb;
+    }
+
+    /// <summary>
+    /// The headline guarantee. A transmitter one channel away (12.5 kHz) must be pushed deep into
+    /// the stopband rather than sitting in the passband alongside the wanted signal.
+    ///
+    /// This fails on the pre-2026 filter design, which cut off at 19.2 kHz with a ~63 kHz Blackman
+    /// transition — the adjacent channel was inside the passband and essentially unattenuated.
+    /// </summary>
+    [Fact]
+    public void AdjacentChannel_IsRejectedByAtLeast60dB()
+    {
+        double onChannel = PowerDbOf(tunedOffsetHz: 100000, carrierOffsetHz: 100000, channelCutoffHz: 6250);
+        double adjacent = PowerDbOf(tunedOffsetHz: 100000, carrierOffsetHz: 100000 + AdjacentChannelHz, channelCutoffHz: 6250);
+
+        double rejectionDb = onChannel - adjacent;
+        Assert.True(rejectionDb >= 60,
+            $"adjacent channel at {AdjacentChannelHz / 1000:F1} kHz rejected by only {rejectionDb:F1} dB " +
+            $"(on-channel {onChannel:F1} dB, adjacent {adjacent:F1} dB)");
+    }
+
+    /// <summary>
+    /// The wanted signal must survive the new filter intact — a selectivity win that also
+    /// attenuated the passband would be a net loss.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1000)]
+    [InlineData(3000)]
+    public void InBandSignal_PassesUnattenuated(double toneHz)
+    {
+        double reference = PowerDbOf(100000, 100000, channelCutoffHz: 6250);
+        double shifted = PowerDbOf(100000, 100000 + toneHz, channelCutoffHz: 6250);
+
+        Assert.True(Math.Abs(reference - shifted) < 1.0,
+            $"in-band tone at {toneHz} Hz lost {reference - shifted:F2} dB");
+    }
+
+    /// <summary>
+    /// Narrowing the channel filter to the signal's real occupied bandwidth cuts the noise that
+    /// reaches the demodulator. Going from the old 19.2 kHz cutoff to 6.25 kHz is a 3.07x
+    /// reduction in noise bandwidth, so roughly 4.9 dB — this asserts the bulk of it lands.
+    /// </summary>
+    [Fact]
+    public void NarrowerChannel_LowersNoiseBandwidth()
+    {
+        var rng = new Random(20260814);
+        var noise = new byte[InputRate * 2];
+        for (int i = 0; i < noise.Length; i++)
+            noise[i] = (byte)Math.Clamp(127.5 + 40 * (rng.NextDouble() * 2 - 1), 0, 255);
+
+        double wide = NoisePowerDb(channelCutoffHz: 19200);
+        double narrow = NoisePowerDb(channelCutoffHz: 6250);
+
+        Assert.True(narrow < wide - 3.5,
+            $"expected >=3.5 dB less noise through the narrow filter, got {wide - narrow:F2} dB");
+
+        double NoisePowerDb(double channelCutoffHz)
+        {
+            var ch = new Channelizer(InputRate, OutputRate, 100000, channelCutoffHz: channelCutoffHz);
+            var output = new byte[ch.MaxOutputBytes(noise.Length)];
+            ch.ProcessIQ(noise, noise.Length, output);
+            return ch.SignalPowerDb;
+        }
+    }
+
+    /// <summary>
+    /// The recursive NCO trades a per-sample Math.Cos/Math.Sin pair for one complex multiply,
+    /// which is only sound if its magnitude does not creep. A constant-amplitude carrier must
+    /// therefore read the same power at the end of a long run as at the start.
+    /// </summary>
+    [Fact]
+    public void RecursiveNco_DoesNotDriftOverALongRun()
+    {
+        var ch = new Channelizer(InputRate, OutputRate, 100000, channelCutoffHz: 6250);
+        var iq = Carrier(100000, InputRate);
+        var output = new byte[ch.MaxOutputBytes(iq.Length)];
+
+        ch.ProcessIQ(iq, iq.Length, output);
+        double early = ch.SignalPowerDb;
+
+        // ~20 more seconds of samples: 19.2M complex multiplies for the rotator to drift in.
+        for (int i = 0; i < 20; i++) ch.ProcessIQ(iq, iq.Length, output);
+        double late = ch.SignalPowerDb;
+
+        Assert.True(Math.Abs(early - late) < 0.05,
+            $"NCO magnitude drifted: {early:F4} dB -> {late:F4} dB");
+    }
+
+    /// <summary>
+    /// P25 C4FM peaks at ±1800 Hz. Scaling for the 5 kHz deviation of analog voice left digital
+    /// audio at ~28% of full scale — about 11 dB of headroom handed to the decoder unused.
+    /// </summary>
+    [Fact]
+    public void DeviationScaling_FillsTheRangeForNarrowDeviation()
+    {
+        Assert.InRange(OutputRms(deviationHz: 1800, modulationDeviationHz: 1800), 0.45, 0.70);
+    }
+
+    /// <summary>Analog FM keeps its existing 5 kHz assumption, so this is a no-change guard.</summary>
+    [Fact]
+    public void DeviationScaling_LeavesAnalogUnchanged()
+    {
+        Assert.InRange(OutputRms(deviationHz: 5000, modulationDeviationHz: 5000), 0.45, 0.70);
+    }
+
+    /// <summary>
+    /// Generates an FM carrier deviated by <paramref name="modulationDeviationHz"/> at 1 kHz,
+    /// channelizes it, and returns the output RMS as a fraction of full scale. Full deviation
+    /// maps to 0.8, so a correctly scaled sine reads 0.8/sqrt(2) = 0.566.
+    ///
+    /// RMS rather than peak: the source is 8-bit quantized, so the discriminator throws
+    /// occasional outliers that a peak measurement would latch onto and report as clipping.
+    /// </summary>
+    private static double OutputRms(double deviationHz, double modulationDeviationHz)
+    {
+        const double toneHz = 1000;
+        int samples = InputRate / 4;
+        var iq = new byte[samples * 2];
+        double carrierPhase = 0, tonePhase = 0;
+        double toneInc = 2.0 * Math.PI * toneHz / InputRate;
+
+        for (int i = 0; i < samples; i++)
+        {
+            double instantaneous = modulationDeviationHz * Math.Sin(tonePhase);
+            carrierPhase += 2.0 * Math.PI * instantaneous / InputRate;
+            tonePhase += toneInc;
+            iq[i * 2] = (byte)Math.Clamp(127.5 + 100 * Math.Cos(carrierPhase), 0, 255);
+            iq[i * 2 + 1] = (byte)Math.Clamp(127.5 + 100 * Math.Sin(carrierPhase), 0, 255);
+        }
+
+        var ch = new Channelizer(InputRate, OutputRate, 0, channelCutoffHz: 6250, deviationHz: deviationHz);
+        var output = new byte[ch.MaxOutputBytes(iq.Length)];
+        int written = ch.ProcessIQ(iq, iq.Length, output);
+
+        // Skip the filter's start-up transient before measuring.
+        double sumSquares = 0;
+        int count = 0;
+        for (int i = 2000; i + 1 < written; i += 2)
+        {
+            short sample = (short)(output[i] | (output[i + 1] << 8));
+            sumSquares += (double)sample * sample;
+            count++;
+        }
+        return Math.Sqrt(sumSquares / count) / 32000.0;
+    }
+
+    /// <summary>
+    /// RTL-SDR dongles put a large DC spike at the tuner centre. Without a DC blocker it lands
+    /// inside whichever channel happens to sit at the centre frequency, which is exactly the
+    /// case multi-channel FastScan can produce when it centres on the midpoint of the set.
+    /// </summary>
+    [Fact]
+    public void DcBlocker_RemovesTheCentreSpike()
+    {
+        // A constant IQ offset with no modulation: pure DC, i.e. the dongle's spike.
+        var iq = new byte[InputRate * 2];
+        for (int i = 0; i < InputRate; i++)
+        {
+            iq[i * 2] = 180;       // well away from the 127.5 midpoint
+            iq[i * 2 + 1] = 150;
+        }
+
+        var ch = new Channelizer(InputRate, OutputRate, 0, channelCutoffHz: 6250);
+        var output = new byte[ch.MaxOutputBytes(iq.Length)];
+        ch.ProcessIQ(iq, iq.Length, output);
+
+        // Reference is an in-band carrier offset from DC — a carrier *at* DC is precisely what
+        // the blocker is meant to remove, so it cannot serve as the yardstick.
+        double realSignal = PowerDbOf(tunedOffsetHz: 0, carrierOffsetHz: 2000, channelCutoffHz: 6250);
+        Assert.True(ch.SignalPowerDb < realSignal - 40,
+            $"DC spike only suppressed to {ch.SignalPowerDb:F1} dB against a {realSignal:F1} dB carrier");
+    }
+}

--- a/server/OpenScanner.Tests/DSP/ChannelizerSelectivityTests.cs
+++ b/server/OpenScanner.Tests/DSP/ChannelizerSelectivityTests.cs
@@ -20,6 +20,14 @@ public class ChannelizerSelectivityTests
     private const double AdjacentChannelHz = 12500;
 
     /// <summary>
+    /// Samples per measurement. The power meter averages over 4800 output samples, and total
+    /// decimation here is 20, so 96k input samples fill the window exactly once; 250k fills it
+    /// 2.6 times, which settles the reading without burning CI time. These tests share a
+    /// 2-core runner with wall-clock-sensitive ones, so their cost is not free.
+    /// </summary>
+    private const int MeasurementSamples = 250000;
+
+    /// <summary>
     /// Generates a constant-amplitude carrier at <paramref name="toneOffsetHz"/> from the SDR
     /// centre, as unsigned 8-bit interleaved IQ (what rtl_sdr emits).
     /// </summary>
@@ -40,13 +48,13 @@ public class ChannelizerSelectivityTests
 
     /// <summary>
     /// Runs a carrier through a channelizer tuned to <paramref name="tunedOffsetHz"/> and returns
-    /// the settled in-channel power. Uses a full second so the ~100 ms power window is filled
-    /// several times over and filter start-up transients have washed out.
+    /// the settled in-channel power, over enough samples to fill the power window several times
+    /// and wash out filter start-up transients.
     /// </summary>
     private static double PowerDbOf(double tunedOffsetHz, double carrierOffsetHz, double channelCutoffHz)
     {
         var ch = new Channelizer(InputRate, OutputRate, tunedOffsetHz, channelCutoffHz: channelCutoffHz);
-        var iq = Carrier(carrierOffsetHz, InputRate);
+        var iq = Carrier(carrierOffsetHz, MeasurementSamples);
         var output = new byte[ch.MaxOutputBytes(iq.Length)];
         ch.ProcessIQ(iq, iq.Length, output);
         return ch.SignalPowerDb;
@@ -97,7 +105,7 @@ public class ChannelizerSelectivityTests
     public void NarrowerChannel_LowersNoiseBandwidth()
     {
         var rng = new Random(20260814);
-        var noise = new byte[InputRate * 2];
+        var noise = new byte[MeasurementSamples * 2];
         for (int i = 0; i < noise.Length; i++)
             noise[i] = (byte)Math.Clamp(127.5 + 40 * (rng.NextDouble() * 2 - 1), 0, 255);
 
@@ -125,14 +133,16 @@ public class ChannelizerSelectivityTests
     public void RecursiveNco_DoesNotDriftOverALongRun()
     {
         var ch = new Channelizer(InputRate, OutputRate, 100000, channelCutoffHz: 6250);
-        var iq = Carrier(100000, InputRate);
+        var iq = Carrier(100000, MeasurementSamples);
         var output = new byte[ch.MaxOutputBytes(iq.Length)];
 
         ch.ProcessIQ(iq, iq.Length, output);
         double early = ch.SignalPowerDb;
 
-        // ~20 more seconds of samples: 19.2M complex multiplies for the rotator to drift in.
-        for (int i = 0; i < 20; i++) ch.ProcessIQ(iq, iq.Length, output);
+        // ~2M further complex multiplies. The rotator renormalizes every 1024 samples, so drift
+        // can never accumulate past that window — this only has to prove renormalization runs,
+        // not survive an arbitrarily long soak.
+        for (int i = 0; i < 8; i++) ch.ProcessIQ(iq, iq.Length, output);
         double late = ch.SignalPowerDb;
 
         Assert.True(Math.Abs(early - late) < 0.05,
@@ -167,7 +177,7 @@ public class ChannelizerSelectivityTests
     private static double OutputRms(double deviationHz, double modulationDeviationHz)
     {
         const double toneHz = 1000;
-        int samples = InputRate / 4;
+        int samples = MeasurementSamples;
         var iq = new byte[samples * 2];
         double carrierPhase = 0, tonePhase = 0;
         double toneInc = 2.0 * Math.PI * toneHz / InputRate;
@@ -206,8 +216,8 @@ public class ChannelizerSelectivityTests
     public void DcBlocker_RemovesTheCentreSpike()
     {
         // A constant IQ offset with no modulation: pure DC, i.e. the dongle's spike.
-        var iq = new byte[InputRate * 2];
-        for (int i = 0; i < InputRate; i++)
+        var iq = new byte[MeasurementSamples * 2];
+        for (int i = 0; i < MeasurementSamples; i++)
         {
             iq[i * 2] = 180;       // well away from the 127.5 midpoint
             iq[i * 2 + 1] = 150;

--- a/server/OpenScanner.Tests/DSP/SpectrumEstimatorTests.cs
+++ b/server/OpenScanner.Tests/DSP/SpectrumEstimatorTests.cs
@@ -1,0 +1,182 @@
+using OpenScanner.Server.DSP;
+using Xunit;
+
+namespace OpenScanner.Tests.DSP;
+
+/// <summary>
+/// Carrier detection decides whether the scanner ever hears a transmission, so these tests
+/// pin the two properties that decide it: how far into the noise a weak signal can be and
+/// still be found, and whether one strong signal can hide the others.
+/// </summary>
+public class SpectrumEstimatorTests
+{
+    private const int SampleRate = 1024000;
+    private const int FftSize = 1024;
+
+    /// <summary>
+    /// Builds an IQ buffer of complex Gaussian noise with optional carriers on top.
+    /// Amplitudes are relative to the 8-bit full scale.
+    /// </summary>
+    private static byte[] Scene(int samples, double noiseAmplitude, params (double OffsetHz, double Amplitude)[] carriers)
+    {
+        var rng = new Random(20260814);
+        var iq = new byte[samples * 2];
+        var phases = new double[carriers.Length];
+
+        for (int i = 0; i < samples; i++)
+        {
+            // Box-Muller for Gaussian noise; uniform noise would have the wrong tail behaviour
+            // for a median-vs-mean comparison to mean anything.
+            double u1 = 1.0 - rng.NextDouble(), u2 = rng.NextDouble();
+            double mag = noiseAmplitude * Math.Sqrt(-2.0 * Math.Log(u1));
+            double sampleI = mag * Math.Cos(2 * Math.PI * u2);
+            double sampleQ = mag * Math.Sin(2 * Math.PI * u2);
+
+            for (int c = 0; c < carriers.Length; c++)
+            {
+                sampleI += carriers[c].Amplitude * Math.Cos(phases[c]);
+                sampleQ += carriers[c].Amplitude * Math.Sin(phases[c]);
+                phases[c] += 2.0 * Math.PI * carriers[c].OffsetHz / SampleRate;
+            }
+
+            iq[i * 2] = (byte)Math.Clamp(127.5 + sampleI * 127.5, 0, 255);
+            iq[i * 2 + 1] = (byte)Math.Clamp(127.5 + sampleQ * 127.5, 0, 255);
+        }
+        return iq;
+    }
+
+    private static SpectrumEstimate Estimate(byte[] iq, int segments = 16) =>
+        SpectrumEstimator.Estimate(iq, iq.Length, SampleRate, FftSize, segments)!;
+
+    /// <summary>
+    /// Levels are absolute rather than relative to an empirical fudge factor, so the same
+    /// carrier reads the same dB whatever FFT size measured it. This is what lets the squelch
+    /// setting mean something fixed; the previous code subtracted a hardcoded 20 dB from raw
+    /// FFT magnitudes, so changing the FFT size silently changed what the setting meant.
+    ///
+    /// A full-scale carrier reads +1.76 dB, not 0: integrating the channel picks up the whole
+    /// Hann main lobe, whose 0.5/1.0/0.5 amplitude taper carries 1.5x the peak bin's power.
+    /// That is the correct behaviour for an integrating measurement — the constant is only
+    /// asserted here so a future change to the window or normalization cannot pass unnoticed.
+    /// </summary>
+    [Fact]
+    public void CarrierLevel_IsIndependentOfFftSize()
+    {
+        var levels = new[] { 256, 1024, 4096 }.Select(fftSize =>
+        {
+            var iq = Scene(fftSize * 4, noiseAmplitude: 0, (OffsetHz: 100000, Amplitude: 1.0));
+            var spectrum = SpectrumEstimator.Estimate(iq, iq.Length, SampleRate, fftSize, 4)!;
+            int bin = spectrum.BinForOffset(100000);
+            return spectrum.ChannelPowerDb(bin, spectrum.HalfWidthBins(12500));
+        }).ToArray();
+
+        Assert.True(levels.Max() - levels.Min() < 0.25,
+            $"level varied with FFT size: [{string.Join(", ", levels.Select(l => l.ToString("F3")))}]");
+
+        // 10*log10(1.5) = 1.761 dB of Hann main-lobe energy above the peak bin.
+        Assert.All(levels, level => Assert.InRange(level, 1.5, 2.0));
+    }
+
+    /// <summary>
+    /// The mean-vs-median fix. A loud carrier in the band must not raise the estimated noise
+    /// floor, because doing so subtracts directly from every other channel's SNR — the
+    /// scanner would go deaf to weak signals exactly when a strong one was up.
+    /// </summary>
+    [Fact]
+    public void StrongCarrier_DoesNotRaiseTheNoiseFloor()
+    {
+        var quiet = Estimate(Scene(FftSize * 16, noiseAmplitude: 0.02));
+        var loud = Estimate(Scene(FftSize * 16, noiseAmplitude: 0.02, (OffsetHz: 200000, Amplitude: 0.8)));
+
+        Assert.True(Math.Abs(quiet.NoiseFloorDb - loud.NoiseFloorDb) < 1.0,
+            $"noise floor moved {loud.NoiseFloorDb - quiet.NoiseFloorDb:F2} dB when a carrier appeared");
+    }
+
+    /// <summary>
+    /// A weak carrier alongside a strong one must still clear a 10 dB squelch. This is the
+    /// scenario the old mean-based floor failed: the strong carrier inflated the reference and
+    /// pushed the weak one's apparent SNR below threshold.
+    /// </summary>
+    [Fact]
+    public void WeakCarrier_IsFoundAlongsideAStrongOne()
+    {
+        var spectrum = Estimate(Scene(
+            FftSize * 16,
+            noiseAmplitude: 0.02,
+            (OffsetHz: 200000, Amplitude: 0.8),
+            (OffsetHz: -150000, Amplitude: 0.02)));
+
+        int weakBin = spectrum.BinForOffset(-150000);
+        double weakSnr = spectrum.ChannelSnrDb(weakBin, spectrum.HalfWidthBins(12500));
+
+        Assert.True(weakSnr > 10, $"weak carrier only reached {weakSnr:F1} dB SNR");
+    }
+
+    /// <summary>
+    /// Averaging is what buys the detection margin. More segments must produce a measurably
+    /// steadier noise floor — this compares the spread of the floor across independent buffers.
+    /// </summary>
+    [Fact]
+    public void MoreSegments_ProduceASteadierNoiseFloor()
+    {
+        double spread1 = NoiseFloorSpread(segments: 1);
+        double spread16 = NoiseFloorSpread(segments: 16);
+
+        Assert.True(spread16 < spread1,
+            $"averaging did not steady the estimate: 1 segment {spread1:F3} dB, 16 segments {spread16:F3} dB");
+
+        static double NoiseFloorSpread(int segments)
+        {
+            var floors = new List<double>();
+            for (int trial = 0; trial < 8; trial++)
+            {
+                var rng = new Random(trial);
+                var iq = new byte[FftSize * 16 * 2];
+                for (int i = 0; i < iq.Length; i++)
+                    iq[i] = (byte)Math.Clamp(127.5 + 0.02 * 127.5 * (rng.NextDouble() * 2 - 1), 0, 255);
+                floors.Add(SpectrumEstimator.Estimate(iq, iq.Length, SampleRate, FftSize, segments)!.NoiseFloorDb);
+            }
+            return floors.Max() - floors.Min();
+        }
+    }
+
+    /// <summary>
+    /// Scalloping: a carrier landing between bin centres splits its energy across neighbours.
+    /// Integrating the channel's bins recovers it; reading the single nearest bin does not.
+    /// </summary>
+    [Fact]
+    public void OffCentreCarrier_IsNotUnderReported()
+    {
+        double binWidth = SampleRate / (double)FftSize;
+        double onBin = MeasuredPower(100 * binWidth);
+        double betweenBins = MeasuredPower(100.5 * binWidth);
+
+        Assert.True(Math.Abs(onBin - betweenBins) < 1.0,
+            $"carrier between bins under-reported by {onBin - betweenBins:F2} dB");
+
+        static double MeasuredPower(double offsetHz)
+        {
+            var iq = Scene(FftSize * 8, noiseAmplitude: 0, (offsetHz, 0.5));
+            var spectrum = Estimate(iq, segments: 8);
+            int bin = spectrum.BinForOffset(offsetHz);
+            return spectrum.ChannelPowerDb(bin, spectrum.HalfWidthBins(12500));
+        }
+    }
+
+    [Fact]
+    public void BinForOffset_MapsCentreAndEdges()
+    {
+        var spectrum = Estimate(Scene(FftSize * 16, noiseAmplitude: 0.02));
+
+        Assert.Equal(FftSize / 2, spectrum.BinForOffset(0));
+        Assert.Equal(-1, spectrum.BinForOffset(SampleRate));      // far outside the window
+        Assert.Equal(1000.0, spectrum.BinWidthHz, 6);             // 1.024 MHz / 1024
+    }
+
+    [Fact]
+    public void ShortBuffer_YieldsNoEstimateRatherThanThrowing()
+    {
+        var tiny = new byte[64];
+        Assert.Null(SpectrumEstimator.Estimate(tiny, tiny.Length, SampleRate, FftSize));
+    }
+}

--- a/server/OpenScanner.Tests/Decoders/DecoderCommandLineTests.cs
+++ b/server/OpenScanner.Tests/Decoders/DecoderCommandLineTests.cs
@@ -1,0 +1,155 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using OpenScanner.Server.Decoders;
+using OpenScanner.Server.Models;
+using Xunit;
+
+namespace OpenScanner.Tests.Decoders;
+
+/// <summary>
+/// Pins the rtl_fm front-end flags. These are one-character options buried in long shell
+/// pipelines, easy to lose in a refactor and invisible when lost — the radio simply receives
+/// worse. Each assertion here corresponds to a specific reception defect.
+/// </summary>
+public class DecoderCommandLineTests
+{
+    private static readonly Channel Vhf = new() { Frequency = 155.460, Mode = "P25", AlphaTag = "TEST" };
+
+    private static string CommandFor(DSDBase decoder, SdrTuning? tuning = null)
+    {
+        decoder.Tuning = tuning ?? new SdrTuning(GainDb: 38.5, Ppm: -27);
+        return decoder.GetCommandLine(Vhf);
+    }
+
+    private static DSDBase[] AllDecoders() =>
+    [
+        new P25(NullLogger<P25>.Instance),
+        new DMR(NullLogger<DMR>.Instance),
+        new NFM(NullLogger<NFM>.Instance),
+        new AM(NullLogger<AM>.Instance),
+    ];
+
+    /// <summary>
+    /// rtl_fm's own help calls the default downsample roll-off "bad". For 12.5 kHz channels
+    /// that roll-off decides whether the neighbouring transmitter is audible underneath.
+    /// </summary>
+    [Fact]
+    public void EveryDecoder_EnablesTheLowLeakageDownsampleFilter()
+    {
+        foreach (var decoder in AllDecoders())
+            Assert.Contains("-F 9", CommandFor(decoder));
+    }
+
+    /// <summary>
+    /// Frequency correction used to be hardcoded to "-p 0". A generic dongle is commonly
+    /// 20-60 ppm out, which at VHF puts the signal outside a narrowband passband entirely.
+    /// </summary>
+    [Fact]
+    public void EveryDecoder_PassesTheConfiguredPpm()
+    {
+        foreach (var decoder in AllDecoders())
+        {
+            var cmd = CommandFor(decoder);
+            Assert.Contains("-p -27", cmd);
+            Assert.DoesNotContain("-p 0 ", cmd);
+        }
+    }
+
+    /// <summary>
+    /// Gain was hardcoded at 42 in three decoders and 45 in the fourth, while the wideband
+    /// scan that decides when to hand off ran at 20 — so detection was ~22 dB deafer than
+    /// reception, and a signal could be perfectly listenable yet never found.
+    /// </summary>
+    [Fact]
+    public void EveryDecoder_PassesTheConfiguredGain()
+    {
+        foreach (var decoder in AllDecoders())
+        {
+            var cmd = CommandFor(decoder);
+            Assert.Contains("-g 38.5", cmd);
+            Assert.DoesNotContain("-g 42", cmd);
+            Assert.DoesNotContain("-g 45", cmd);
+        }
+    }
+
+    [Fact]
+    public void EveryDecoder_EnablesDcBlocking()
+    {
+        foreach (var decoder in AllDecoders())
+            Assert.Contains("-E dc", CommandFor(decoder));
+    }
+
+    /// <summary>
+    /// The regression this exists to prevent: squelch in front of dsd-fme. rtl_fm's squelch
+    /// gates the sample stream, and a digital decoder needs a continuous one to hold symbol
+    /// sync. P25 shipped "-l 50" for years.
+    /// </summary>
+    [Theory]
+    [InlineData("P25")]
+    [InlineData("DMR")]
+    public void DigitalDecoders_NeverSquelchAheadOfDsdFme(string mode)
+    {
+        DSDBase decoder = mode == "P25"
+            ? new P25(NullLogger<P25>.Instance)
+            : new DMR(NullLogger<DMR>.Instance);
+
+        var cmd = CommandFor(decoder);
+        Assert.Contains("-l 0", cmd);
+        Assert.DoesNotContain("-l 50", cmd);
+    }
+
+    /// <summary>
+    /// Analog voice keeps its squelch — nothing downstream needs an unbroken stream, and it
+    /// saves the CPU of demodulating dead air.
+    /// </summary>
+    [Theory]
+    [InlineData("NFM")]
+    [InlineData("AM")]
+    public void AnalogDecoders_KeepTheirSquelch(string mode)
+    {
+        DSDBase decoder = mode == "NFM"
+            ? new NFM(NullLogger<NFM>.Instance)
+            : new AM(NullLogger<AM>.Instance);
+
+        Assert.Contains("-l 50", CommandFor(decoder));
+    }
+
+    /// <summary>
+    /// In parallel FastScan the caller supplies channelized samples over stdin, so the decoder
+    /// must not launch a second rtl_fm and fight for the USB device.
+    /// </summary>
+    [Fact]
+    public void WithAnInputSource_NoRtlFmIsLaunched()
+    {
+        var decoder = new P25(NullLogger<P25>.Instance) { InputSource = "cat -" };
+        var cmd = CommandFor(decoder);
+
+        Assert.DoesNotContain("rtl_fm", cmd);
+        Assert.Contains("cat -", cmd);
+    }
+
+    /// <summary>Default tuning is AUTO gain and no correction, matching rtl_fm's own defaults.</summary>
+    [Fact]
+    public void DefaultTuning_SelectsAutoGainAndNoCorrection()
+    {
+        Assert.Equal("-g 0 -p 0 -F 9 -E dc", new SdrTuning().RtlFmArgs());
+    }
+
+    /// <summary>
+    /// Arguments are built with the invariant culture: on a locale that formats decimals with
+    /// a comma, "38,5" would be parsed by rtl_fm as 38 and the fractional part silently lost.
+    /// </summary>
+    [Fact]
+    public void FractionalValues_UseInvariantFormatting()
+    {
+        var previous = Thread.CurrentThread.CurrentCulture;
+        try
+        {
+            Thread.CurrentThread.CurrentCulture = new System.Globalization.CultureInfo("de-DE");
+            Assert.Equal("-g 38.5 -p -1.25 -F 9 -E dc", new SdrTuning(38.5, -1.25).RtlFmArgs());
+        }
+        finally
+        {
+            Thread.CurrentThread.CurrentCulture = previous;
+        }
+    }
+}

--- a/server/OpenScanner.Tests/Devices/ScanCenterTests.cs
+++ b/server/OpenScanner.Tests/Devices/ScanCenterTests.cs
@@ -1,0 +1,87 @@
+using OpenScanner.Server.Devices;
+using OpenScanner.Server.Models;
+using Xunit;
+
+namespace OpenScanner.Tests.Devices;
+
+/// <summary>
+/// A FastScan bank tunes the SDR to one centre frequency and channelizes outwards from it.
+/// Whatever sits at that centre lands on the dongle's DC spike, so the centre must never be a
+/// channel — otherwise there is exactly one channel in the bank the scanner can never hear,
+/// silently, with no error anywhere.
+/// </summary>
+public class ScanCenterTests
+{
+    private static List<Channel> At(params double[] frequencies) =>
+        frequencies.Select(f => new Channel { Frequency = f, AlphaTag = $"CH{f}" }).ToList();
+
+    private static double Spread(List<Channel> channels) =>
+        channels.Max(c => c.Frequency) - channels.Min(c => c.Frequency);
+
+    private static double Center(List<Channel> channels)
+    {
+        var sorted = channels.OrderBy(c => c.Frequency).ToList();
+        double midpoint = (sorted.First().Frequency + sorted.Last().Frequency) / 2.0;
+        return RtlDevice.NudgeOffChannels(midpoint, sorted, Spread(sorted));
+    }
+
+    /// <summary>
+    /// The case that motivated this: three evenly spaced channels put the middle one exactly on
+    /// the midpoint. The old code took the midpoint unconditionally, on the assumption that a
+    /// multi-channel centre was "already offset from DC".
+    /// </summary>
+    [Fact]
+    public void EvenlySpacedChannels_DoNotLeaveOneOnTheCentre()
+    {
+        var channels = At(154.100, 154.250, 154.400);
+        double center = Center(channels);
+
+        Assert.All(channels, c =>
+            Assert.True(Math.Abs(c.Frequency - center) > 0.005,
+                $"{c.AlphaTag} at {c.Frequency} sits {Math.Abs(c.Frequency - center) * 1000:F1} kHz from centre {center}"));
+    }
+
+    /// <summary>Two channels straddle their midpoint already, so nothing should move.</summary>
+    [Fact]
+    public void ClearMidpoint_IsLeftAlone()
+    {
+        var channels = At(154.100, 154.400);
+        Assert.Equal(154.250, Center(channels), 6);
+    }
+
+    /// <summary>
+    /// Nudging must not push a channel outside the 2.4 MHz capture window. When the set already
+    /// fills the window there is no room, and keeping every channel in view beats rescuing one
+    /// from the DC spike.
+    /// </summary>
+    [Fact]
+    public void FullWidthBank_IsNotNudgedOutOfTheWindow()
+    {
+        var channels = At(150.000, 151.200, 152.400);
+        double center = Center(channels);
+
+        Assert.Equal(151.200, center, 6);
+        Assert.All(channels, c => Assert.True(Math.Abs(c.Frequency - center) <= 1.2 + 1e-9));
+    }
+
+    /// <summary>
+    /// Every channel must stay inside the window after any nudge, across a range of layouts.
+    /// </summary>
+    [Theory]
+    [InlineData(new[] { 154.100, 154.250, 154.400 })]
+    [InlineData(new[] { 460.0, 460.5, 461.0, 461.5 })]
+    [InlineData(new[] { 155.460, 155.475, 155.490 })]
+    [InlineData(new[] { 462.5625, 462.5875, 462.6125 })]
+    public void NudgedCentre_KeepsEveryChannelInTheWindow(double[] frequencies)
+    {
+        var channels = At(frequencies);
+        double center = Center(channels);
+
+        Assert.All(channels, c =>
+            Assert.True(Math.Abs(c.Frequency - center) <= 1.2 + 1e-9,
+                $"{c.AlphaTag} fell {Math.Abs(c.Frequency - center):F3} MHz from centre {center:F3}"));
+        Assert.All(channels, c =>
+            Assert.True(Math.Abs(c.Frequency - center) > 0.005,
+                $"{c.AlphaTag} landed on the DC spike at centre {center:F3}"));
+    }
+}


### PR DESCRIPTION
Two independent changes to the radio path, kept as two commits. Both started from "the audio is worse than it should be", from opposite ends: one is what leaves the box, the other is what arrives at the antenna.

---

## 1. Compress live audio with Opus (`82474f7`)

`/ws/audio` sent raw headerless s16le PCM at 48 kHz: a flat **768 kbps per listener**, **1.536 Mbps** in parallel FastScan, multiplied by every connected client. That is the dominant cost of listening from outside the LAN, and the audio is narrowband voice the client already lowpasses at 3400 Hz.

Clients now advertise what they can decode via `?codec=`, and the server encodes once per chunk and fans the packets out to every Opus session.

| Mode | 30 s of real P25 audio | Rate |
|---|---|---|
| Legacy (no `?codec=`) | 1,444,514 bytes | 385 kbps |
| Negotiated PCM | 1,444,514 bytes (**byte-identical**) | 385 kbps |
| Opus | 41,272 bytes | 11 kbps |

**35× reduction**, ~1% of one x86 core to encode. Concentus is managed C#, so there is no ffmpeg subprocess to install or babysit.

A client that sends no `?codec=` at all is untouched — same bytes, no text frames — and a test asserts that mechanically rather than by inspection.

**Frame alignment was the substance of it.** Opus accepts only exact frame sizes, but nothing upstream produces them: the decoder path flushes at ≥4096 bytes *or* every 40 ms, while `MixTick` emits exactly 3840. Worse, `DSDBase.cs:121` passes a trailing odd byte through unchanged, so a chunk can end mid-sample — dropping that byte would swap the endianness of everything after it, permanently. `OpusStreamEncoder` accumulates into exact 960-sample frames and carries both the partial frame and the half-sample across calls. A test encodes the same audio split at random boundaries and unsplit, and compares packets byte for byte.

**The format announcement fixes a bug that predates compression.** The client inferred stereo from `STATE_UPDATE.parallelChannels` on the *control* socket, so frames in flight across a scan-mode switch were deinterleaved with the wrong channel count until the two sockets agreed. Channel count now rides in-band as an `AUDIO_FORMAT` text frame on the audio socket itself, sent in PCM mode too, with the session semaphore held across the announcement and the samples it describes so the two can never reorder. `onParallel`/`setParallel` are gone.

**Client decode is three tiers**: WebCodecs `AudioDecoder`, then `opus-decoder` (libopus in wasm), then plain PCM. The wasm tier matters more than it looks — the Pi is usually reached over plain `http://`, which is not a secure context, so WebCodecs is unavailable exactly where the bandwidth win is needed most. It sits behind a dynamic import and code-splits into an 89 KB chunk that browsers on the native path never download, asserted by a test rather than assumed.

Two failure modes that cost real time, commented at their call sites: `AudioData.close()` is mandatory or playback stops a few hundred frames in, and `opus-decoder` reuses its output buffers between calls, so they must be sliced before the playback path transfers them to the worklet.

---

## 2. Fix the receiver's selectivity, frequency accuracy and detection (`a593a8c`)

Chasing two symptoms — weak transmissions never found, P25/DMR decoding flaky — to specific defects rather than to the limits of the hardware.

### The channel filter had no selectivity at all

Filter taps were sized by `Math.Max(4 * decim, 32)`: a heuristic keyed to the *decimation factor*, which says nothing about the selectivity a channel needs. At the 960 kHz rate parallel FastScan actually uses, that put the final stage at 21 taps cutting off at 19.2 kHz with a ~63 kHz transition.

Measured on a two-tone test:

| | Adjacent channel (12.5 kHz) | In-channel noise |
|---|---|---|
| Before | **0.0 dB rejected** | −26.03 dB |
| After | **110.6 dB rejected** | −30.97 dB (**−4.94 dB**) |

Not "poorly rejected" — not rejected at all. dsd-fme was being handed the wanted P25 signal with its neighbour mixed in at equal strength, inside a passband three times wider than the signal. That is a sufficient explanation for flaky digital decoding on its own.

Filters are now sized from the transition width they have to achieve. A 131-tap channel filter at the output rate does the selectivity work; the two decimation stages only have to stop what would fold into the band being kept — which is why they get *cheaper* as the channel filter gets narrower.

### Frequency error was never corrected anywhere

`-p 0` was hardcoded in all four decoders and `-p` was absent entirely from both `rtl_sdr` invocations. A generic non-TCXO dongle — the one on my test rig is a crystal R820T — runs tens of ppm off, which at VHF is several kHz against a 12.5 kHz channel.

Gain, ppm and squelch are now one persisted settings group. Since the channelizer's discriminator DC *is* the frequency error, the settings page reads it live off the strongest active channel and offers to apply it, so ppm is calibrated rather than guessed.

### P25 squelched its own decoder's input

`P25.cs` passed `-l 50`. rtl_fm's squelch gates the sample stream, and dsd-fme needs a continuous one to hold C4FM symbol sync. `DMR.cs` already omitted it, so the two disagreed. Both are now explicitly `-l 0`; analog keeps its squelch, where nothing downstream needs an unbroken stream.

All four decoders also gain `-F 9` — rtl_fm's own help describes the default downsample roll-off as "bad", and its absence only ever shows up as "the radio sounds worse" — plus `-E dc`, and the configured gain in place of the hardcoded 42 (45 for DMR).

### Detection discarded 99.2% of every buffer

`ProcessSamples` read 65,536 bytes and ran one 256-point FFT over the **last 250 microseconds** of it. It then took the *mean* of all bins in dB as the noise floor, so one strong carrier or the DC spike inflated the reference and suppressed every other channel's computed SNR — the scanner went deaf to weak signals exactly when a strong one was up.

It now Welch-averages sixteen 1024-point FFTs, takes the median, and integrates each channel's real bandwidth rather than sampling one bin (worth up to 3.9 dB of scalloping loss on a carrier landing between bins). Levels are normalized so a carrier reads the same dB at any FFT size, retiring the `// Normalize (Empirical)` −20 dB fudge.

### Two latent bugs surfaced on the way

- **`ChannelPipeline` took a `squelchDb` parameter, stored it, and never read it.** A hardcoded `-28.0` was used instead, so the squelch setting had no effect in parallel FastScan at all.
- **Multi-channel FastScan centred on the exact midpoint** of the channel set, on the stated assumption that a midpoint is "already offset from DC". That is false whenever the set is symmetric about one of its own members: three evenly spaced channels put the middle one permanently on the DC spike, undetectable, silently.

---

## Testing

**246 server tests** (was 195) and **21 client tests** (was ~14); `tsc -b` and `eslint` clean; production build succeeds.

New coverage where there was none:

- **`/ws/audio` had zero tests before.** A fake-`WebSocket` suite now covers legacy byte-identity, both negotiated modes, pre-roll re-encoding, channel-switch ordering, and mixed PCM/Opus listeners on one broadcast.
- **Two-tone selectivity** — injects an interferer one channel away and asserts ≥60 dB of rejection. This **fails on the pre-change code**, and is the regression guard for the whole filter change.
- **Decoder command lines asserted as strings**, so a dropped `-F 9` or a resurrected `-l 50` on P25 fails CI instead of quietly degrading reception.
- Noise-bandwidth, NCO drift over 19.2M complex multiplies, deviation scaling, DC-blocker suppression, median-vs-mean noise floor, scalloping, and FastScan centring against four real channel layouts.

Opus packets were also cross-validated outside the .NET decoder: 459 captured packets through the real `opus-decoder` wasm, zero decode errors, exactly 960 samples each.

## Caveats

**CPU went up, not down.** Measured against the pre-change implementation extracted from git rather than estimated: **1.80% → 1.89% of one x86 core per channel**. I expected a drop, because the NCO's per-sample `Math.Cos`/`Math.Sin` pair is gone and in isolation that loop is 4× cheaper. It does not show up in the whole pipeline — the transcendentals were already overlapping with FIR work. ~5% more CPU for 110 dB of adjacent-channel rejection is a good trade, but the prediction was wrong. If a Pi struggles, cutting the channel filter to 91 taps (~3 kHz transition) is still ample for 12.5 kHz spacing.

**Not verified on real RF.** The end-to-end P25 decode rate needs exclusive SDR access, and the comparison is only fair against a captured IQ file replayed through both implementations — live RF will not repeat, so measuring before and after on separate transmissions would tell you nothing. Also unverified in a real browser: Opus playback itself, the parallel-stereo path, and the plain-`http://` wasm + buffer-source path on a Pi. That last one is the most common deployment and the least-exercised code path.

**Squelch changed meaning** from an absolute dB level to SNR above the measured noise floor. It is not persisted, so there is no stored value on the old scale to migrate — but a `-55` in anyone's muscle memory now means something else.

**This supersedes `feat/configurable-sdr-gain`.** That branch's gain plumbing is reimplemented here as part of the gain/ppm/squelch group, so it should be closed rather than merged — merging both would conflict in `RtlDevice.cs` and `IRadioSource.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
